### PR TITLE
Better error handling for stream creation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,8 +97,8 @@
 //!
 #![cfg_attr(test, deny(missing_docs))]
 pub use cpal::{
-    traits::DeviceTrait, Device, Devices, DevicesError, InputDevices, OutputDevices,
-    SupportedStreamConfig, self,
+    self, traits::DeviceTrait, Device, Devices, DevicesError, InputDevices, OutputDevices,
+    SupportedStreamConfig,
 };
 
 mod conversions;


### PR DESCRIPTION
I am a contributor to Veloren (an open source game) and we have had players with different devices reaching the expects in stream.rs. This MR removes all the expects and replaces it with some error handling. Instead of panicking, this will allow the program to decide what to do with the error.
You can ignore the changes in src/decoder/mod.rs, that was just a result of cargo fmt.