### PR TITLE
Fix: Audio playback not working after stop on sink

### DIFF
--- a/src/sink.rs
+++ b/src/sink.rs
@@ -132,6 +132,7 @@ impl Sink {
     /// No effect if not paused.
     #[inline]
     pub fn play(&self) {
+        self.controls.stopped.store(false, Ordering::SeqCst);
         self.controls.pause.store(false, Ordering::SeqCst);
     }
 


### PR DESCRIPTION
Hi,

I'm working on a project of my own in which I'm using rodio for audio playback, however I came across the issue that I am unable to play audio after I've called the `.stop` method on `rodio::sink::Sink`, in my project I've fixed this by changing the `.play` method  on Sink to this:
```rust
    #[inline]
    pub fn play(&self) {
        self.controls.stopped.store(false, Ordering::SeqCst);
        self.controls.pause.store(false, Ordering::SeqCst);
    }
```

At first I thought the documentation for `.stop` was wrong, but it turns out it does actually clear the queue but it completely prevents your Sink from doing any more audio playback (at least I wasn't able to figure out how to make it play anything after the fact).

This fix works for me, and I'd like some feedback on whether this is a feasible solution, warning I'm pretty new to Rust.

P.S. the tests ran fine