### PR TITLE
Use pinboard crate to avoid blocking Sinks during playback

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ hound = { version = "3.3.1", optional = true }
 lewton = { version = "0.10", optional = true }
 minimp3 = { version = "0.5.0", optional = true }
 symphonia = {version = "0.5", optional = true }
+pinboard = "2.1.0"
 
 [features]
 default = ["flac", "vorbis", "wav", "mp3"]


### PR DESCRIPTION
Calls to `Sink` and `SpatialSink`'s set methods risk causing delays to the playback thread. This pull requests attempts to fix that by replacing the mutex with a lock-free `Pinboard` from the [pinboard](https://lib.rs/pinboard) crate.