### PR TITLE
Elapsed Duration functionality for the Decoder/LoopedDecoder

### DIFF
--- a/examples/sample_count.rs
+++ b/examples/sample_count.rs
@@ -1,0 +1,16 @@
+use std::fs::File;
+use std::io::BufReader;
+use rodio::Decoder;
+
+fn main() {
+    let (_stream, stream_handle) = rodio::OutputStream::try_default().unwrap();
+
+    let file = BufReader::new(File::open("assets/music.flac").unwrap());
+    let decoder = Decoder::new(file).unwrap();
+    let info = decoder.get_info();
+    let sink = rodio::Sink::try_new(&stream_handle).unwrap();
+    sink.append(decoder);
+    while sink.len() > 0 {
+        println!("Elapsed Duration: {:?}", info.elapsed_duration().unwrap());
+    }
+}

--- a/examples/sample_count.rs
+++ b/examples/sample_count.rs
@@ -1,6 +1,6 @@
+use rodio::Decoder;
 use std::fs::File;
 use std::io::BufReader;
-use rodio::Decoder;
 
 fn main() {
     let (_stream, stream_handle) = rodio::OutputStream::try_default().unwrap();

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -70,7 +70,7 @@ where
 pub struct DecoderInfo {
     channels: u16,
     sample_rate: u32,
-    pub(crate) samples_elapsed: AtomicUsize,
+    samples_elapsed: AtomicUsize,
 }
 
 impl DecoderInfo {


### PR DESCRIPTION
The commits add a member to the Decoders, which contains the required information for the elapsed duration.

The functionality is implemented in the `impl<R> Iterator for Decoder<R>/LoopedDecoder<R>` and ticks an AtomicUsize up each read sample. With the channel count and sample rate the effective elapsed duration of a Decoder can be calculated.