### PR TITLE
Update to cpal 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["assets/**", "tests/**"]
 edition = "2018"
 
 [dependencies]
-cpal = "0.14"
+cpal = "0.15"
 claxon = { version = "0.4.2", optional = true }
 hound = { version = "3.3.1", optional = true }
 lewton = { version = "0.10", optional = true }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -219,6 +219,7 @@ impl CpalDeviceExt for cpal::Device {
                         .for_each(|d| *d = mixer_rx.next().unwrap_or(0f32))
                 },
                 error_callback,
+                None
             ),
             cpal::SampleFormat::I16 => self.build_output_stream::<i16, _, _>(
                 &format.config(),
@@ -227,6 +228,7 @@ impl CpalDeviceExt for cpal::Device {
                         .for_each(|d| *d = mixer_rx.next().map(|s| s.to_i16()).unwrap_or(0i16))
                 },
                 error_callback,
+                None
             ),
             cpal::SampleFormat::U16 => self.build_output_stream::<u16, _, _>(
                 &format.config(),
@@ -239,6 +241,7 @@ impl CpalDeviceExt for cpal::Device {
                     })
                 },
                 error_callback,
+                None
             ),
         }
         .map(|stream| (mixer_tx, stream))


### PR DESCRIPTION
This just bumps the version number and doesn't yet address any breaking changes that may have occurred.