### PR TITLE
update cpal to 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["assets/**", "tests/**"]
 edition = "2018"
 
 [dependencies]
-cpal = "0.14"
+cpal = "0.15"
 claxon = { version = "0.4.2", optional = true }
 hound = { version = "3.3.1", optional = true }
 lewton = { version = "0.10", optional = true }

--- a/src/conversions/sample.rs
+++ b/src/conversions/sample.rs
@@ -1,4 +1,4 @@
-use cpal::Sample as CpalSample;
+use cpal::{FromSample, Sample as CpalSample};
 use std::marker::PhantomData;
 
 /// Converts the samples data type to `O`.
@@ -29,13 +29,13 @@ impl<I, O> Iterator for DataConverter<I, O>
 where
     I: Iterator,
     I::Item: Sample,
-    O: Sample,
+    O: FromSample<I::Item> + Sample,
 {
     type Item = O;
 
     #[inline]
     fn next(&mut self) -> Option<O> {
-        self.input.next().map(|s| CpalSample::from(&s))
+        self.input.next().map(|s| CpalSample::from_sample(s))
     }
 
     #[inline]
@@ -48,7 +48,7 @@ impl<I, O> ExactSizeIterator for DataConverter<I, O>
 where
     I: ExactSizeIterator,
     I::Item: Sample,
-    O: Sample,
+    O: FromSample<I::Item> + Sample,
 {
 }
 
@@ -93,7 +93,7 @@ impl Sample for u16 {
 
     #[inline]
     fn amplify(self, value: f32) -> u16 {
-        self.to_i16().amplify(value).to_u16()
+        ((self as f32) * value) as u16
     }
 
     #[inline]

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 
 use crate::stream::{OutputStreamHandle, PlayError};
 use crate::{queue, source::Done, Sample, Source};
+use cpal::FromSample;
 
 /// Handle to an device that outputs sounds.
 ///
@@ -61,8 +62,8 @@ impl Sink {
     pub fn append<S>(&self, source: S)
     where
         S: Source + Send + 'static,
-        S::Item: Sample,
-        S::Item: Send,
+        f32: FromSample<S::Item>,
+        S::Item: Sample + Send,
     {
         let controls = self.controls.clone();
 

--- a/src/source/crossfade.rs
+++ b/src/source/crossfade.rs
@@ -1,5 +1,7 @@
 use std::time::Duration;
 
+use cpal::FromSample;
+
 use crate::source::{FadeIn, Mix, TakeDuration};
 use crate::{Sample, Source};
 
@@ -14,7 +16,7 @@ pub fn crossfade<I1, I2>(
 where
     I1: Source,
     I2: Source,
-    I1::Item: Sample,
+    I1::Item: FromSample<I2::Item> + Sample,
     I2::Item: Sample,
 {
     let mut input_fadeout = input_fadeout.take_duration(duration);

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -2,6 +2,8 @@
 
 use std::time::Duration;
 
+use cpal::FromSample;
+
 use crate::Sample;
 
 pub use self::amplify::Amplify;
@@ -158,6 +160,7 @@ where
     fn mix<S>(self, other: S) -> Mix<Self, S>
     where
         Self: Sized,
+        Self::Item: FromSample<S::Item>,
         S: Source,
         S::Item: Sample,
     {
@@ -224,6 +227,7 @@ where
     fn take_crossfade_with<S: Source>(self, other: S, duration: Duration) -> Crossfade<Self, S>
     where
         Self: Sized,
+        Self::Item: FromSample<S::Item>,
         <S as Iterator>::Item: Sample,
     {
         crossfade::crossfade(self, other, duration)

--- a/src/source/samples_converter.rs
+++ b/src/source/samples_converter.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 use std::time::Duration;
 
 use crate::{Sample, Source};
-use cpal::Sample as CpalSample;
+use cpal::{FromSample, Sample as CpalSample};
 
 /// An iterator that reads from a `Source` and converts the samples to a specific rate and
 /// channels count.
@@ -47,13 +47,13 @@ impl<I, D> Iterator for SamplesConverter<I, D>
 where
     I: Source,
     I::Item: Sample,
-    D: Sample,
+    D: FromSample<I::Item> + Sample,
 {
     type Item = D;
 
     #[inline]
     fn next(&mut self) -> Option<D> {
-        self.inner.next().map(|s| CpalSample::from(&s))
+        self.inner.next().map(|s| CpalSample::from_sample(s))
     }
 
     #[inline]
@@ -66,7 +66,7 @@ impl<I, D> ExactSizeIterator for SamplesConverter<I, D>
 where
     I: Source + ExactSizeIterator,
     I::Item: Sample,
-    D: Sample,
+    D: FromSample<I::Item> + Sample,
 {
 }
 
@@ -74,7 +74,7 @@ impl<I, D> Source for SamplesConverter<I, D>
 where
     I: Source,
     I::Item: Sample,
-    D: Sample,
+    D: FromSample<I::Item> + Sample,
 {
     #[inline]
     fn current_frame_len(&self) -> Option<usize> {

--- a/src/source/uniform.rs
+++ b/src/source/uniform.rs
@@ -1,6 +1,8 @@
 use std::cmp;
 use std::time::Duration;
 
+use cpal::FromSample;
+
 use crate::conversions::{ChannelCountConverter, DataConverter, SampleRateConverter};
 use crate::{Sample, Source};
 
@@ -77,7 +79,7 @@ impl<I, D> Iterator for UniformSourceIterator<I, D>
 where
     I: Source,
     I::Item: Sample,
-    D: Sample,
+    D: FromSample<I::Item> + Sample,
 {
     type Item = D;
 
@@ -114,7 +116,7 @@ impl<I, D> Source for UniformSourceIterator<I, D>
 where
     I: Iterator + Source,
     I::Item: Sample,
-    D: Sample,
+    D: FromSample<I::Item> + Sample,
 {
     #[inline]
     fn current_frame_len(&self) -> Option<usize> {

--- a/src/spatial_sink.rs
+++ b/src/spatial_sink.rs
@@ -2,6 +2,8 @@ use std::f32;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use cpal::FromSample;
+
 use crate::source::Spatial;
 use crate::stream::{OutputStreamHandle, PlayError};
 use crate::{Sample, Sink, Source};
@@ -55,6 +57,7 @@ impl SpatialSink {
     pub fn append<S>(&self, source: S)
     where
         S: Source + Send + 'static,
+        f32: FromSample<S::Item>,
         S::Item: Sample + Send,
     {
         let positions = self.positions.clone();

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -219,14 +219,65 @@ impl CpalDeviceExt for cpal::Device {
                         .for_each(|d| *d = mixer_rx.next().unwrap_or(0f32))
                 },
                 error_callback,
+                None,
+            ),
+            cpal::SampleFormat::F64 => self.build_output_stream::<f64, _, _>(
+                &format.config(),
+                move |data, _| {
+                    data.iter_mut()
+                        .for_each(|d| *d = mixer_rx.next().map(Sample::from_sample).unwrap_or(0f64))
+                },
+                error_callback,
+                None,
+            ),
+            cpal::SampleFormat::I8 => self.build_output_stream::<i8, _, _>(
+                &format.config(),
+                move |data, _| {
+                    data.iter_mut()
+                        .for_each(|d| *d = mixer_rx.next().map(Sample::from_sample).unwrap_or(0i8))
+                },
+                error_callback,
+                None,
             ),
             cpal::SampleFormat::I16 => self.build_output_stream::<i16, _, _>(
                 &format.config(),
                 move |data, _| {
                     data.iter_mut()
-                        .for_each(|d| *d = mixer_rx.next().map(|s| s.to_i16()).unwrap_or(0i16))
+                        .for_each(|d| *d = mixer_rx.next().map(Sample::from_sample).unwrap_or(0i16))
                 },
                 error_callback,
+                None,
+            ),
+            cpal::SampleFormat::I32 => self.build_output_stream::<i32, _, _>(
+                &format.config(),
+                move |data, _| {
+                    data.iter_mut()
+                        .for_each(|d| *d = mixer_rx.next().map(Sample::from_sample).unwrap_or(0i32))
+                },
+                error_callback,
+                None,
+            ),
+            cpal::SampleFormat::I64 => self.build_output_stream::<i64, _, _>(
+                &format.config(),
+                move |data, _| {
+                    data.iter_mut()
+                        .for_each(|d| *d = mixer_rx.next().map(Sample::from_sample).unwrap_or(0i64))
+                },
+                error_callback,
+                None,
+            ),
+            cpal::SampleFormat::U8 => self.build_output_stream::<u8, _, _>(
+                &format.config(),
+                move |data, _| {
+                    data.iter_mut().for_each(|d| {
+                        *d = mixer_rx
+                            .next()
+                            .map(Sample::from_sample)
+                            .unwrap_or(u8::max_value() / 2)
+                    })
+                },
+                error_callback,
+                None,
             ),
             cpal::SampleFormat::U16 => self.build_output_stream::<u16, _, _>(
                 &format.config(),
@@ -234,12 +285,40 @@ impl CpalDeviceExt for cpal::Device {
                     data.iter_mut().for_each(|d| {
                         *d = mixer_rx
                             .next()
-                            .map(|s| s.to_u16())
+                            .map(Sample::from_sample)
                             .unwrap_or(u16::max_value() / 2)
                     })
                 },
                 error_callback,
+                None,
             ),
+            cpal::SampleFormat::U32 => self.build_output_stream::<u32, _, _>(
+                &format.config(),
+                move |data, _| {
+                    data.iter_mut().for_each(|d| {
+                        *d = mixer_rx
+                            .next()
+                            .map(Sample::from_sample)
+                            .unwrap_or(u32::max_value() / 2)
+                    })
+                },
+                error_callback,
+                None,
+            ),
+            cpal::SampleFormat::U64 => self.build_output_stream::<u64, _, _>(
+                &format.config(),
+                move |data, _| {
+                    data.iter_mut().for_each(|d| {
+                        *d = mixer_rx
+                            .next()
+                            .map(Sample::from_sample)
+                            .unwrap_or(u64::max_value() / 2)
+                    })
+                },
+                error_callback,
+                None,
+            ),
+            _ => return Err(cpal::BuildStreamError::StreamConfigNotSupported),
         }
         .map(|stream| (mixer_tx, stream))
     }


### PR DESCRIPTION
Bump the version, and use the new `FromSample` trait for all conversions.

All the examples continue to work 🎉 