### PR TITLE
Make `DynamicMixer` and `OutputStream` generic

### DIFF
--- a/src/dynamic_mixer.rs
+++ b/src/dynamic_mixer.rs
@@ -27,21 +27,32 @@ where
         sample_rate,
     });
 
-    let output = DynamicMixer {
-        current_sources: Vec::with_capacity(16),
-        input: input.clone(),
-        sample_count: 0,
-        still_pending: vec![],
-        still_current: vec![],
-    };
+    let output = input.clone().into();
 
     (input, output)
+}
+
+/// A mixer that can be used as the global target of a sink. This should be used with `MixerDriver` and `MixerController`.
+///
+/// Note that this does _not_ require a `Source` implementation - as the inputs are determined by `MixerDriver`, the
+/// mixer itself cannot specify e.g. frame length or total duration.
+// TODO: Should we allow mixers to specify frame lenght,
+// TODO: Add an "advanced" mixer interface and implement it for any `T: Mixer`, so that things like the
+//       pending sources queue can be configured - e.g. for single-threaded mixers.
+pub trait Mixer: Iterator {
+    /// Adds a new source to mix to the existing ones.
+    fn drain_sources(
+        &mut self,
+        sample_count: usize,
+        sources: &mut Vec<Box<dyn Source<Item = Self::Item> + Send>>,
+    );
 }
 
 /// The input of the mixer.
 pub struct DynamicMixerController<S> {
     has_pending: AtomicBool,
-    pending_sources: Mutex<Vec<Box<dyn Source<Item = S> + Send>>>,
+    // TODO: Make this configurable - we can probably use a lockfree queue
+    pending_sources: Mutex<Vec<Box<dyn Source<Item = S> + Send + 'static>>>,
     channels: u16,
     sample_rate: u32,
 }
@@ -60,21 +71,17 @@ where
         self.pending_sources
             .lock()
             .unwrap()
-            .push(Box::new(uniform_source) as Box<_>);
+            .push(Box::new(uniform_source) as _);
         self.has_pending.store(true, Ordering::SeqCst); // TODO: can we relax this ordering?
     }
 }
 
-/// The output of the mixer. Implements `Source`.
-pub struct DynamicMixer<S> {
+pub type DynamicMixer<S> = MixerDriver<S, BasicMixer<S>>;
+
+/// A basic summing mixer.
+pub struct BasicMixer<S> {
     // The current iterator that produces samples.
     current_sources: Vec<Box<dyn Source<Item = S> + Send>>,
-
-    // The pending sounds.
-    input: Arc<DynamicMixerController<S>>,
-
-    // The number of samples produced so far.
-    sample_count: usize,
 
     // A temporary vec used in start_pending_sources.
     still_pending: Vec<Box<dyn Source<Item = S> + Send>>,
@@ -83,9 +90,102 @@ pub struct DynamicMixer<S> {
     still_current: Vec<Box<dyn Source<Item = S> + Send>>,
 }
 
-impl<S> Source for DynamicMixer<S>
+impl<S> Default for BasicMixer<S> {
+    fn default() -> Self {
+        Self {
+            current_sources: Vec::with_capacity(16),
+            still_pending: vec![],
+            still_current: vec![],
+        }
+    }
+}
+
+/// The output of the mixer. Implements `Source`.
+pub struct MixerDriver<S, M: ?Sized> {
+    // The pending sounds.
+    // TODO: Should this be `Weak`, since a new controller cannot be created once the
+    //       original one has been dropped.
+    input: Arc<DynamicMixerController<S>>,
+
+    // The number of samples produced so far.
+    sample_count: usize,
+
+    mixer: M,
+}
+
+impl<S, M> MixerDriver<S, M> {
+    /// Create a new mixer driver, given an existing mixer.
+    ///
+    /// If the mixer implements `Default`, you can use `MixerDriver::new`.
+    pub fn from_mixer(
+        mixer: M,
+        channels: u16,
+        sample_rate: u32,
+    ) -> (Arc<DynamicMixerController<S>>, Self) {
+        let controller = Arc::new(DynamicMixerController {
+            has_pending: AtomicBool::new(false),
+            pending_sources: Mutex::new(Vec::new()),
+            channels,
+            sample_rate,
+        });
+
+        let mixer = Self {
+            mixer,
+            input: controller.clone(),
+            sample_count: 0,
+        };
+
+        (controller, mixer)
+    }
+}
+
+impl<S, M> MixerDriver<S, M>
 where
-    S: Sample + Send + 'static,
+    M: Default,
+{
+    /// Create a new mixer driver, along with a controller to control the mixer by.
+    pub fn new(channels: u16, sample_rate: u32) -> (Arc<DynamicMixerController<S>>, Self) {
+        Self::from_mixer(Default::default(), channels, sample_rate)
+    }
+}
+
+impl<S, M> From<Arc<DynamicMixerController<S>>> for MixerDriver<S, M>
+where
+    M: Default,
+{
+    fn from(value: Arc<DynamicMixerController<S>>) -> Self {
+        Self {
+            mixer: Default::default(),
+            input: value,
+            sample_count: 0,
+        }
+    }
+}
+
+impl<M> Iterator for MixerDriver<M::Item, M>
+where
+    M: Mixer + ?Sized,
+{
+    type Item = M::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.input.has_pending.load(Ordering::SeqCst) {
+            let mut pending = self.input.pending_sources.lock().unwrap(); // TODO: relax ordering?
+            self.mixer.drain_sources(self.sample_count, &mut *pending);
+            let has_pending = !pending.is_empty();
+            self.input.has_pending.store(has_pending, Ordering::SeqCst); // TODO: relax ordering?
+        }
+
+        self.sample_count += 1;
+
+        self.mixer.next()
+    }
+}
+
+impl<M> Source for MixerDriver<M::Item, M>
+where
+    M: Mixer + ?Sized,
+    M::Item: Sample,
 {
     #[inline]
     fn current_frame_len(&self) -> Option<usize> {
@@ -108,7 +208,7 @@ where
     }
 }
 
-impl<S> Iterator for DynamicMixer<S>
+impl<S> Iterator for BasicMixer<S>
 where
     S: Sample + Send + 'static,
 {
@@ -116,12 +216,6 @@ where
 
     #[inline]
     fn next(&mut self) -> Option<S> {
-        if self.input.has_pending.load(Ordering::SeqCst) {
-            self.start_pending_sources();
-        }
-
-        self.sample_count += 1;
-
         let sum = self.sum_current_sources();
 
         if self.current_sources.is_empty() {
@@ -137,7 +231,7 @@ where
     }
 }
 
-impl<S> DynamicMixer<S>
+impl<S> Mixer for BasicMixer<S>
 where
     S: Sample + Send + 'static,
 {
@@ -145,11 +239,13 @@ where
     // We need to ensure we start playing sources so that their samples are
     // in-step with the modulo of the samples produced so far. Otherwise, the
     // sound will play on the wrong channels, e.g. left / right will be reversed.
-    fn start_pending_sources(&mut self) {
-        let mut pending = self.input.pending_sources.lock().unwrap(); // TODO: relax ordering?
-
+    fn drain_sources(
+        &mut self,
+        sample_count: usize,
+        pending: &mut Vec<Box<dyn Source<Item = S> + Send>>,
+    ) {
         for source in pending.drain(..) {
-            let in_step = self.sample_count % source.channels() as usize == 0;
+            let in_step = sample_count % source.channels() as usize == 0;
 
             if in_step {
                 self.current_sources.push(source);
@@ -157,12 +253,14 @@ where
                 self.still_pending.push(source);
             }
         }
-        std::mem::swap(&mut self.still_pending, &mut pending);
-
-        let has_pending = !pending.is_empty();
-        self.input.has_pending.store(has_pending, Ordering::SeqCst); // TODO: relax ordering?
+        std::mem::swap(&mut self.still_pending, pending);
     }
+}
 
+impl<S> BasicMixer<S>
+where
+    S: Sample + Send + 'static,
+{
     fn sum_current_sources(&mut self) -> S {
         let mut sum = S::zero_value();
 

--- a/src/dynamic_mixer.rs
+++ b/src/dynamic_mixer.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use crate::source::{Source, UniformSourceIterator};
 use crate::Sample;
 
-type DynSource<S> = Box<dyn Source<Item = S> + Send + Sync + 'static>;
+type DynSource<S> = Box<dyn Source<Item = S> + Send + 'static>;
 
 /// Builds a new mixer.
 ///
@@ -20,7 +20,7 @@ pub fn mixer<S>(
     sample_rate: u32,
 ) -> (Arc<DynamicMixerController<S>>, DynamicMixer<S>)
 where
-    S: Sample + Send + Sync + 'static,
+    S: Sample + Send + 'static,
 {
     let input = Arc::new(DynamicMixerController {
         has_pending: AtomicBool::new(false),
@@ -61,13 +61,13 @@ pub struct DynamicMixerController<S> {
 
 impl<S> DynamicMixerController<S>
 where
-    S: Sample + Send + Sync + 'static,
+    S: Sample + Send + 'static,
 {
     /// Adds a new source to mix to the existing ones.
     #[inline]
     pub fn add<T>(&self, source: T)
     where
-        T: Source<Item = S> + Send + Sync + 'static,
+        T: Source<Item = S> + Send + 'static,
     {
         let uniform_source = UniformSourceIterator::new(source, self.channels, self.sample_rate);
         self.pending_sources
@@ -212,7 +212,7 @@ where
 
 impl<S> Iterator for BasicMixer<S>
 where
-    S: Sample + Send + Sync + 'static,
+    S: Sample + Send + 'static,
 {
     type Item = S;
 
@@ -235,7 +235,7 @@ where
 
 impl<S> Mixer for BasicMixer<S>
 where
-    S: Sample + Send + Sync + 'static,
+    S: Sample + Send + 'static,
 {
     // Samples from the #next() function are interlaced for each of the channels.
     // We need to ensure we start playing sources so that their samples are
@@ -261,7 +261,7 @@ where
 
 impl<S> BasicMixer<S>
 where
-    S: Sample + Send + Sync + 'static,
+    S: Sample + Send + 'static,
 {
     fn sum_current_sources(&mut self) -> S {
         let mut sum = S::zero_value();


### PR DESCRIPTION
This commit adds a new trait, `Mixer`, and refactors some of the code around generic mixers in order to support it. This is to make more of the code reusable without rewriting - specifically, to support a feature that I would like to implement in `bevy_audio` where audio sources can send audio to an intermediate mixer. The motivation for this was to add a global limiter to all game audio, so that loud sounds did not cause clipping on the master bus, but another possible usecase would be to split in-game audio and menu audio into separate "worlds" and apply, for example, a low-pass filter while in the pause screen.