### PR TITLE
Enable gapless playback

### DIFF
--- a/src/decoder/symphonia.rs
+++ b/src/decoder/symphonia.rs
@@ -60,7 +60,10 @@ impl SymphoniaDecoder {
         if let Some(ext) = extension {
             hint.with_extension(ext);
         }
-        let format_opts: FormatOptions = Default::default();
+        let format_opts: FormatOptions = FormatOptions {
+            enable_gapless: true,
+            ..Default::default()
+        };
         let metadata_opts: MetadataOptions = Default::default();
         let mut probed = get_probe().format(&hint, mss, &format_opts, &metadata_opts)?;
 


### PR DESCRIPTION
Only when using symphonia

I have no idea why it is not the default

minimp3 still has the issue, it seems like there is a way fix minimp3 as well using minimp3-ex or something: https://github.com/lieff/minimp3/issues/63