### PR TITLE
Release 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Version 0.15.0 (2022-01-23)
+
+- Remove requirement that the argument `Decoder::new` and `LoopedDecoder::new` implement `Send`.
+- Add optional symphonia backend.
+- `WavDecoder`'s `total_duration` now returns the total duration of the sound rather than the remaining duration.
+- Add 32-bit signed in WAV decoding.
+- `SineWave::new()` now takes a `f32` instead of a `u32`.
+- Add `len()` method to `SpatialSink`.
+
 # Version 0.14.0 (2021-05-21)
 
 - Re-export `cpal` in full.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ claxon = { version = "0.4.2", optional = true }
 hound = { version = "3.3.1", optional = true }
 lewton = { version = "0.10", optional = true }
 minimp3 = { version = "0.5.0", optional = true }
-symphonia = {version = "0.3", optional = true }
+symphonia = {version = "0.4", optional = true }
 
 [features]
 default = ["flac", "vorbis", "wav", "mp3"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rodio"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = "Audio playback library"

--- a/src/decoder/read_seek_source.rs
+++ b/src/decoder/read_seek_source.rs
@@ -19,7 +19,7 @@ impl<T: Read + Seek + Send> MediaSource for ReadSeekSource<T> {
         true
     }
 
-    fn len(&self) -> Option<u64> {
+    fn byte_len(&self) -> Option<u64> {
         None
     }
 }


### PR DESCRIPTION
Prepares the changelog for 0.15 (I've just included externally-visible changes) and bumps version number. In a separate commit I've updated the symphonia dep to 0.4 (please lmk if you'd rather that go in its own PR). Am I correct in understanding that as soon as this is merged, the release will take place automatically?