### PR TITLE
Added a storing file example.

### DIFF
--- a/examples/storing_file.rs
+++ b/examples/storing_file.rs
@@ -1,0 +1,31 @@
+use rodio::source::{Buffered, SkipDuration, TakeDuration};
+use rodio::{source::Source, Decoder, Sink};
+use std::fs::File;
+use std::io::BufReader;
+use std::time::Duration;
+
+fn main() {
+    let (_stream, stream_handle) = rodio::OutputStream::try_default().unwrap();
+
+    // Loading an audio file and storing it to use again
+    let file = BufReader::new(File::open("assets/beep.wav").unwrap());
+    let buffered_beep = Decoder::new(file).unwrap().buffered();
+
+    // Modifying loaded audio file
+    let buffered_modified_beep: Buffered<
+        TakeDuration<SkipDuration<Buffered<Decoder<BufReader<File>>>>>,
+    >;
+    buffered_modified_beep = buffered_beep
+        .clone()
+        .skip_duration(Duration::from_millis(10))
+        .take_duration(Duration::from_millis(1000))
+        .buffered();
+
+    let sink = Sink::try_new(&stream_handle).unwrap();
+
+    sink.append(buffered_modified_beep.clone());
+    sink.sleep_until_end();
+
+    sink.append(buffered_modified_beep.clone());
+    sink.sleep_until_end();
+}


### PR DESCRIPTION
This is an example of loading files and playing them several times after reading issue #423. It would not make a lot of sense for larger audio as it is not streaming.

One downside of that is that, when adding operation to the saved file, the type becomes painfully long in rust as per the example : `Buffered<TakeDuration<SkipDuration<Buffered<Decoder<BufReader<File>>>>>>`.

I'm not really sure how to address that for now.