### PR TITLE
Fix `output_devices` return type to be `OutputDevices` instead of `InputDevices`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ extern crate lewton;
 #[cfg(feature = "mp3")]
 extern crate minimp3;
 
-pub use cpal::{traits::DeviceTrait, Device, Devices, DevicesError, InputDevices};
+pub use cpal::{traits::DeviceTrait, Device, Devices, DevicesError, InputDevices, OutputDevices};
 
 pub use conversions::Sample;
 pub use decoder::Decoder;
@@ -169,6 +169,6 @@ pub fn input_devices() -> Result<InputDevices<Devices>, DevicesError> {
 ///
 /// Can be empty if the system does not support audio output.
 #[inline]
-pub fn output_devices() -> Result<InputDevices<Devices>, DevicesError> {
+pub fn output_devices() -> Result<OutputDevices<Devices>, DevicesError> {
     cpal::default_host().output_devices()
 }


### PR DESCRIPTION
This looks like a typo that just was overlooked because both `InputDevices` and `OutputDevices` are type aliases for `std::iter::Filter<I, fn(&<I as Iterator>::Item) -> bool>`.