### PR TITLE
Try next packet after a decode error (Symphonia)

### DIFF
--- a/src/decoder/symphonia.rs
+++ b/src/decoder/symphonia.rs
@@ -90,9 +90,9 @@ impl SymphoniaDecoder {
                         }
                     }
                     _ => return Err(e),
-                }
+                },
             }
-        }
+        };
         let spec = decoded.spec().to_owned();
         let buffer = SymphoniaDecoder::get_buffer(decoded, &spec);
 
@@ -163,7 +163,7 @@ impl Iterator for SymphoniaDecoder {
                                 }
                             }
                             _ => return None,
-                        }
+                        },
                     },
                     Err(_) => return None,
                 }

--- a/src/decoder/symphonia.rs
+++ b/src/decoder/symphonia.rs
@@ -145,14 +145,10 @@ impl Iterator for SymphoniaDecoder {
     fn next(&mut self) -> Option<i16> {
         if self.current_frame_offset == self.buffer.len() {
             let mut decode_errors: usize = 0;
-            loop {
+            let decoded = loop {
                 match self.format.next_packet() {
                     Ok(packet) => match self.decoder.decode(&packet) {
-                        Ok(decoded) => {
-                            self.spec = decoded.spec().to_owned();
-                            self.buffer = SymphoniaDecoder::get_buffer(decoded, &self.spec);
-                            break;
-                        }
+                        Ok(decoded) => break decoded,
                         Err(e) => match e {
                             Error::DecodeError(_) => {
                                 decode_errors += 1;
@@ -167,7 +163,9 @@ impl Iterator for SymphoniaDecoder {
                     },
                     Err(_) => return None,
                 }
-            }
+            };
+            self.spec = decoded.spec().to_owned();
+            self.buffer = SymphoniaDecoder::get_buffer(decoded, &self.spec);
             self.current_frame_offset = 0;
         }
 


### PR DESCRIPTION
PR for issue #401. In symphonia, a decode error is not fatal and one must try the next packet in case of a decode error.
However a limit is set to the number of successive packets with decode errors. Only tested with aac files.