### PR TITLE
Release version 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Version 0.15.1 (2022-09-13)
+# Version 0.16.0 (2022-09-14)
 
 - Update `cpal` to [0.14](https://github.com/RustAudio/cpal/blob/master/CHANGELOG.md#version-0140-2022-08-22).
 - Update `symphonia` to [0.5](https://github.com/pdeljanov/Symphonia/releases/tag/v0.5.1).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 0.15.1 (2022-09-13)
+
+- Update `cpal` to [0.14](https://github.com/RustAudio/cpal/blob/master/CHANGELOG.md#version-0140-2022-08-22).
+- Update `symphonia` to [0.5](https://github.com/pdeljanov/Symphonia/releases/tag/v0.5.1).
+
 # Version 0.15.0 (2022-01-23)
 
 - Remove requirement that the argument `Decoder::new` and `LoopedDecoder::new` implement `Send`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rodio"
-version = "0.15.1"
+version = "0.16.0"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = "Audio playback library"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rodio"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = "Audio playback library"


### PR DESCRIPTION
Bumps the version to 0.16.0 to trigger CI publishing.

Releases `cpal` and `symphonia` updates.

P.S: Feel free to mention other changes that should be put inside `CHANGELOG.md`.