### PR TITLE
Implement clear() and skip_one() functionality (continuation of #287)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 target
 Cargo.lock
-.idea

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -87,16 +87,15 @@ where
             .store(keep_alive_if_empty, Ordering::Release);
     }
 
-    pub fn clear(&self) {
+    /// Removes all the sounds from the queue. Returns the number of sounds cleared.
+    pub fn clear(&self) -> usize {
         let mut sounds = self.next_sounds.lock().unwrap();
+        let len = sounds.len();
         sounds.clear();
+        len
     }
 
-    pub fn len(&self) -> usize {
-        self.next_sounds.lock().unwrap().len()
-    }
 }
-
 /// The output of the queue. Implements `Source`.
 pub struct SourcesQueueOutput<S> {
     // The current iterator that produces samples.

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -94,7 +94,6 @@ where
         sounds.clear();
         len
     }
-
 }
 /// The output of the queue. Implements `Source`.
 pub struct SourcesQueueOutput<S> {

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -86,6 +86,15 @@ where
         self.keep_alive_if_empty
             .store(keep_alive_if_empty, Ordering::Release);
     }
+
+    pub fn clear(&self) {
+        let mut sounds = self.next_sounds.lock().unwrap();
+        sounds.clear();
+    }
+
+    pub fn len(&self) -> usize {
+        self.next_sounds.lock().unwrap().len()
+    }
 }
 
 /// The output of the queue. Implements `Source`.

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -26,6 +26,7 @@ struct Controls {
     stopped: AtomicBool,
     speed: Mutex<f32>,
     do_skip: AtomicBool,
+    to_clear: Mutex<u32>,
 }
 
 impl Sink {
@@ -51,6 +52,7 @@ impl Sink {
                 stopped: AtomicBool::new(false),
                 speed: Mutex::new(1.0),
                 do_skip: AtomicBool::new(false),
+                to_clear: Mutex::new(0),
             }),
             sound_count: Arc::new(AtomicUsize::new(0)),
             detached: false,
@@ -75,20 +77,26 @@ impl Sink {
             .skippable()
             .stoppable()
             .periodic_access(Duration::from_millis(5), move |src| {
-                
                 if controls.stopped.load(Ordering::SeqCst) {
                     src.stop();
                 }
                 if controls.do_skip.load(Ordering::SeqCst) {
-                    src.inner_mut().skip();
-                    controls.do_skip.store(false, Ordering::SeqCst);
+                    let _ = src.inner_mut().skip();
+                    let mut to_clear = controls.to_clear.lock().unwrap();
+                    if *to_clear == 1 {
+                        controls.do_skip.store(false, Ordering::SeqCst);
+                        *to_clear = 0;
+                    } else if *to_clear > 0 {
+                        *to_clear -= 1;
+                    }
                 }
                 let amp = src.inner_mut().inner_mut();
                 amp.set_factor(*controls.volume.lock().unwrap());
                 amp.inner_mut()
-                   .set_paused(controls.pause.load(Ordering::SeqCst));
-                amp.inner_mut().inner_mut().set_factor(*controls.speed.lock().unwrap());
-                
+                    .set_paused(controls.pause.load(Ordering::SeqCst));
+                amp.inner_mut()
+                    .inner_mut()
+                    .set_factor(*controls.speed.lock().unwrap());
             })
             .convert_samples();
         self.sound_count.fetch_add(1, Ordering::Relaxed);
@@ -157,19 +165,19 @@ impl Sink {
         self.controls.pause.load(Ordering::SeqCst)
     }
 
-
     /// Removes all currently loaded `Source`s from the `Sink`, and pauses it.
     ///
     /// See `pause()` for information about pausing a `Sink`.
     pub fn clear(&self) {
-        let len = self.queue_tx.clear();
-        self.sound_count.fetch_sub(len, Ordering::SeqCst);
+        let len = self.sound_count.load(Ordering::SeqCst) as u32;
+        *self.controls.to_clear.lock().unwrap() = len;
+        self.skip_one();
         self.pause();
     }
-    
+
     /// Skips to the next `Source` in the `Sink`
     ///
-    /// If there are more `Source`s appended to the `Sink` at the time, 
+    /// If there are more `Source`s appended to the `Sink` at the time,
     /// it will play the next one. Otherwise, the `Sink` will finish as if
     /// it had finished playing a `Source` all the way through.
     pub fn skip_one(&self) {

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -162,8 +162,8 @@ impl Sink {
     ///
     /// See `pause()` for information about pausing a `Sink`.
     pub fn clear(&self) {
-        self.sound_count.fetch_sub(self.queue_tx.len(), Ordering::SeqCst);
-        self.queue_tx.clear();
+        let len = self.queue_tx.clear();
+        self.sound_count.fetch_sub(len, Ordering::SeqCst);
         self.pause();
     }
     

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -25,6 +25,7 @@ struct Controls {
     volume: Mutex<f32>,
     stopped: AtomicBool,
     speed: Mutex<f32>,
+    do_skip: AtomicBool,
 }
 
 impl Sink {
@@ -49,6 +50,7 @@ impl Sink {
                 volume: Mutex::new(1.0),
                 stopped: AtomicBool::new(false),
                 speed: Mutex::new(1.0),
+                do_skip: AtomicBool::new(false),
             }),
             sound_count: Arc::new(AtomicUsize::new(0)),
             detached: false,
@@ -70,20 +72,23 @@ impl Sink {
             .speed(1.0)
             .pausable(false)
             .amplify(1.0)
+            .skippable()
             .stoppable()
             .periodic_access(Duration::from_millis(5), move |src| {
+                
                 if controls.stopped.load(Ordering::SeqCst) {
                     src.stop();
-                } else {
-                    src.inner_mut().set_factor(*controls.volume.lock().unwrap());
-                    src.inner_mut()
-                        .inner_mut()
-                        .set_paused(controls.pause.load(Ordering::SeqCst));
-                    src.inner_mut()
-                        .inner_mut()
-                        .inner_mut()
-                        .set_factor(*controls.speed.lock().unwrap());
                 }
+                if controls.do_skip.load(Ordering::SeqCst) {
+                    src.inner_mut().skip();
+                    controls.do_skip.store(false, Ordering::SeqCst);
+                }
+                let amp = src.inner_mut().inner_mut();
+                amp.set_factor(*controls.volume.lock().unwrap());
+                amp.inner_mut()
+                   .set_paused(controls.pause.load(Ordering::SeqCst));
+                amp.inner_mut().set_factor(*controls.speed.lock().unwrap());
+                
             })
             .convert_samples();
         self.sound_count.fetch_add(1, Ordering::Relaxed);
@@ -150,6 +155,25 @@ impl Sink {
     /// sink is paused.
     pub fn is_paused(&self) -> bool {
         self.controls.pause.load(Ordering::SeqCst)
+    }
+
+
+    /// Removes all currently loaded `Source`s from the `Sink`, and pauses it.
+    ///
+    /// See `pause()` for information about pausing a `Sink`.
+    pub fn clear(&self) {
+        self.sound_count.fetch_sub(self.queue_tx.len(), Ordering::SeqCst);
+        self.queue_tx.clear();
+        self.pause();
+    }
+    
+    /// Skips to the next `Source` in the `Sink`
+    ///
+    /// If there are more `Source`s appended to the `Sink` at the time, 
+    /// it will play the next one. Otherwise, the `Sink` will finish as if
+    /// it had finished playing a `Source` all the way through.
+    pub fn skip_one(&self) {
+        self.controls.do_skip.store(true, Ordering::SeqCst);
     }
 
     /// Stops the sink by emptying the queue.

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -87,7 +87,7 @@ impl Sink {
                 amp.set_factor(*controls.volume.lock().unwrap());
                 amp.inner_mut()
                    .set_paused(controls.pause.load(Ordering::SeqCst));
-                amp.inner_mut().set_factor(*controls.speed.lock().unwrap());
+                amp.inner_mut().inner_mut().set_factor(*controls.speed.lock().unwrap());
                 
             })
             .convert_samples();

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -25,6 +25,7 @@ pub use self::skip::SkipDuration;
 pub use self::spatial::Spatial;
 pub use self::speed::Speed;
 pub use self::stoppable::Stoppable;
+pub use self::skippable::Skippable;
 pub use self::take::TakeDuration;
 pub use self::uniform::UniformSourceIterator;
 pub use self::zero::Zero;
@@ -49,6 +50,7 @@ mod sine;
 mod skip;
 mod spatial;
 mod speed;
+mod skippable;
 mod stoppable;
 mod take;
 mod uniform;
@@ -315,6 +317,13 @@ where
         Self: Sized,
     {
         stoppable::stoppable(self)
+    }
+
+    fn skippable(self) -> Skippable<Self>
+    where
+        Self: Sized
+    {
+        skippable::skippable(self)
     }
 
     /// Applies a low-pass filter to the source.

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -22,10 +22,10 @@ pub use self::repeat::Repeat;
 pub use self::samples_converter::SamplesConverter;
 pub use self::sine::SineWave;
 pub use self::skip::SkipDuration;
+pub use self::skippable::Skippable;
 pub use self::spatial::Spatial;
 pub use self::speed::Speed;
 pub use self::stoppable::Stoppable;
-pub use self::skippable::Skippable;
 pub use self::take::TakeDuration;
 pub use self::uniform::UniformSourceIterator;
 pub use self::zero::Zero;
@@ -48,9 +48,9 @@ mod repeat;
 mod samples_converter;
 mod sine;
 mod skip;
+mod skippable;
 mod spatial;
 mod speed;
-mod skippable;
 mod stoppable;
 mod take;
 mod uniform;
@@ -321,7 +321,7 @@ where
 
     fn skippable(self) -> Skippable<Self>
     where
-        Self: Sized
+        Self: Sized,
     {
         skippable::skippable(self)
     }

--- a/src/source/skippable.rs
+++ b/src/source/skippable.rs
@@ -1,0 +1,92 @@
+use std::time::Duration;
+
+use Sample;
+use Source;
+
+/// Internal function that builds a `Skippable` object.
+pub fn skippable<I>(source: I) -> Skippable<I> {
+    Skippable {
+        input: source,
+        do_skip: false,
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Skippable<I> {
+    input: I,
+    do_skip: bool,
+}
+
+impl<I> Skippable<I> {
+    /// Skips the current source
+    #[inline]
+    pub fn skip(&mut self) {
+        self.do_skip = true;
+    }
+
+    /// Returns a reference to the inner source.
+    #[inline]
+    pub fn inner(&self) -> &I {
+        &self.input
+    }
+
+    /// Returns a mutable reference to the inner source.
+    #[inline]
+    pub fn inner_mut(&mut self) -> &mut I {
+        &mut self.input
+    }
+
+    /// Returns the inner source.
+    #[inline]
+    pub fn into_inner(self) -> I {
+        self.input
+    }
+}
+
+impl<I> Iterator for Skippable<I>
+where
+    I: Source,
+    I::Item: Sample,
+{
+    type Item = I::Item;
+
+    #[inline]
+    fn next(&mut self) -> Option<I::Item> {
+        if self.do_skip {
+            None
+        } else {
+            self.input.next()
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.input.size_hint()
+    }
+}
+
+impl<I> Source for Skippable<I>
+where
+    I: Source,
+    I::Item: Sample,
+{
+    #[inline]
+    fn current_frame_len(&self) -> Option<usize> {
+        self.input.current_frame_len()
+    }
+
+    #[inline]
+    fn channels(&self) -> u16 {
+        self.input.channels()
+    }
+
+    #[inline]
+    fn sample_rate(&self) -> u32 {
+        self.input.sample_rate()
+    }
+
+    #[inline]
+    fn total_duration(&self) -> Option<Duration> {
+        self.input.total_duration()
+    }
+}

--- a/src/source/skippable.rs
+++ b/src/source/skippable.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
-use Sample;
-use Source;
+use crate::Sample;
+use crate::Source;
 
 /// Internal function that builds a `Skippable` object.
 pub fn skippable<I>(source: I) -> Skippable<I> {


### PR DESCRIPTION
This PR is my continuation of #287 where I've firstly rebased against the lastest master (as of writing) as well as reworked the clear() function to act more as described [here](https://github.com/RustAudio/rodio/issues/171#issuecomment-628804096).

The code passes all tests, but I have not written any new tests. As for the implementation, I think it looks fine. There's no major deviation from the existing architecture, but all feedback is of course welcome.