### PR TITLE
Allow creating a SymphoniaDecoder directly from a FormatReader

### DIFF
--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -14,8 +14,8 @@ use crate::Source;
 use self::read_seek_source::ReadSeekSource;
 #[cfg(feature = "symphonia")]
 use ::symphonia::core::{
-	io::{MediaSource, MediaSourceStream},
-	formats::FormatReader,
+    formats::FormatReader,
+    io::{MediaSource, MediaSourceStream},
 };
 
 #[cfg(all(feature = "flac", not(feature = "symphonia-flac")))]
@@ -201,7 +201,9 @@ where
     /// will be produced.  Ensure that the appropriate symphonia features have been
     /// enabled before using this method.
     #[cfg(feature = "symphonia")]
-    pub fn new_from_format_reader(format_reader: Box<dyn FormatReader>) -> Result<Decoder<R>, DecoderError> {
+    pub fn new_from_format_reader(
+        format_reader: Box<dyn FormatReader>,
+    ) -> Result<Decoder<R>, DecoderError> {
         symphonia::SymphoniaDecoder::new_with_format_reader(format_reader)
             .map(DecoderImpl::Symphonia)
             .map(Decoder)

--- a/src/decoder/symphonia.rs
+++ b/src/decoder/symphonia.rs
@@ -48,7 +48,9 @@ impl SymphoniaDecoder {
         }
     }
 
-    pub fn new_with_format_reader(format_reader: Box<dyn FormatReader>) -> Result<Self, DecoderError> {
+    pub fn new_with_format_reader(
+        format_reader: Box<dyn FormatReader>,
+    ) -> Result<Self, DecoderError> {
         match SymphoniaDecoder::init_from_format_reader(format_reader) {
             Err(e) => match e {
                 Error::IoError(e) => Err(DecoderError::IoError(e.to_string())),
@@ -87,7 +89,6 @@ impl SymphoniaDecoder {
     fn init_from_format_reader(
         mut format_reader: Box<dyn FormatReader>,
     ) -> symphonia::core::errors::Result<Option<SymphoniaDecoder>> {
-
         let stream = match format_reader.default_track() {
             Some(stream) => stream,
             None => return Ok(None),


### PR DESCRIPTION
Hello!

I'm working on using `rodio` for audio playback in a personal application, with Symphonia as my decoder.  The problem is, I've already parsed the data I'm working with (in my case, to extract the metadata).  This leaves me in the interesting situation of having a partially decoded file that needs to be thrown away and read from scratch in order to be played.

As it stands, `rodio` already has all of the internals for playing the `FormatReader` that any user who has already started deconstructing a song in Symphonia would have.  I believe that creating a user-friendly interface to instantiate a decoder from a `FormatReader` (with the disclaimer that this is not the most common usecase) is an easy way to expand the functionality of `rodio` without adding too much complexity or unnecessary code.

This PR does exactly this, by creating the new `pub fn new_from_format_reader(..)` method for the `Decoder`, which is enabled when any of the `symphonia-*` features are enabled.  To facilitate this, the PR also makes a slight internal change to the `SymphoniaDecoder` that just adds another entrypoint to the constructor.

This should be an entirely non-breaking change, and the aforementioned new `Decoder` constructor is the only public facing API change.

I'd love to hear your thoughts on this!