### PR TITLE
Clear and skip

### DIFF
--- a/src/queue.rs
+++ b/src/queue.rs
@@ -94,16 +94,15 @@ where
             .store(keep_alive_if_empty, Ordering::Release);
     }
 
-    pub fn clear(&self) {
+    /// Removes all the sounds from the queue. Returns the number of sounds cleared.
+    pub fn clear(&self) -> usize {
         let mut sounds = self.next_sounds.lock().unwrap();
+        let len = sounds.len();
         sounds.clear();
+        len
     }
 
-    pub fn len(&self) -> usize {
-        self.next_sounds.lock().unwrap().len()
-    }
 }
-
 /// The output of the queue. Implements `Source`.
 pub struct SourcesQueueOutput<S> {
     // The current iterator that produces samples.

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -93,6 +93,15 @@ where
         self.keep_alive_if_empty
             .store(keep_alive_if_empty, Ordering::Release);
     }
+
+    pub fn clear(&self) {
+        let mut sounds = self.next_sounds.lock().unwrap();
+        sounds.clear();
+    }
+
+    pub fn len(&self) -> usize {
+        self.next_sounds.lock().unwrap().len()
+    }
 }
 
 /// The output of the queue. Implements `Source`.

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -146,8 +146,8 @@ impl Sink {
     ///
     /// See `pause()` for information about pausing a `Sink`.
     pub fn clear(&self) {
-        self.sound_count.fetch_sub(self.queue_tx.len(), Ordering::SeqCst);
-        self.queue_tx.clear();
+        let len = self.queue_tx.clear();
+        self.sound_count.fetch_sub(len, Ordering::SeqCst);
         self.pause();
     }
     

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -30,6 +30,7 @@ struct Controls {
     pause: AtomicBool,
     volume: Mutex<f32>,
     stopped: AtomicBool,
+    do_skip: AtomicBool,
 }
 
 impl Sink {
@@ -53,6 +54,7 @@ impl Sink {
                 pause: AtomicBool::new(false),
                 volume: Mutex::new(1.0),
                 stopped: AtomicBool::new(false),
+                do_skip: AtomicBool::new(false),
             }),
             sound_count: Arc::new(AtomicUsize::new(0)),
             detached: false,
@@ -73,16 +75,22 @@ impl Sink {
         let source = source
             .pausable(false)
             .amplify(1.0)
+            .skippable()
             .stoppable()
             .periodic_access(Duration::from_millis(5), move |src| {
+                
                 if controls.stopped.load(Ordering::SeqCst) {
                     src.stop();
-                } else {
-                    src.inner_mut().set_factor(*controls.volume.lock().unwrap());
-                    src.inner_mut()
-                        .inner_mut()
-                        .set_paused(controls.pause.load(Ordering::SeqCst));
                 }
+                if controls.do_skip.load(Ordering::SeqCst) {
+                    src.inner_mut().skip();
+                    controls.do_skip.store(false, Ordering::SeqCst);
+                }
+                let amp = src.inner_mut().inner_mut();
+                amp.set_factor(*controls.volume.lock().unwrap());
+                amp.inner_mut()
+                   .set_paused(controls.pause.load(Ordering::SeqCst));
+                
             })
             .convert_samples();
         self.sound_count.fetch_add(1, Ordering::Relaxed);
@@ -131,6 +139,25 @@ impl Sink {
     /// sink is paused.
     pub fn is_paused(&self) -> bool {
         self.controls.pause.load(Ordering::SeqCst)
+    }
+
+
+    /// Removes all currently loaded `Source`s from the `Sink`, and pauses it.
+    ///
+    /// See `pause()` for information about pausing a `Sink`.
+    pub fn clear(&self) {
+        self.sound_count.fetch_sub(self.queue_tx.len(), Ordering::SeqCst);
+        self.queue_tx.clear();
+        self.pause();
+    }
+    
+    /// Skips to the next `Source` in the `Sink`
+    ///
+    /// If there are more `Source`s appended to the `Sink` at the time, 
+    /// it will play the next one. Otherwise, the `Sink` will finish as if
+    /// it had finished playing a `Source` all the way through.
+    pub fn skip_one(&self) {
+        self.controls.do_skip.store(true, Ordering::SeqCst);
     }
 
     /// Stops the sink by emptying the queue.

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -24,6 +24,7 @@ pub use self::sine::SineWave;
 pub use self::spatial::Spatial;
 pub use self::speed::Speed;
 pub use self::stoppable::Stoppable;
+pub use self::skippable::Skippable;
 pub use self::take::TakeDuration;
 pub use self::uniform::UniformSourceIterator;
 pub use self::zero::Zero;
@@ -47,6 +48,7 @@ mod samples_converter;
 mod sine;
 mod spatial;
 mod speed;
+mod skippable;
 mod stoppable;
 mod take;
 mod uniform;
@@ -302,6 +304,13 @@ where
         Self: Sized,
     {
         stoppable::stoppable(self)
+    }
+
+    fn skippable(self) -> Skippable<Self>
+    where
+        Self: Sized
+    {
+        skippable::skippable(self)
     }
 
     /// Applies a low-pass filter to the source.

--- a/src/source/skippable.rs
+++ b/src/source/skippable.rs
@@ -1,0 +1,92 @@
+use std::time::Duration;
+
+use Sample;
+use Source;
+
+/// Internal function that builds a `Skippable` object.
+pub fn skippable<I>(source: I) -> Skippable<I> {
+    Skippable {
+        input: source,
+        do_skip: false,
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Skippable<I> {
+    input: I,
+    do_skip: bool,
+}
+
+impl<I> Skippable<I> {
+    /// Skips the current source
+    #[inline]
+    pub fn skip(&mut self) {
+        self.do_skip = true;
+    }
+
+    /// Returns a reference to the inner source.
+    #[inline]
+    pub fn inner(&self) -> &I {
+        &self.input
+    }
+
+    /// Returns a mutable reference to the inner source.
+    #[inline]
+    pub fn inner_mut(&mut self) -> &mut I {
+        &mut self.input
+    }
+
+    /// Returns the inner source.
+    #[inline]
+    pub fn into_inner(self) -> I {
+        self.input
+    }
+}
+
+impl<I> Iterator for Skippable<I>
+where
+    I: Source,
+    I::Item: Sample,
+{
+    type Item = I::Item;
+
+    #[inline]
+    fn next(&mut self) -> Option<I::Item> {
+        if self.do_skip {
+            None
+        } else {
+            self.input.next()
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.input.size_hint()
+    }
+}
+
+impl<I> Source for Skippable<I>
+where
+    I: Source,
+    I::Item: Sample,
+{
+    #[inline]
+    fn current_frame_len(&self) -> Option<usize> {
+        self.input.current_frame_len()
+    }
+
+    #[inline]
+    fn channels(&self) -> u16 {
+        self.input.channels()
+    }
+
+    #[inline]
+    fn sample_rate(&self) -> u32 {
+        self.input.sample_rate()
+    }
+
+    #[inline]
+    fn total_duration(&self) -> Option<Duration> {
+        self.input.total_duration()
+    }
+}


### PR DESCRIPTION
This PR still has some room for work, but this gives basic functionality for `clear()`ing and `skip_one()`ing `Sink`s. This seems like very useful functionality, and helps make the library more accessible.

There's also some simple formatting stuff done here, since `cargo-fmt` didn't work when I was using it due to an error in the `.rustfmt.toml` file. That's a simple enough to change to something else if need be :) 

Closes? #171 