### PR TITLE
Disable Symphonia default features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# Version 0.17.0 (2022-09-14)
+# Version 0.17.1 (2023-02-25)
+
+- Disable `symphonia`'s default features.
+
+# Version 0.17.0 (2023-02-17)
 
 - Update `cpal` to [0.15](https://github.com/RustAudio/cpal/blob/master/CHANGELOG.md#version-0150-2022-01-29).
 - Default to `symphonia` for mp3 decoding.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ claxon = { version = "0.4.2", optional = true }
 hound = { version = "3.3.1", optional = true }
 lewton = { version = "0.10", optional = true }
 minimp3 = { version = "0.5.0", optional = true }
-symphonia = {version = "0.5.2", optional = true }
+symphonia = { version = "0.5.2", optional = true, default-features = false }
 
 [features]
 default = ["flac", "vorbis", "wav", "mp3"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rodio"
-version = "0.17.0"
+version = "0.17.1"
 license = "MIT OR Apache-2.0"
 description = "Audio playback library"
 keywords = ["audio", "playback", "gamedev"]


### PR DESCRIPTION
Rodio's dependency on Symphonia doesn't disable default features, meaning that enabling any of the Symphonia features in Rodio will also [pull in all of the other royalty-free codecs that Symphonia supports](https://github.com/pdeljanov/Symphonia/blob/master/symphonia/Cargo.toml#L18).

This is made a bit more problematic due to the fact that Symphonia is now the default MP3 backend, so anyone with using Rodio without disabling default features will also get those extra codecs.

You can see this if you run `cargo tree`:

```shell
> cargo tree
rodio v0.17.0 (E:\Code\rodio)
# ...
└── symphonia v0.5.2
    ├── lazy_static v1.4.0
    ├── symphonia-bundle-flac v0.5.2
    │   ├── log v0.4.17
    │   │   └── cfg-if v1.0.0
    │   ├── symphonia-core v0.5.2
    │   │   ├── arrayvec v0.7.2
    │   │   ├── bitflags v1.3.2
    │   │   ├── bytemuck v1.13.0
    │   │   ├── lazy_static v1.4.0
    │   │   └── log v0.4.17 (*)
    │   ├── symphonia-metadata v0.5.2
    │   │   ├── encoding_rs v0.8.32
    │   │   │   └── cfg-if v1.0.0
    │   │   ├── lazy_static v1.4.0
    │   │   ├── log v0.4.17 (*)
    │   │   └── symphonia-core v0.5.2 (*)
    │   └── symphonia-utils-xiph v0.5.2
    │       ├── symphonia-core v0.5.2 (*)
    │       └── symphonia-metadata v0.5.2 (*)
    ├── symphonia-bundle-mp3 v0.5.2
    │   ├── bitflags v1.3.2
    │   ├── lazy_static v1.4.0
    │   ├── log v0.4.17 (*)
    │   ├── symphonia-core v0.5.2 (*)
    │   └── symphonia-metadata v0.5.2 (*)
    ├── symphonia-codec-adpcm v0.5.2
    │   ├── log v0.4.17 (*)
    │   └── symphonia-core v0.5.2 (*)
    ├── symphonia-codec-pcm v0.5.2
    │   ├── log v0.4.17 (*)
    │   └── symphonia-core v0.5.2 (*)
    ├── symphonia-codec-vorbis v0.5.2
    │   ├── log v0.4.17 (*)
    │   ├── symphonia-core v0.5.2 (*)
    │   └── symphonia-utils-xiph v0.5.2 (*)
    ├── symphonia-core v0.5.2 (*)
    ├── symphonia-format-mkv v0.5.2
    │   ├── lazy_static v1.4.0
    │   ├── log v0.4.17 (*)
    │   ├── symphonia-core v0.5.2 (*)
    │   ├── symphonia-metadata v0.5.2 (*)
    │   └── symphonia-utils-xiph v0.5.2 (*)
    ├── symphonia-format-ogg v0.5.2
    │   ├── log v0.4.17 (*)
    │   ├── symphonia-core v0.5.2 (*)
    │   ├── symphonia-metadata v0.5.2 (*)
    │   └── symphonia-utils-xiph v0.5.2 (*)
    ├── symphonia-format-wav v0.5.2
    │   ├── log v0.4.17 (*)
    │   ├── symphonia-core v0.5.2 (*)
    │   └── symphonia-metadata v0.5.2 (*)
    └── symphonia-metadata v0.5.2 (*)
# ...
```

Switching off Symphonia's default features makes this look a bit more reasonable:

```shell
> cargo tree
rodio v0.17.0 (E:\Code\rodio)
# ...
└── symphonia v0.5.2
    ├── lazy_static v1.4.0
    ├── symphonia-bundle-mp3 v0.5.2
    │   ├── bitflags v1.3.2
    │   ├── lazy_static v1.4.0
    │   ├── log v0.4.17
    │   │   └── cfg-if v1.0.0
    │   ├── symphonia-core v0.5.2
    │   │   ├── arrayvec v0.7.2
    │   │   ├── bitflags v1.3.2
    │   │   ├── bytemuck v1.13.0
    │   │   ├── lazy_static v1.4.0
    │   │   └── log v0.4.17 (*)
    │   └── symphonia-metadata v0.5.2
    │       ├── encoding_rs v0.8.32
    │       │   └── cfg-if v1.0.0
    │       ├── lazy_static v1.4.0
    │       ├── log v0.4.17 (*)
    │       └── symphonia-core v0.5.2 (*)
    ├── symphonia-core v0.5.2 (*)
    └── symphonia-metadata v0.5.2 (*)
# ...
```