### PR TITLE
Generate samples at a multiple of channels

### DIFF
--- a/src/source/delay.rs
+++ b/src/source/delay.rs
@@ -10,7 +10,7 @@ where
     I::Item: Sample,
 {
     let duration_ns = duration.as_secs() * 1000000000 + duration.subsec_nanos() as u64;
-    let samples = duration_ns * input.sample_rate() as u64 * input.channels() as u64 / 1000000000;
+    let samples = duration_ns * input.sample_rate() as u64 / 1000000000 * input.channels() as u64; 
 
     Delay {
         input: input,

--- a/src/source/pausable.rs
+++ b/src/source/pausable.rs
@@ -4,26 +4,46 @@ use Sample;
 use Source;
 
 /// Internal function that builds a `Pausable` object.
-pub fn pausable<I>(source: I, paused: bool) -> Pausable<I> {
+pub fn pausable<I>(source: I, paused: bool) -> Pausable<I>
+where
+    I: Source,
+    I::Item: Sample,
+{
+    let paused_channels = if paused {
+        Some(source.channels())
+    } else {
+        None
+    };
     Pausable {
         input: source,
-        paused: paused,
+        paused_channels: paused_channels,
+        remaining_paused_samples: 0,
     }
 }
 
 #[derive(Clone, Debug)]
 pub struct Pausable<I> {
     input: I,
-    paused: bool,
+    paused_channels: Option<u16>,
+    remaining_paused_samples: u16,
 }
 
-impl<I> Pausable<I> {
+impl<I> Pausable<I>
+where
+    I: Source,
+    I::Item: Sample,
+{
     /// Sets whether the filter applies.
     ///
     /// If set to true, the inner sound stops playing and no samples are processed from it.
     #[inline]
     pub fn set_paused(&mut self, paused: bool) {
-        self.paused = paused;
+        // Minimize calls to channels by only calling on state change
+        match (self.paused_channels, paused) {
+            (None, true) => self.paused_channels = Some(self.input.channels()),
+            (Some(_), false) => self.paused_channels = None,
+            _ => (),
+        }
     }
 
     /// Returns a reference to the inner source.
@@ -54,7 +74,13 @@ where
 
     #[inline]
     fn next(&mut self) -> Option<I::Item> {
-        if self.paused {
+        if self.remaining_paused_samples > 0 {
+            self.remaining_paused_samples -= 1;
+            return Some(I::Item::zero_value());
+        }
+
+        if let Some(paused_channels) = self.paused_channels {
+            self.remaining_paused_samples = paused_channels - 1;
             return Some(I::Item::zero_value());
         }
 

--- a/src/source/pausable.rs
+++ b/src/source/pausable.rs
@@ -16,7 +16,7 @@ where
     };
     Pausable {
         input: source,
-        paused_channels: paused_channels,
+        paused_channels,
         remaining_paused_samples: 0,
     }
 }
@@ -38,7 +38,6 @@ where
     /// If set to true, the inner sound stops playing and no samples are processed from it.
     #[inline]
     pub fn set_paused(&mut self, paused: bool) {
-        // Minimize calls to channels by only calling on state change
         match (self.paused_channels, paused) {
             (None, true) => self.paused_channels = Some(self.input.channels()),
             (Some(_), false) => self.paused_channels = None,

--- a/src/source/periodic.rs
+++ b/src/source/periodic.rs
@@ -12,8 +12,7 @@ where
     // TODO: handle the fact that the samples rate can change
     // TODO: generally, just wrong
     let update_ms = period.as_secs() as u32 * 1_000 + period.subsec_nanos() / 1_000_000;
-    let sample_rate = source.sample_rate() * source.channels() as u32;
-    let update_frequency = (update_ms * sample_rate) / 1000;
+    let update_frequency = (update_ms * source.sample_rate()) / 1000 * source.channels() as u32;
 
     PeriodicAccess {
         input: source,


### PR DESCRIPTION
I ran into an issue where pausing and unpausing would swap the channels of a stereo source.  It was because the number of samples the pause source generated while paused wasn't a multiple of 2. This has two fixes for that issue. 

One Pausable now always generates Zero's in a multiple of the number of channels.
Two Periodic only changes things at a multiple of the number of channels. This might help other similar issues.

I also fixed Delay since it has the same potential issue.

I suspect channel ordering issues can also occur if current_frame_len isn't a multiple of the channels, when called before iterating. Also if the iterator returns a None that's not aligned with current_frame_len. Those could cause the issue with Repeat, Stop and various ways of chaining Sources.