### PR TITLE
Fix stack overflow on audio change

### DIFF
--- a/src/source/buffered.rs
+++ b/src/source/buffered.rs
@@ -1,4 +1,5 @@
 use std::cmp;
+use std::mem;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -64,6 +65,40 @@ where
     channels: u16,
     rate: u32,
     next: Mutex<Arc<Frame<I>>>,
+}
+
+impl<I> Drop for FrameData<I>
+where
+    I: Source,
+    I::Item: Sample,
+{
+    fn drop(&mut self) {
+        // This is necessary to prevent stack overflows deallocating long chains of the mutually
+        // recursive `Frame` and `FrameData` types. This iteratively traverses as much of the
+        // chain as needs to be deallocated, and repeatedly "pops" the head off the list. This
+        // solves the problem, as when the time comes to actually deallocate the `FrameData`,
+        // the `next` field will contain a `Frame::End`, or an `Arc` with additional references,
+        // so the depth of recursive drops will be bounded.
+        loop {
+            if let Ok(arc_next) = self.next.get_mut() {
+                if let Some(next_ref) = Arc::get_mut(arc_next) {
+                    // This allows us to own the next Frame.
+                    let next = mem::replace(next_ref, Frame::End);
+                    if let Frame::Data(next_data) = next {
+                        // Swap the current FrameData with the next one, allowing the current one
+                        // to go out of scope.
+                        *self = next_data;
+                    } else {
+                        break;
+                    }
+                } else {
+                    break;
+                }
+            } else {
+                break;
+            }
+        }
+    }
 }
 
 /// Builds a frame from the input iterator.


### PR DESCRIPTION
The types `Frame` and `FrameData` are mutually recursive, and the
incidental linked lists that can be formed as a result can be long (at
least in the order of thousands of elements). As a result, when a frame
is deallocated, rust appears to recursively call `drop_in_place` down
the list, causing stack overflows for long lists.

Addresses https://github.com/RustAudio/rodio/issues/283

This problem is hard to reproduce. I've tried constructing toy programs to no avail. The only way I've managed to trigger it is running https://github.com/stevebob/slime99/ `graphical` or `ansi-terminal` crates with the `--audio` flag (audio is disabled by default because of exactly this problem). Start a new game and leave it on the first floor for ~5 minutes, then walk down the stairs. The track will switch and _sometimes_ there will be a stack overflow on the "rodio audio processing" thread.

I was able to reliably reproduce the problem last night, but I'm trying to again now (after changing nothing) and it's not happening. Something something phase of the moon. In other words, I'm not satisfied with my testing of this patch thus far. I'm opening this PR now to start a discussion. Is there a way to construct a long chain of `Frame`->`FrameData`->`Frame`->...? I think doing so would reliably trigger this problem.