### PR TITLE
Fix crackling audio when using Sink

### DIFF
--- a/src/queue.rs
+++ b/src/queue.rs
@@ -132,10 +132,11 @@ where
         }
 
         // Try the size hint.
-        if let Some(val) = self.current.size_hint().1 {
-            if val < THRESHOLD && val != 0 {
-                return Some(val);
-            }
+        let (lower_bound, _) = self.current.size_hint();
+        // The iterator default implementation just returns 0.
+        // That's a problematic value, so skip it.
+        if lower_bound > 0 {
+            return Some(lower_bound);
         }
 
         // Otherwise we use the constant value.

--- a/src/source/done.rs
+++ b/src/source/done.rs
@@ -57,6 +57,10 @@ where
         }
         next
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.input.size_hint()
+    }
 }
 
 impl<I> Source for Done<I>


### PR DESCRIPTION
Fixes #318.
Fixes #319.
Fixes #266.

Combined, these two fixes also fix crackling audio on my computer. The reason for the crackling audio was that Done did not implement size_hint so it would always fall back to a frame size of 512. Somewhere down the pipeline this causing crackling every 512 samples I suspect (which might be worth fixing too).

The current_frame_length fix is necessary because in my case I was playing from a sound file and it returns a size hint on the format `(very_large_number, Some(very_large_number))` and the current_frame_length method would just ignore that and fall back to a frame length of 512 samples anyway.

This might also fix #225 (I am running on linux, so I cannot test that).
