### PR TITLE
Update cpal -> 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "http://docs.rs/rodio"
 
 [dependencies]
 claxon = { version = "0.4.2", optional = true }
-cpal = "0.8"
+cpal = "0.10"
 hound = { version = "3.3.1", optional = true }
 lazy_static = "1.0.0"
 lewton = { version = "0.9", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,9 +96,7 @@ extern crate lewton;
 #[cfg(feature = "mp3")]
 extern crate minimp3;
 
-pub use cpal::{
-    default_input_device, default_output_device, devices, input_devices, output_devices, Device,
-};
+pub use cpal::{traits::DeviceTrait, Device, Devices, DevicesError, InputDevices};
 
 pub use conversions::Sample;
 pub use decoder::Decoder;
@@ -107,6 +105,7 @@ pub use sink::Sink;
 pub use source::Source;
 pub use spatial_sink::SpatialSink;
 
+use cpal::traits::HostTrait;
 use std::io::{Read, Seek};
 
 mod conversions;
@@ -131,4 +130,46 @@ where
     let sink = Sink::new(device);
     sink.append(input);
     Ok(sink)
+}
+
+/// The default input audio device on the system.
+///
+/// Returns `None` if no input device is available.
+#[inline]
+pub fn default_input_device() -> Option<Device> {
+    cpal::default_host().default_input_device()
+}
+
+/// The default output audio device on the system.
+///
+/// Returns `None` if no output device is available.
+#[inline]
+pub fn default_output_device() -> Option<Device> {
+    cpal::default_host().default_output_device()
+}
+
+/// An iterator yielding all `Device`s currently available to the host on the system.
+///
+/// Can be empty if the system does not support audio in general.
+#[inline]
+pub fn devices() -> Result<Devices, DevicesError> {
+    cpal::default_host().devices()
+}
+
+/// An iterator yielding all `Device`s currently available to the system that support one or more
+/// input stream formats.
+///
+/// Can be empty if the system does not support audio input.
+#[inline]
+pub fn input_devices() -> Result<InputDevices<Devices>, DevicesError> {
+    cpal::default_host().input_devices()
+}
+
+/// An iterator yielding all `Device`s currently available to the system that support one or more
+/// output stream formats.
+///
+/// Can be empty if the system does not support audio output.
+#[inline]
+pub fn output_devices() -> Result<InputDevices<Devices>, DevicesError> {
+    cpal::default_host().output_devices()
 }


### PR DESCRIPTION
* Provide device prevous method using `cpal::default_host()`
* Naively handle new cpal errors

If instead we'd want to reexport the `default_host` method, we'd have to change the `play_raw` behaviour, and that wouldn't be trivial as far as I can see.

This is a breaking change, but not very.