### PR TITLE
Resolving panic case 

### DIFF
--- a/src/decoder/symphonia.rs
+++ b/src/decoder/symphonia.rs
@@ -172,7 +172,7 @@ impl Iterator for SymphoniaDecoder {
             self.current_frame_offset = 0;
         }
 
-        let sample = self.buffer.samples()[self.current_frame_offset];
+        let sample = *self.buffer.samples().get(self.current_frame_offset)?;
         self.current_frame_offset += 1;
 
         Some(sample)


### PR DESCRIPTION
Exception handling for panic that can occur when using sink.

Related issues:
https://github.com/RustAudio/rodio/issues/486

It seems that the issue will be resolved after applying the modification.