### PR TITLE
Fix Sink playback after stop

### DIFF
--- a/src/sink.rs
+++ b/src/sink.rs
@@ -206,9 +206,9 @@ impl Drop for Sink {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::Ordering;
     use crate::buffer::SamplesBuffer;
     use crate::{Sink, Source};
+    use std::sync::atomic::Ordering;
 
     #[test]
     fn test_pause_and_stop() {
@@ -248,19 +248,19 @@ mod tests {
         let v = vec![10i16, -10, 20, -20, 30, -30];
 
         sink.append(SamplesBuffer::new(1, 1, v.clone()));
-        let mut src = SamplesBuffer::new(1, 1, v.clone()).convert_samples(); 
-        
+        let mut src = SamplesBuffer::new(1, 1, v.clone()).convert_samples();
+
         assert_eq!(queue_rx.next(), src.next());
         assert_eq!(queue_rx.next(), src.next());
-        
+
         sink.stop();
 
         assert!(sink.controls.stopped.load(Ordering::SeqCst));
         assert_eq!(queue_rx.next(), Some(0.0));
-        
-        src = SamplesBuffer::new(1, 1, v.clone()).convert_samples(); 
+
+        src = SamplesBuffer::new(1, 1, v.clone()).convert_samples();
         sink.append(SamplesBuffer::new(1, 1, v));
-        
+
         assert!(!sink.controls.stopped.load(Ordering::SeqCst));
         // Flush silence
         let mut queue_rx = queue_rx.skip_while(|v| *v == 0.0);

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -66,7 +66,7 @@ impl Sink {
     {
         // Wait for queue to flush then resume stopped playback
         if self.controls.stopped.load(Ordering::SeqCst) {
-            while self.sound_count.load(Ordering::SeqCst) > 0 {
+            if self.sound_count.load(Ordering::SeqCst) > 0 {
                 self.sleep_until_end();
             }
             self.controls.stopped.store(false, Ordering::SeqCst);
@@ -206,6 +206,7 @@ impl Drop for Sink {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::Ordering;
     use crate::buffer::SamplesBuffer;
     use crate::{Sink, Source};
 
@@ -238,6 +239,34 @@ mod tests {
         assert_eq!(queue_rx.next(), Some(0.0));
 
         assert_eq!(sink.empty(), true);
+    }
+
+    #[test]
+    fn test_stop_and_start() {
+        let (sink, mut queue_rx) = Sink::new_idle();
+
+        let v = vec![10i16, -10, 20, -20, 30, -30];
+
+        sink.append(SamplesBuffer::new(1, 1, v.clone()));
+        let mut src = SamplesBuffer::new(1, 1, v.clone()).convert_samples(); 
+        
+        assert_eq!(queue_rx.next(), src.next());
+        assert_eq!(queue_rx.next(), src.next());
+        
+        sink.stop();
+
+        assert!(sink.controls.stopped.load(Ordering::SeqCst));
+        assert_eq!(queue_rx.next(), Some(0.0));
+        
+        src = SamplesBuffer::new(1, 1, v.clone()).convert_samples(); 
+        sink.append(SamplesBuffer::new(1, 1, v));
+        
+        assert!(!sink.controls.stopped.load(Ordering::SeqCst));
+        // Flush silence
+        let mut queue_rx = queue_rx.skip_while(|v| *v == 0.0);
+
+        assert_eq!(queue_rx.next(), src.next());
+        assert_eq!(queue_rx.next(), src.next());
     }
 
     #[test]

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -64,6 +64,14 @@ impl Sink {
         S::Item: Sample,
         S::Item: Send,
     {
+        // Wait for queue to flush then resume stopped playback
+        if self.controls.stopped.load(Ordering::SeqCst) {
+            while self.sound_count.load(Ordering::SeqCst) > 0 {
+                self.sleep_until_end();
+            }
+            self.controls.stopped.store(false, Ordering::SeqCst);
+        }
+
         let controls = self.controls.clone();
 
         let source = source


### PR DESCRIPTION
Addressing issues #462 and #315 and #171

Given how the sink's queue is drained on stop I made some modifications in `sink.append()`. I added a check to ensure the sink was flushed completely (not sure this is necessary? I think it is, to avoid race conditions) and to restart the sink on append (when stopped.)

I added a test demonstrating correctness, as well as performing some trials on my own.

However, in #171 there is mention that the stopped sink being dead is intended behavior. It would appear the general sentiment is that this should not be the case, and as a new user of rodio I can say this took me by surprise as well. 
In the case that it should kill a sink, I think it prudent to amend the documentation to reflect this, instead.

I think this provides a more correct solution than #449 and does not require any workaround for use.
