### PR TITLE
always seek to start in mp3::is_mp3()

### DIFF
--- a/src/decoder/mp3.rs
+++ b/src/decoder/mp3.rs
@@ -91,10 +91,8 @@ where
 {
     let stream_pos = data.seek(SeekFrom::Current(0)).unwrap();
     let mut decoder = Decoder::new(data.by_ref());
-    if decoder.next_frame().is_err() {
-        data.seek(SeekFrom::Start(stream_pos)).unwrap();
-        return false;
-    }
+    let ok = decoder.next_frame().is_ok();
+    data.seek(SeekFrom::Start(stream_pos)).unwrap();
 
-    true
+    ok
 }


### PR DESCRIPTION
Not rewinding in the OK case skips a frame and crashes later in `Mp3Decoder::new()` when there is exactly one frame in total.
I've checked the other decoders, they already do this (albeit with slightly more code 😀). 