### PR TITLE
Remove debug_assert which was triggering unnecessary panic

### DIFF
--- a/src/conversions/sample_rate.rs
+++ b/src/conversions/sample_rate.rs
@@ -183,8 +183,6 @@ where
         if result.is_some() {
             result
         } else {
-            debug_assert!(self.next_frame.is_empty());
-
             // draining `self.current_frame`
             if self.current_frame.len() >= 1 {
                 let r = Some(self.current_frame.remove(0));


### PR DESCRIPTION
When playing an mp3 on Windows in debug mode, sometimes
self.next_frame() is not empty in SampleRateConverter, leading to a
panic

See issue: #229