### PR TITLE
always seek to start in mp3::is_mp3()

### DIFF
--- a/src/decoder/mp3.rs
+++ b/src/decoder/mp3.rs
@@ -91,10 +91,8 @@ where
 {
     let stream_pos = data.seek(SeekFrom::Current(0)).unwrap();
     let mut decoder = Decoder::new(data.by_ref());
-    if decoder.next_frame().is_err() {
-        data.seek(SeekFrom::Start(stream_pos)).unwrap();
-        return false;
-    }
+    let ok = decoder.next_frame().is_ok();
+    data.seek(SeekFrom::Start(stream_pos)).unwrap();
 
-    true
+    ok
 }


### PR DESCRIPTION
the doc comment for this method states `/// Returns true if the stream contains mp3 data, then resets it to where it was.`
but the current code only seeks back to the original position if the data isn't MP3. This PR changes it so that it always resets.