### PR TITLE
Fix sounds playing on the wrong channels

### DIFF
--- a/src/dynamic_mixer.rs
+++ b/src/dynamic_mixer.rs
@@ -30,6 +30,8 @@ where
     let output = DynamicMixer {
         current_sources: Vec::with_capacity(16),
         input: input.clone(),
+        sample_count: 0,
+        still_pending: vec![],
     };
 
     (input, output)
@@ -69,6 +71,12 @@ pub struct DynamicMixer<S> {
 
     // The pending sounds.
     input: Arc<DynamicMixerController<S>>,
+
+    // The number of samples produced so far.
+    sample_count: usize,
+
+    // A temporary vec used in start_pending_sources.
+    still_pending: Vec<Box<dyn Source<Item = S> + Send>>,
 }
 
 impl<S> Source for DynamicMixer<S>
@@ -105,11 +113,10 @@ where
     #[inline]
     fn next(&mut self) -> Option<S> {
         if self.input.has_pending.load(Ordering::SeqCst) {
-            // TODO: relax ordering?
-            let mut pending = self.input.pending_sources.lock().unwrap();
-            self.current_sources.extend(pending.drain(..));
-            self.input.has_pending.store(false, Ordering::SeqCst); // TODO: relax ordering?
+            self.start_pending_sources();
         }
+
+        self.sample_count += 1;
 
         if self.current_sources.is_empty() {
             return None;
@@ -140,6 +147,33 @@ where
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         (0, None)
+    }
+}
+
+impl<S> DynamicMixer<S>
+where
+    S: Sample + Send + 'static,
+{
+    // Samples from the #next() function are interlaced for each of the channels.
+    // We need to ensure we start playing sources so that their samples are
+    // in-step with the modulo of the samples produced so far. Otherwise, the
+    // sound will play on the wrong channels, e.g. left / right will be reversed.
+    fn start_pending_sources(&mut self) {
+        let mut pending = self.input.pending_sources.lock().unwrap(); // TODO: relax ordering?
+
+        for source in pending.drain(..) {
+            let in_step = self.sample_count % source.channels() as usize == 0;
+
+            if in_step {
+                self.current_sources.push(source);
+            } else {
+                self.still_pending.push(source);
+            }
+        }
+        std::mem::swap(&mut self.still_pending, &mut pending);
+
+        let has_pending = !pending.is_empty();
+        self.input.has_pending.store(has_pending, Ordering::SeqCst); // TODO: relax ordering?
     }
 }
 


### PR DESCRIPTION
Previously, the DynamicMixer implementation had a problem where it would start playing pending sources immediately. This meant that sometimes the first sample of a source was sent to the wrong audio channel. For example, if a stereo source starts playing on an odd-numbered call to DynamicMixer::next() then its left/right channels would be reversed because the output is expecting the right-channel's sample at that time.

This fixes https://github.com/RustAudio/rodio/issues/386 and possibly https://github.com/RustAudio/rodio/issues/286 (I haven't checked) and maybe even https://github.com/RustAudio/rodio/issues/252 (I haven't checked).

This is my first PR to rodio. I'm not really sure if there's a style guide or anything so any suggestions would be more than welcome! Thanks