### PR TITLE
Add feature flag to enable wasm-bindgen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ flac = ["claxon"]
 vorbis = ["lewton"]
 wav = ["hound"]
 mp3 = ["minimp3"]
+wasm-bindgen = ["cpal/wasm-bindgen"]
 
 [dev-dependencies]
 quickcheck = "0.9.2"


### PR DESCRIPTION
Rodio can work on wasm32 target if the cpal/wasm-bindgen feature is enabled.

This is described in more details here #313.

Only mp3 needs to be disabled for it to work.