### PR TITLE
spatial: ignore NaNs when setting the volume of each ear

### DIFF
--- a/src/source/spatial.rs
+++ b/src/source/spatial.rs
@@ -60,10 +60,18 @@ where
         let right_diff_modifier = ((right_dist - left_dist) / max_diff + 1.0) / 4.0 + 0.5;
         let left_dist_modifier = (1.0 / left_dist_sq).min(1.0);
         let right_dist_modifier = (1.0 / right_dist_sq).min(1.0);
-        self.input
-            .set_volume(0, left_diff_modifier * left_dist_modifier);
-        self.input
-            .set_volume(1, right_diff_modifier * right_dist_modifier);
+        if !left_diff_modifier.is_nan() {
+            self.input
+                .set_volume(0, left_diff_modifier * left_dist_modifier);
+        } else {
+            self.input.set_volume(0, left_dist_modifier);
+        }
+        if !right_diff_modifier.is_nan() {
+            self.input
+                .set_volume(1, right_diff_modifier * right_dist_modifier);
+        } else {
+            self.input.set_volume(1, right_dist_modifier);
+        }
     }
 }
 

--- a/src/source/spatial.rs
+++ b/src/source/spatial.rs
@@ -56,22 +56,15 @@ where
         let max_diff = dist_sq(left_ear, right_ear).sqrt();
         let left_dist = left_dist_sq.sqrt();
         let right_dist = right_dist_sq.sqrt();
-        let left_diff_modifier = ((left_dist - right_dist) / max_diff + 1.0) / 4.0 + 0.5;
-        let right_diff_modifier = ((right_dist - left_dist) / max_diff + 1.0) / 4.0 + 0.5;
+        let left_diff_modifier = (((left_dist - right_dist) / max_diff + 1.0) / 4.0 + 0.5).min(1.0);
+        let right_diff_modifier =
+            (((right_dist - left_dist) / max_diff + 1.0) / 4.0 + 0.5).min(1.0);
         let left_dist_modifier = (1.0 / left_dist_sq).min(1.0);
         let right_dist_modifier = (1.0 / right_dist_sq).min(1.0);
-        if !left_diff_modifier.is_nan() {
-            self.input
-                .set_volume(0, left_diff_modifier * left_dist_modifier);
-        } else {
-            self.input.set_volume(0, left_dist_modifier);
-        }
-        if !right_diff_modifier.is_nan() {
-            self.input
-                .set_volume(1, right_diff_modifier * right_dist_modifier);
-        } else {
-            self.input.set_volume(1, right_dist_modifier);
-        }
+        self.input
+            .set_volume(0, left_diff_modifier * left_dist_modifier);
+        self.input
+            .set_volume(1, right_diff_modifier * right_dist_modifier);
     }
 }
 

--- a/src/source/spatial.rs
+++ b/src/source/spatial.rs
@@ -51,6 +51,7 @@ where
         left_ear: [f32; 3],
         right_ear: [f32; 3],
     ) {
+        debug_assert!(left_ear != right_ear);
         let left_dist_sq = dist_sq(left_ear, emitter_pos);
         let right_dist_sq = dist_sq(right_ear, emitter_pos);
         let max_diff = dist_sq(left_ear, right_ear).sqrt();


### PR DESCRIPTION
fixes #284 

When the two ears have the same position, their distance would be 0.0 which led to NaN for the modifiers. I ignored the value when it's a NaN