### PR TITLE
Lift `Sink::clear` into `SpatialSink`

### DIFF
--- a/src/spatial_sink.rs
+++ b/src/spatial_sink.rs
@@ -135,6 +135,14 @@ impl SpatialSink {
         self.sink.is_paused()
     }
 
+    /// Removes all currently loaded `Source`s from the `SpatialSink` and pauses it.
+    ///
+    /// See `pause()` for information about pausing a `Sink`.
+    #[inline]
+    pub fn clear(&self) {
+        self.sink.clear();
+    }
+
     /// Stops the sink by emptying the queue.
     #[inline]
     pub fn stop(&self) {


### PR DESCRIPTION
Pretty straightforward: just implementing `.clear()` for `SpatialSink` — since the underlying `Sink` of a `SpatialSink` is a private field, there isn't really a way to clear it without making a change like this. 