### PR TITLE
Implement Display and Error traits for PlayError

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -85,6 +85,24 @@ impl From<decoder::DecoderError> for PlayError {
     }
 }
 
+impl fmt::Display for PlayError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DecoderError(e) => e.fmt(f),
+            Self::NoDevice => write!(f, "NoDevice"),
+        }
+    }
+}
+
+impl error::Error for PlayError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            Self::DecoderError(e) => Some(e),
+            Self::NoDevice => None,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub enum StreamError {
     PlayStreamError(cpal::PlayStreamError),


### PR DESCRIPTION
Noticed that `rodio::StreamError` had implemented `Error`, however, `rodio::PlayError` had not.

The implementations of `Display` and `Error`for `PlayError` are identical to the ones for `StreamError`. 