### PR TITLE
Configurable buffer size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rodio"
-version = "0.17.1"
+version = "0.18.0"
 license = "MIT OR Apache-2.0"
 description = "Audio playback library"
 keywords = ["audio", "playback", "gamedev"]

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -342,7 +342,7 @@ impl CpalDeviceExt for cpal::Device {
             ),
             _ => return Err(cpal::BuildStreamError::StreamConfigNotSupported),
         }
-            .map(|stream| (mixer_tx, stream))
+        .map(|stream| (mixer_tx, stream))
     }
 
     fn try_new_output_stream_config(


### PR DESCRIPTION
If accepted, [PR#641](https://github.com/RustAudio/rodio/pull/641) replaces this one.

I needed to configure smaller buffer size to reduce playback delays (for a MIDI/VST application), and could not find a better way than to patch `rodio`. Notes:
* This is a breaking change, I needed to pass the buffer size to new_output_stream_with_format, it is likely possible to rewrite this, keeping that function intact if necessary.
* Using references to pass parameters is not strictly required, but the stream constructor does not need to own them, and it made it a bit easier to required some parameters after calling
* SampleFormat probably should be a part of StreamConfig. This will streamline the construction parameters. It is not clear to me what this affects, though.

The version from this patch works for me. I am willing to rework the request if there is a better idea how to do this.
