### PR TITLE
Document PlayError and expose in public API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,4 +104,4 @@ pub use crate::decoder::Decoder;
 pub use crate::sink::Sink;
 pub use crate::source::Source;
 pub use crate::spatial_sink::SpatialSink;
-pub use crate::stream::{OutputStream, OutputStreamHandle, StreamError};
+pub use crate::stream::{OutputStream, OutputStreamHandle, PlayError, StreamError};

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -70,9 +70,12 @@ impl OutputStreamHandle {
     }
 }
 
+/// An error occurred while attemping to play a sound.
 #[derive(Debug)]
 pub enum PlayError {
+    /// Attempting to decode the audio failed.
     DecoderError(decoder::DecoderError),
+    /// The output device was lost.
     NoDevice,
 }
 


### PR DESCRIPTION
Currently, there are multiple public API methods which return `Result<T, PlayError>`:

- `Sink::try_new`
- `SpatialSink::try_new`
- `OutputStreamHandle::play_raw`
- `OutputStreamHandle::play_once`

However, `PlayError` is not exposed in the public API, so it can't be imported and doesn't generate documentation. It also has no doc comments. This PR resolves both problems.