### PR TITLE
remove the need for a source to be debug on a spatial sink

### DIFF
--- a/src/source/spatial.rs
+++ b/src/source/spatial.rs
@@ -1,4 +1,3 @@
-use std::fmt::Debug;
 use std::time::Duration;
 
 use crate::source::ChannelVolume;
@@ -6,11 +5,11 @@ use crate::{Sample, Source};
 
 /// Combines channels in input into a single mono source, then plays that mono sound
 /// to each channel at the volume given for that channel.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Spatial<I>
 where
     I: Source,
-    I::Item: Sample + Debug,
+    I::Item: Sample,
 {
     input: ChannelVolume<I>,
 }
@@ -25,7 +24,7 @@ fn dist_sq(a: [f32; 3], b: [f32; 3]) -> f32 {
 impl<I> Spatial<I>
 where
     I: Source,
-    I::Item: Sample + Debug,
+    I::Item: Sample,
 {
     pub fn new(
         input: I,
@@ -70,7 +69,7 @@ where
 impl<I> Iterator for Spatial<I>
 where
     I: Source,
-    I::Item: Sample + Debug,
+    I::Item: Sample,
 {
     type Item = I::Item;
 
@@ -88,14 +87,14 @@ where
 impl<I> ExactSizeIterator for Spatial<I>
 where
     I: Source + ExactSizeIterator,
-    I::Item: Sample + Debug,
+    I::Item: Sample,
 {
 }
 
 impl<I> Source for Spatial<I>
 where
     I: Source,
-    I::Item: Sample + Debug,
+    I::Item: Sample,
 {
     #[inline]
     fn current_frame_len(&self) -> Option<usize> {

--- a/src/spatial_sink.rs
+++ b/src/spatial_sink.rs
@@ -1,5 +1,4 @@
 use std::f32;
-use std::fmt::Debug;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -56,7 +55,7 @@ impl SpatialSink {
     pub fn append<S>(&self, source: S)
     where
         S: Source + Send + 'static,
-        S::Item: Sample + Send + Debug,
+        S::Item: Sample + Send,
     {
         let positions = self.positions.clone();
         let pos_lock = self.positions.lock().unwrap();


### PR DESCRIPTION
[`SpatialSink::append`](https://docs.rs/rodio/latest/rodio/struct.SpatialSink.html#method.append) requires the source to be `Debug`, while [`Sink::append`](https://docs.rs/rodio/latest/rodio/struct.Sink.html#method.append) doesn't.

I removed the bound, and all the other that were needed to get it to compile again