### PR TITLE
SampleRateConverter: Fix reliance on Vec internals (see #303)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ flac = ["claxon"]
 vorbis = ["lewton"]
 wav = ["hound"]
 mp3 = ["minimp3"]
+
+[dev-dependencies]
+quickcheck = "0.9.2"

--- a/src/conversions/sample.rs
+++ b/src/conversions/sample.rs
@@ -84,7 +84,11 @@ pub trait Sample: CpalSample {
 impl Sample for u16 {
     #[inline]
     fn lerp(first: u16, second: u16, numerator: u32, denominator: u32) -> u16 {
-        (first as u32 + (second as u32 - first as u32) * numerator / denominator) as u16
+        let a = first as i32;
+        let b = second as i32;
+        let n = numerator as i32;
+        let d = denominator as i32;
+        (a + (b - a) * n / d) as u16
     }
 
     #[inline]

--- a/src/conversions/sample_rate.rs
+++ b/src/conversions/sample_rate.rs
@@ -274,27 +274,15 @@ mod test {
             assert_eq!(output, []);
         }
 
-        fn identity(from: u32, n: u16) -> () {
+        fn identity(from: u32, n: u16, input: Vec<u16>) -> () {
             let from = if from == 0 { return; } else { SampleRate(from) };
             if n == 0 { return; }
 
-            let input = vec![2u16, 16, 4, 18, 6, 20, 8, 22];
             let output =
-                SampleRateConverter::new(input.into_iter(), from, from, n);
+                SampleRateConverter::new(input.clone().into_iter(), from, from, n);
 
             let output = output.collect::<Vec<_>>();
-            assert_eq!(output, [2u16, 16, 4, 18, 6, 20, 8, 22]);
-        }
-
-        fn identity_2channels_misalign(from: u32) -> () {
-            let from = if from == 0 { return; } else { SampleRate(from) };
-
-            let input = vec![2u16, 16, 4, 18, 6];
-            let output =
-                SampleRateConverter::new(input.into_iter(), from, from, 2);
-
-            let output = output.collect::<Vec<_>>();
-            assert_eq!(output, [2u16, 16, 4, 18, 6]);
+            assert_eq!(input, output);
         }
 
         fn half_sample_rate(to: u32) -> () {

--- a/src/conversions/sample_rate.rs
+++ b/src/conversions/sample_rate.rs
@@ -285,28 +285,46 @@ mod test {
             assert_eq!(input, output);
         }
 
-        fn half_sample_rate(to: u32) -> () {
+        fn half_sample_rate(to: u32, input: Vec<u16>) -> () {
             let to = if to == 0 { return; } else { SampleRate(to) };
             let from = multiply_rate(to, 2);
+            let n = 2u16;
 
-            let input = vec![1u16, 16, 2, 17, 3, 18, 4, 19, 5, 20, 6, 21];
+            // Truncate the input, so it contains an integer number of frames.
+            let input = {
+                let ns = n as usize;
+                let mut i = input;
+                i.truncate(ns * (i.len() / ns));
+                i
+            };
+
             let output =
                 SampleRateConverter::new(input.clone().into_iter(), from, to, n)
                   .collect::<Vec<_>>();
 
-            assert_eq!(output, [1, 16, 3, 18, 5, 20]);
+            assert_eq!(input.chunks_exact(n.into()).step_by(2).collect::<Vec<_>>().concat(),
+                       output)
         }
 
-        fn double_sample_rate(from: u32) -> () {
+        fn double_sample_rate(from: u32, input: Vec<u16>) -> () {
             let from = if from == 0 { return; } else { SampleRate(from) };
             let to = multiply_rate(from, 2);
+            let n = 2u16;
 
-            let input = vec![2u16, 16, 4, 18, 6, 20, 8, 22];
+            // Truncate the input, so it contains an integer number of frames.
+            let input = {
+                let ns = n as usize;
+                let mut i = input;
+                i.truncate(ns * (i.len() / ns));
+                i
+            };
+
             let output =
-                SampleRateConverter::new(input.into_iter(), from, to, 2)
+                SampleRateConverter::new(input.clone().into_iter(), from, to, n)
                   .collect::<Vec<_>>();
 
-            assert_eq!(output, [2, 16, 3, 17, 4, 18, 5, 19, 6, 20, 7, 21, 8, 22]);
+            assert_eq!(input,
+                       output.chunks_exact(n.into()).step_by(2).collect::<Vec<_>>().concat())
         }
     }
 

--- a/src/conversions/sample_rate.rs
+++ b/src/conversions/sample_rate.rs
@@ -341,39 +341,4 @@ mod test {
         let output = output.collect::<Vec<_>>();
         assert_eq!(output, [2, 16, 3, 17, 4, 18, 6, 20, 7, 21, 8, 22]);
     }
-
-    #[test]
-    #[ignore]
-    fn upsample_lengths() {
-        let input = vec![2u16, 16, 4, 18, 6, 20, 8, 22];
-        let mut output =
-            SampleRateConverter::new(input.into_iter(), SampleRate(2000), SampleRate(3000), 2);
-
-        assert_eq!(output.len(), 12);
-        assert_eq!(output.next(), Some(2));
-        assert_eq!(output.len(), 11);
-        assert_eq!(output.next(), Some(16));
-        assert_eq!(output.len(), 10);
-        assert_eq!(output.next(), Some(3));
-        assert_eq!(output.len(), 9);
-        assert_eq!(output.next(), Some(17));
-        assert_eq!(output.len(), 8);
-        assert_eq!(output.next(), Some(4));
-        assert_eq!(output.len(), 7);
-        assert_eq!(output.next(), Some(18));
-        assert_eq!(output.len(), 6);
-        assert_eq!(output.next(), Some(6));
-        assert_eq!(output.len(), 5);
-        assert_eq!(output.next(), Some(20));
-        assert_eq!(output.len(), 4);
-        assert_eq!(output.next(), Some(7));
-        assert_eq!(output.len(), 3);
-        assert_eq!(output.next(), Some(21));
-        assert_eq!(output.len(), 2);
-        assert_eq!(output.next(), Some(8));
-        assert_eq!(output.len(), 1);
-        assert_eq!(output.next(), Some(22));
-        assert_eq!(output.len(), 0);
-        assert_eq!(output.next(), None);
-    }
 }

--- a/src/conversions/sample_rate.rs
+++ b/src/conversions/sample_rate.rs
@@ -285,10 +285,10 @@ mod test {
             assert_eq!(input, output);
         }
 
-        fn half_sample_rate(to: u32, input: Vec<u16>, n: u16) -> () {
+        fn divide_sample_rate(to: u32, k: u32, input: Vec<u16>, n: u16) -> () {
             let to = if to == 0 { return; } else { SampleRate(to) };
-            let from = multiply_rate(to, 2);
-            if n == 0 { return; }
+            let from = multiply_rate(to, k);
+            if k == 0 || n == 0 { return; }
 
             // Truncate the input, so it contains an integer number of frames.
             let input = {
@@ -302,14 +302,15 @@ mod test {
                 SampleRateConverter::new(input.clone().into_iter(), from, to, n)
                   .collect::<Vec<_>>();
 
-            assert_eq!(input.chunks_exact(n.into()).step_by(2).collect::<Vec<_>>().concat(),
+            assert_eq!(input.chunks_exact(n.into())
+                         .step_by(k as usize).collect::<Vec<_>>().concat(),
                        output)
         }
 
-        fn double_sample_rate(from: u32, input: Vec<u16>, n: u16) -> () {
+        fn multiply_sample_rate(from: u32, k: u32, input: Vec<u16>, n: u16) -> () {
             let from = if from == 0 { return; } else { SampleRate(from) };
-            let to = multiply_rate(from, 2);
-            if n == 0 { return; }
+            let to = multiply_rate(from, k);
+            if k == 0 || n == 0 { return; }
 
             // Truncate the input, so it contains an integer number of frames.
             let input = {
@@ -324,7 +325,9 @@ mod test {
                   .collect::<Vec<_>>();
 
             assert_eq!(input,
-                       output.chunks_exact(n.into()).step_by(2).collect::<Vec<_>>().concat())
+                       output.chunks_exact(n.into())
+                         .step_by(k as usize).collect::<Vec<_>>().concat()
+            )
         }
     }
 

--- a/src/conversions/sample_rate.rs
+++ b/src/conversions/sample_rate.rs
@@ -261,36 +261,26 @@ mod test {
     }
 
     quickcheck! {
-        fn zero(from: u32, to: u32) -> () {
+        fn zero(from: u32, to: u32, n: u16) -> () {
             let from = if from == 0 { return; } else { SampleRate(from) };
             let to   = if   to == 0 { return; } else { SampleRate(to)   };
+            if n == 0 { return; }
 
             let input: Vec<u16> = Vec::new();
             let output =
-                SampleRateConverter::new(input.into_iter(), from, to, 1);
+                SampleRateConverter::new(input.into_iter(), from, to, n);
 
             let output = output.collect::<Vec<_>>();
             assert_eq!(output, []);
         }
 
-        fn identity_1channel(from: u32) -> () {
+        fn identity(from: u32, n: u16) -> () {
             let from = if from == 0 { return; } else { SampleRate(from) };
+            if n == 0 { return; }
 
             let input = vec![2u16, 16, 4, 18, 6, 20, 8, 22];
             let output =
-                SampleRateConverter::new(input.into_iter(), from, from, 1);
-
-            let output = output.collect::<Vec<_>>();
-            assert_eq!(output, [2u16, 16, 4, 18, 6, 20, 8, 22]);
-        }
-
-        fn identity_2channels(from: u32) -> () {
-            let from = if from == 0 { return; } else { SampleRate(from) };
-
-            let input = vec![2u16, 16, 4, 18, 6, 20, 8, 22];
-            let output =
-                SampleRateConverter::new(input.into_iter(), from, from, 2);
-            assert_eq!(output.len(), 8);
+                SampleRateConverter::new(input.into_iter(), from, from, n);
 
             let output = output.collect::<Vec<_>>();
             assert_eq!(output, [2u16, 16, 4, 18, 6, 20, 8, 22]);
@@ -305,18 +295,6 @@ mod test {
 
             let output = output.collect::<Vec<_>>();
             assert_eq!(output, [2u16, 16, 4, 18, 6]);
-        }
-
-        fn identity_5channels(from: u32) -> () {
-            let from = if from == 0 { return; } else { SampleRate(from) };
-
-            let input = vec![2u16, 16, 4, 18, 6, 20, 8, 22, 10, 24];
-            let output =
-                SampleRateConverter::new(input.into_iter(), from, from, 5);
-            assert_eq!(output.len(), 10);
-
-            let output = output.collect::<Vec<_>>();
-            assert_eq!(output, [2u16, 16, 4, 18, 6, 20, 8, 22, 10, 24]);
         }
 
         fn half_sample_rate(to: u32) -> () {

--- a/src/conversions/sample_rate.rs
+++ b/src/conversions/sample_rate.rs
@@ -268,9 +268,9 @@ mod test {
 
             let input: Vec<u16> = Vec::new();
             let output =
-                SampleRateConverter::new(input.into_iter(), from, to, n);
+                SampleRateConverter::new(input.into_iter(), from, to, n)
+                  .collect::<Vec<_>>();
 
-            let output = output.collect::<Vec<_>>();
             assert_eq!(output, []);
         }
 
@@ -279,9 +279,9 @@ mod test {
             if n == 0 { return; }
 
             let output =
-                SampleRateConverter::new(input.clone().into_iter(), from, from, n);
+                SampleRateConverter::new(input.clone().into_iter(), from, from, n)
+                  .collect::<Vec<_>>();
 
-            let output = output.collect::<Vec<_>>();
             assert_eq!(input, output);
         }
 
@@ -291,9 +291,9 @@ mod test {
 
             let input = vec![1u16, 16, 2, 17, 3, 18, 4, 19, 5, 20, 6, 21];
             let output =
-                SampleRateConverter::new(input.into_iter(), from, to, 2);
+                SampleRateConverter::new(input.clone().into_iter(), from, to, n)
+                  .collect::<Vec<_>>();
 
-            let output = output.collect::<Vec<_>>();
             assert_eq!(output, [1, 16, 3, 18, 5, 20]);
         }
 
@@ -303,9 +303,9 @@ mod test {
 
             let input = vec![2u16, 16, 4, 18, 6, 20, 8, 22];
             let output =
-                SampleRateConverter::new(input.into_iter(), from, to, 2);
+                SampleRateConverter::new(input.into_iter(), from, to, 2)
+                  .collect::<Vec<_>>();
 
-            let output = output.collect::<Vec<_>>();
             assert_eq!(output, [2, 16, 3, 17, 4, 18, 5, 19, 6, 20, 7, 21, 8, 22]);
         }
     }

--- a/src/conversions/sample_rate.rs
+++ b/src/conversions/sample_rate.rs
@@ -285,10 +285,10 @@ mod test {
             assert_eq!(input, output);
         }
 
-        fn half_sample_rate(to: u32, input: Vec<u16>) -> () {
+        fn half_sample_rate(to: u32, input: Vec<u16>, n: u16) -> () {
             let to = if to == 0 { return; } else { SampleRate(to) };
             let from = multiply_rate(to, 2);
-            let n = 2u16;
+            if n == 0 { return; }
 
             // Truncate the input, so it contains an integer number of frames.
             let input = {
@@ -306,10 +306,10 @@ mod test {
                        output)
         }
 
-        fn double_sample_rate(from: u32, input: Vec<u16>) -> () {
+        fn double_sample_rate(from: u32, input: Vec<u16>, n: u16) -> () {
             let from = if from == 0 { return; } else { SampleRate(from) };
             let to = multiply_rate(from, 2);
-            let n = 2u16;
+            if n == 0 { return; }
 
             // Truncate the input, so it contains an integer number of frames.
             let input = {


### PR DESCRIPTION
## Bugfixes

- [x] Removed use of `Vec::capacity`, instead carry the number of channels as an explicit member of the `struct SampleRateConverter`.
- [x] Fixed an underflow (leading to `panic!`) in `<u16 as Sample>::lerp`, discovered when switching to property-based tests.

## Testsuite improvements

- [x] Added a reproducing testcase for #316 (marked `#[ignore]`, pending a fix)
- [x] Switched to property-based tests (using `quickcheck`)
- [x] Generalised the tests over their input data, number of channels, and sample rates.
- [x] Generalised the sample rate multiplication and division tests over the (integer) conversion ratio.
- [x] Removed redundant tests.
