### PR TITLE
Change Sink playback speed

### DIFF
--- a/src/sink.rs
+++ b/src/sink.rs
@@ -24,6 +24,7 @@ struct Controls {
     pause: AtomicBool,
     volume: Mutex<f32>,
     stopped: AtomicBool,
+    speed: Mutex<f32>,
 }
 
 impl Sink {
@@ -47,6 +48,7 @@ impl Sink {
                 pause: AtomicBool::new(false),
                 volume: Mutex::new(1.0),
                 stopped: AtomicBool::new(false),
+                speed: Mutex::new(1.0),
             }),
             sound_count: Arc::new(AtomicUsize::new(0)),
             detached: false,
@@ -65,6 +67,7 @@ impl Sink {
         let controls = self.controls.clone();
 
         let source = source
+            .speed(1.0)
             .pausable(false)
             .amplify(1.0)
             .stoppable()
@@ -76,6 +79,10 @@ impl Sink {
                     src.inner_mut()
                         .inner_mut()
                         .set_paused(controls.pause.load(Ordering::SeqCst));
+                    src.inner_mut()
+                        .inner_mut()
+                        .inner_mut()
+                        .set_factor(*controls.speed.lock().unwrap());
                 }
             })
             .convert_samples();

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -100,6 +100,15 @@ impl Sink {
         *self.controls.volume.lock().unwrap()
     }
 
+    /// Changes the speed of the sound.
+    ///
+    /// The value `1.0` is the "normal" speed (unfiltered input). Any value other than `1.0` will
+    /// change the play speed of the sound.
+    #[inline]
+    pub fn set_speed(&self, value: f32) {
+        *self.controls.speed.lock().unwrap() = value;
+    }
+
     /// Changes the volume of the sound.
     ///
     /// The value `1.0` is the "normal" volume (unfiltered input). Any value other than `1.0` will

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -100,15 +100,6 @@ impl Sink {
         *self.controls.volume.lock().unwrap()
     }
 
-    /// Changes the speed of the sound.
-    ///
-    /// The value `1.0` is the "normal" speed (unfiltered input). Any value other than `1.0` will
-    /// change the play speed of the sound.
-    #[inline]
-    pub fn set_speed(&self, value: f32) {
-        *self.controls.speed.lock().unwrap() = value;
-    }
-
     /// Changes the volume of the sound.
     ///
     /// The value `1.0` is the "normal" volume (unfiltered input). Any value other than `1.0` will
@@ -116,6 +107,24 @@ impl Sink {
     #[inline]
     pub fn set_volume(&self, value: f32) {
         *self.controls.volume.lock().unwrap() = value;
+    }
+
+    /// Gets the speed of the sound.
+    ///
+    /// The value `1.0` is the "normal" speed (unfiltered input). Any value other than `1.0` will
+    /// change the play speed of the sound.
+    #[inline]
+    pub fn speed(&self) -> f32 {
+        *self.controls.speed.lock().unwrap()
+    }
+
+    /// Changes the speed of the sound.
+    ///
+    /// The value `1.0` is the "normal" speed (unfiltered input). Any value other than `1.0` will
+    /// change the play speed of the sound.
+    #[inline]
+    pub fn set_speed(&self, value: f32) {
+        *self.controls.speed.lock().unwrap() = value;
     }
 
     /// Resumes playback of a paused sink.

--- a/src/source/speed.rs
+++ b/src/source/speed.rs
@@ -19,6 +19,12 @@ where
     I: Source,
     I::Item: Sample,
 {
+    /// Modifies the speed factor.
+    #[inline]
+    pub fn set_factor(&mut self, factor: f32) {
+        self.factor = factor;
+    }
+
     /// Returns a reference to the inner source.
     #[inline]
     pub fn inner(&self) -> &I {

--- a/src/spatial_sink.rs
+++ b/src/spatial_sink.rs
@@ -91,8 +91,6 @@ impl SpatialSink {
         self.sink.set_volume(value);
     }
 
-    
-
     /// Gets the speed of the sound.
     ///
     /// The value `1.0` is the "normal" speed (unfiltered input). Any value other than `1.0` will

--- a/src/spatial_sink.rs
+++ b/src/spatial_sink.rs
@@ -91,6 +91,26 @@ impl SpatialSink {
         self.sink.set_volume(value);
     }
 
+    
+
+    /// Gets the speed of the sound.
+    ///
+    /// The value `1.0` is the "normal" speed (unfiltered input). Any value other than `1.0` will
+    /// change the play speed of the sound.
+    #[inline]
+    pub fn speed(&self) -> f32 {
+        self.sink.speed()
+    }
+
+    /// Changes the speed of the sound.
+    ///
+    /// The value `1.0` is the "normal" speed (unfiltered input). Any value other than `1.0` will
+    /// change the play speed of the sound.
+    #[inline]
+    pub fn set_speed(&self, value: f32) {
+        self.sink.set_speed(value)
+    }
+
     /// Resumes playback of a paused sound.
     ///
     /// No effect if not paused.


### PR DESCRIPTION
Adds the ability to change the playback speed of a Sink while playing.

Adds `Sink::set_speed`, `Sink::speed`, `SpatialSink::set_speed`, and `SpatialSink::speed` (also adds `Speed::set_factor` like Amplify has).
These fns get/set a new `speed` field in `Controls`, and this PR modifies `Sink::append` to use it.

Basically I just copied what was already there for volume and it seems to just work?
I haven't tested this very thoroughly because I don't really know what might break.
I have a [fork of ggez](https://github.com/PieKing1215/ggez/tree/changing_pitch) that I set up to make use of this feature and it seems to work in that case at least.

Related: #177 & #391