### PR TITLE
Update lewton to 0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- Update `lewton` to 0.10.
+
 # Version 0.10.0 (2019-11-16)
 - Removal of nalgebra in favour of own code.
 - Fix a bug that switched channels when resuming after having paused.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ claxon = { version = "0.4.2", optional = true }
 cpal = "0.10"
 hound = { version = "3.3.1", optional = true }
 lazy_static = "1.0.0"
-lewton = { version = "0.9", optional = true }
+lewton = { version = "0.10", optional = true }
 minimp3 = { version = "0.3.2", optional = true }
 
 [features]


### PR DESCRIPTION
See https://github.com/RustAudio/lewton/blob/master/CHANGELOG.md#release-0100---january-30-2020