### PR TITLE
Adds 'cpal' to re-exports

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@
 #![cfg_attr(test, deny(missing_docs))]
 pub use cpal::{
     traits::DeviceTrait, Device, Devices, DevicesError, InputDevices, OutputDevices,
-    SupportedStreamConfig,
+    SupportedStreamConfig, self,
 };
 
 mod conversions;


### PR DESCRIPTION
If a user wants some finer access to devices and hosts this will allow
that without having to add a separate dependency to cpal and risk having
a cersion conflict between the cpal dependency and the version of cpal
within rodio.
