### PR TITLE
queue: add `crossbeam-channel` feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ hound = { version = "3.3.1", optional = true }
 lewton = { version = "0.10", optional = true }
 minimp3 = { version = "0.5.0", optional = true }
 symphonia = { version = "0.5.2", optional = true, default-features = false }
+crossbeam-channel = { version = "0.5.8", optional = true }
 
 [features]
 default = ["flac", "vorbis", "wav", "mp3"]

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -1,7 +1,11 @@
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::mpsc::Receiver;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
+
+#[cfg(feature = "crossbeam-channel")]
+use crossbeam_channel::Receiver;
+#[cfg(not(feature = "crossbeam-channel"))]
+use std::sync::mpsc::Receiver;
 
 use crate::stream::{OutputStreamHandle, PlayError};
 use crate::{queue, source::Done, Sample, Source};


### PR DESCRIPTION
This changes `rodio::queue::*` and `rodio::Sink` to use a `crossbeam_channel` instead of the standard library's when sending the "end of queue" signal (`Receiver<()>`). This change only occurs if the `crossbeam-channel` feature flag is enabled in `rodio`, the default behavior is the same.

The main reason I'd like this is so that I can use crossbeam's [`Select`](https://docs.rs/crossbeam-channel/latest/crossbeam_channel/struct.Select.html) API.

Since the standard library (no longer) has a multiple channel sleep API, the only way to poll the `Receiver` from `append_with_signal()` is to `try_recv()` in a loop, which isn't ideal.