### PR TITLE
Add new_X format specific methods to Decoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 - Breaking: Update `cpal` to [0.12](https://github.com/RustAudio/cpal/blob/master/CHANGELOG.md#version-0120-2020-07-09).
 - Breaking: Rework API removing global "rodio audio processing" thread & adapting to the upstream cpal API changes.
+- Add new_X format specific methods to Decoder.
 
 # Version 0.11.0 (2020-03-16)
 

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -91,6 +91,42 @@ where
     pub fn new_looped(data: R) -> Result<LoopedDecoder<R>, DecoderError> {
         Self::new(data).map(LoopedDecoder::new)
     }
+
+    /// Builds a new decoder from wav data.
+    #[cfg(feature = "wav")]
+    pub fn new_wav(data: R) -> Result<Decoder<R>, DecoderError> {
+        match wav::WavDecoder::new(data) {
+            Err(_) => Err(DecoderError::UnrecognizedFormat),
+            Ok(decoder) => Ok(Decoder(DecoderImpl::Wav(decoder))),
+        }
+    }
+
+    /// Builds a new decoder from flac data.
+    #[cfg(feature = "flac")]
+    pub fn new_flac(data: R) -> Result<Decoder<R>, DecoderError> {
+        match flac::FlacDecoder::new(data) {
+            Err(_) => Err(DecoderError::UnrecognizedFormat),
+            Ok(decoder) => Ok(Decoder(DecoderImpl::Flac(decoder))),
+        }
+    }
+
+    /// Builds a new decoder from vorbis data.
+    #[cfg(feature = "vorbis")]
+    pub fn new_vorbis(data: R) -> Result<Decoder<R>, DecoderError> {
+        match vorbis::VorbisDecoder::new(data) {
+            Err(_) => Err(DecoderError::UnrecognizedFormat),
+            Ok(decoder) => Ok(Decoder(DecoderImpl::Vorbis(decoder))),
+        }
+    }
+
+    /// Builds a new decoder from mp3 data.
+    #[cfg(feature = "mp3")]
+    pub fn new_mp3(data: R) -> Result<Decoder<R>, DecoderError> {
+        match mp3::Mp3Decoder::new(data) {
+            Err(_) => Err(DecoderError::UnrecognizedFormat),
+            Ok(decoder) => Ok(Decoder(DecoderImpl::Mp3(decoder))),
+        }
+    }
 }
 
 impl<R> LoopedDecoder<R>


### PR DESCRIPTION
In my project I want to decode data only if it matches an expected file format. I can't see anything in the current API to either retrieve the file format after decoding has started, or to only attempt to decode a specific format.

This is a small addition to the API, to add per file-format decoding methods so that I can ensure that the data matches a specified format.