### PR TITLE
Create an OutputStream from a Device and SupportedStreamConfig

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -8,7 +8,7 @@ use crate::dynamic_mixer::{self, DynamicMixerController};
 use crate::sink::Sink;
 use crate::source::Source;
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use cpal::Sample;
+use cpal::{Sample, SupportedStreamConfig};
 
 /// `cpal::Stream` container. Also see the more useful `OutputStreamHandle`.
 ///
@@ -30,6 +30,20 @@ impl OutputStream {
         device: &cpal::Device,
     ) -> Result<(Self, OutputStreamHandle), StreamError> {
         let (mixer, _stream) = device.try_new_output_stream()?;
+        _stream.play()?;
+        let out = Self { mixer, _stream };
+        let handle = OutputStreamHandle {
+            mixer: Arc::downgrade(&out.mixer),
+        };
+        Ok((out, handle))
+    }
+
+    /// Returns a new stream & handle using the given device and stream config.
+    pub fn try_from_device_config(
+        device: &cpal::Device,
+        config: SupportedStreamConfig,
+    ) -> Result<(Self, OutputStreamHandle), StreamError> {
+        let (mixer, _stream) = device.try_new_output_stream_config(config)?;
         _stream.play()?;
         let out = Self { mixer, _stream };
         let handle = OutputStreamHandle {
@@ -185,6 +199,11 @@ pub(crate) trait CpalDeviceExt {
     fn try_new_output_stream(
         &self,
     ) -> Result<(Arc<DynamicMixerController<f32>>, cpal::Stream), StreamError>;
+
+    fn try_new_output_stream_config(
+        &self,
+        config: cpal::SupportedStreamConfig,
+    ) -> Result<(Arc<DynamicMixerController<f32>>, cpal::Stream), StreamError>;
 }
 
 impl CpalDeviceExt for cpal::Device {
@@ -240,11 +259,23 @@ impl CpalDeviceExt for cpal::Device {
             .or_else(|err| {
                 // look through all supported formats to see if another works
                 supported_output_formats(self)?
-                .filter_map(|format| self.new_output_stream_with_format(format).ok())
-                .next()
+                .find_map(|format| self.new_output_stream_with_format(format).ok())
                 // return original error if nothing works
                 .ok_or(StreamError::BuildStreamError(err))
             })
+    }
+
+    fn try_new_output_stream_config(
+        &self,
+        config: SupportedStreamConfig,
+    ) -> Result<(Arc<DynamicMixerController<f32>>, cpal::Stream), StreamError> {
+        self.new_output_stream_with_format(config).or_else(|err| {
+            // look through all supported formats to see if another works
+            supported_output_formats(self)?
+                .find_map(|format| self.new_output_stream_with_format(format).ok())
+                // return original error if nothing works
+                .ok_or(StreamError::BuildStreamError(err))
+        })
     }
 }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -25,20 +25,19 @@ pub struct OutputStreamHandle {
 }
 
 impl OutputStream {
-    /// Returns a new stream & handle using the given output device.
+    /// Returns a new stream & handle using the given output device and the default output
+    /// configuration.
     pub fn try_from_device(
         device: &cpal::Device,
     ) -> Result<(Self, OutputStreamHandle), StreamError> {
-        let (mixer, _stream) = device.try_new_output_stream()?;
-        _stream.play()?;
-        let out = Self { mixer, _stream };
-        let handle = OutputStreamHandle {
-            mixer: Arc::downgrade(&out.mixer),
-        };
-        Ok((out, handle))
+        let default_config = device.default_output_config()?;
+        OutputStream::try_from_device_config(device, default_config)
     }
 
     /// Returns a new stream & handle using the given device and stream config.
+    ///
+    /// If the supplied `SupportedStreamConfig` is invalid for the device this function will
+    /// fail to create an output stream and instead return a `StreamError`
     pub fn try_from_device_config(
         device: &cpal::Device,
         config: SupportedStreamConfig,
@@ -196,10 +195,6 @@ pub(crate) trait CpalDeviceExt {
         format: cpal::SupportedStreamConfig,
     ) -> Result<(Arc<DynamicMixerController<f32>>, cpal::Stream), cpal::BuildStreamError>;
 
-    fn try_new_output_stream(
-        &self,
-    ) -> Result<(Arc<DynamicMixerController<f32>>, cpal::Stream), StreamError>;
-
     fn try_new_output_stream_config(
         &self,
         config: cpal::SupportedStreamConfig,
@@ -247,22 +242,6 @@ impl CpalDeviceExt for cpal::Device {
             ),
         }
         .map(|stream| (mixer_tx, stream))
-    }
-
-    fn try_new_output_stream(
-        &self,
-    ) -> Result<(Arc<DynamicMixerController<f32>>, cpal::Stream), StreamError> {
-        // Determine the format to use for the new stream.
-        let default_format = self.default_output_config()?;
-
-        self.new_output_stream_with_format(default_format)
-            .or_else(|err| {
-                // look through all supported formats to see if another works
-                supported_output_formats(self)?
-                .find_map(|format| self.new_output_stream_with_format(format).ok())
-                // return original error if nothing works
-                .ok_or(StreamError::BuildStreamError(err))
-            })
     }
 
     fn try_new_output_stream_config(


### PR DESCRIPTION
This change adds support for getting an `OutputStream` and `OutputStreamHandle` from a specific device with a specific configuration instead of relying on getting the default configuration.

The new function `try_from_device_config` acts the same as `try_from_device` but adds an extra `spal::SupportedStreamConfig` argument. The caller is then responsible for getting a valid configuration from cpal to pass along.