### PR TITLE
Check if the frame length is zero in SkipDuration.

### DIFF
--- a/src/source/skip.rs
+++ b/src/source/skip.rs
@@ -33,6 +33,12 @@ where
         // .unwrap() safety: if `current_frame_len()` is None, the body of the `if` statement
         // above returns before we get here.
         let frame_len: usize = input.current_frame_len().unwrap();
+        // If frame_len is zero, then there is no more data to skip. Instead
+        // just bail out.
+        if frame_len == 0 {
+            return;
+        }
+
         let ns_per_sample: u128 =
             NS_PER_SECOND / input.sample_rate() as u128 / input.channels() as u128;
 


### PR DESCRIPTION
If the source we are skipping runs out of data, it will return Some(0) as the frame length. Before, this would cause an infinite loop because we would skip zero samples forever. This PR fixes it by checking explicitly if the frame length is zero and bailing out if it is.

Fixes #387 