### PR TITLE
Update cpal with Android support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Version 0.12.1 (2020-11-03)
+# Version 0.13.0 (2020-11-03)
 
 - Update `cpal` to [0.13](https://github.com/RustAudio/cpal/blob/master/CHANGELOG.md#version-0130-2020-10-28).
 - Add Android support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 0.12.1 (2020-11-03)
+
+- Update `cpal` to [0.13](https://github.com/RustAudio/cpal/blob/master/CHANGELOG.md#version-0130-2020-10-28).
+- Add Android support.
+
 # Version 0.12.0 (2020-10-05)
 
 - Breaking: Update `cpal` to [0.12](https://github.com/RustAudio/cpal/blob/master/CHANGELOG.md#version-0120-2020-07-09).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rodio"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = "Audio playback library"
@@ -10,7 +10,7 @@ documentation = "http://docs.rs/rodio"
 edition = "2018"
 
 [dependencies]
-cpal = "0.12"
+cpal = "0.13"
 claxon = { version = "0.4.2", optional = true }
 hound = { version = "3.3.1", optional = true }
 lewton = { version = "0.10", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rodio"
-version = "0.12.1"
+version = "0.13.0"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = "Audio playback library"


### PR DESCRIPTION
Bumps `cpal` version to 0.13.0 and `rodio` 0.13.0 as Android support was added but `rodio` interface hasn't changed.

@est31 