### PR TITLE
Replaces minimp3 with minimp3_fixed witch fixes a vital security flaw

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ cpal = "0.15"
 claxon = { version = "0.4.2", optional = true }
 hound = { version = "3.3.1", optional = true }
 lewton = { version = "0.10", optional = true }
-minimp3 = { version = "0.5.0", optional = true }
+minimp3-rs = { git = "https://github.com/BOB450/minimp3-rs.git", branch = "main", optional = true}
 symphonia = { version = "0.5.2", optional = true, default-features = false }
 crossbeam-channel = { version = "0.5.8", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ cpal = "0.15"
 claxon = { version = "0.4.2", optional = true }
 hound = { version = "3.3.1", optional = true }
 lewton = { version = "0.10", optional = true }
-minimp3-rs = { git = "https://github.com/BOB450/minimp3-rs.git", branch = "main", optional = true}
+minimp3_fixed = { version = "0.5.4", optional = true}
 symphonia = { version = "0.5.2", optional = true, default-features = false }
 crossbeam-channel = { version = "0.5.8", optional = true }
 
@@ -25,7 +25,7 @@ flac = ["claxon"]
 vorbis = ["lewton"]
 wav = ["hound"]
 mp3 = ["symphonia-mp3"]
-minimp3 = ["dep:minimp3"]
+minimp3 = ["dep:minimp3_fixed"]
 wasm-bindgen = ["cpal/wasm-bindgen"]
 symphonia-aac = ["symphonia/aac"]
 symphonia-all = ["symphonia-aac", "symphonia-flac", "symphonia-isomp4", "symphonia-mp3", "symphonia-vorbis", "symphonia-wav"]


### PR DESCRIPTION
https://rustsec.org/packages/slice-deque.html
This new minimp3 fork replaces this vulnerable package.