### PR TITLE
Fix channel count upscaling

### DIFF
--- a/src/conversions/channels.rs
+++ b/src/conversions/channels.rs
@@ -21,7 +21,7 @@ where
     ///
     /// # Panic
     ///
-    /// Panicks if `from` or `to` are equal to 0.
+    /// Panics if `from` or `to` are equal to 0.
     ///
     #[inline]
     pub fn new(
@@ -71,7 +71,7 @@ where
         self.next_output_sample_pos += 1;
 
         if self.next_output_sample_pos == self.to {
-            self.next_output_sample_pos -= self.to;
+            self.next_output_sample_pos = 0;
 
             if self.from > self.to {
                 for _ in self.to..self.from {

--- a/src/conversions/channels.rs
+++ b/src/conversions/channels.rs
@@ -68,7 +68,9 @@ where
             _ => Some(I::Item::EQUILIBRIUM),
         };
 
-        self.next_output_sample_pos += 1;
+        if result.is_some() {
+            self.next_output_sample_pos += 1;
+        }
 
         if self.next_output_sample_pos == self.to {
             self.next_output_sample_pos = 0;
@@ -140,16 +142,14 @@ mod test {
     #[test]
     fn size_hint() {
         fn test(input: &[i16], from: cpal::ChannelCount, to: cpal::ChannelCount) {
-            let input = input.to_vec();
-            let scaled_len = input.len() / from as usize * to as usize;
-            let mut converter = ChannelCountConverter::new(input.into_iter(), from, to);
-            for i in 0..scaled_len {
-                assert_eq!(
-                    converter.size_hint(),
-                    (scaled_len - i, Some(scaled_len - i))
-                );
+            let mut converter = ChannelCountConverter::new(input.iter().copied(), from, to);
+            let count = converter.clone().count();
+            for left_in_iter in (0..=count).rev() {
+                println!("left_in_iter = {}", left_in_iter);
+                assert_eq!(converter.size_hint(), (left_in_iter, Some(left_in_iter)));
                 converter.next();
             }
+            assert_eq!(converter.size_hint(), (0, Some(0)));
         }
 
         test(&[1i16, 2, 3], 1, 2);

--- a/src/conversions/channels.rs
+++ b/src/conversions/channels.rs
@@ -1,3 +1,5 @@
+use cpal::Sample;
+
 /// Iterator that converts from a certain channel count to another.
 #[derive(Clone, Debug)]
 pub struct ChannelCountConverter<I>
@@ -7,7 +9,7 @@ where
     input: I,
     from: cpal::ChannelCount,
     to: cpal::ChannelCount,
-    sample_repeat: Vec<Option<I::Item>>,
+    sample_repeat: Option<I::Item>,
     next_output_sample_pos: cpal::ChannelCount,
 }
 
@@ -34,11 +36,7 @@ where
             input,
             from,
             to,
-            sample_repeat: {
-                let mut vec = Vec::with_capacity(from as usize);
-                vec.resize_with(from as usize, || None);
-                vec
-            },
+            sample_repeat: None,
             next_output_sample_pos: 0,
         }
     }
@@ -53,17 +51,21 @@ where
 impl<I> Iterator for ChannelCountConverter<I>
 where
     I: Iterator,
-    I::Item: Clone,
+    I::Item: Sample,
 {
     type Item = I::Item;
 
     fn next(&mut self) -> Option<I::Item> {
-        let result = if self.next_output_sample_pos < self.from {
-            let value = self.input.next();
-            self.sample_repeat[self.next_output_sample_pos as usize] = value.clone();
-            value
-        } else {
-            self.sample_repeat[(self.next_output_sample_pos % self.from) as usize].clone()
+        let result = match self.next_output_sample_pos {
+            0 => {
+                // save first sample for mono -> stereo conversion
+                let value = self.input.next();
+                self.sample_repeat = value;
+                value
+            }
+            x if x < self.from => self.input.next(),
+            1 => self.sample_repeat,
+            _ => Some(I::Item::EQUILIBRIUM),
         };
 
         self.next_output_sample_pos += 1;
@@ -98,7 +100,7 @@ where
 impl<I> ExactSizeIterator for ChannelCountConverter<I>
 where
     I: ExactSizeIterator,
-    I::Item: Clone,
+    I::Item: Sample,
 {
 }
 
@@ -118,26 +120,33 @@ mod test {
     }
 
     #[test]
-    fn add_channels() {
-        let input = vec![1u16, 2, 3, 4];
-        let output = ChannelCountConverter::new(input.into_iter(), 2, 3).collect::<Vec<_>>();
-        assert_eq!(output, [1, 2, 1, 3, 4, 3]);
+    fn mono_to_stereo() {
+        let input = vec![1i16, 2, 3, 4];
+        let output = ChannelCountConverter::new(input.into_iter(), 1, 2).collect::<Vec<_>>();
+        assert_eq!(output, [1, 1, 2, 2, 3, 3, 4, 4]);
+    }
 
-        let input = vec![1u16, 2, 3, 4];
+    #[test]
+    fn add_channels() {
+        let input = vec![1i16, 2];
+        let output = ChannelCountConverter::new(input.into_iter(), 1, 4).collect::<Vec<_>>();
+        assert_eq!(output, [1, 1, 0, 0, 2, 2, 0, 0]);
+
+        let input = vec![1i16, 2, 3, 4];
         let output = ChannelCountConverter::new(input.into_iter(), 2, 4).collect::<Vec<_>>();
-        assert_eq!(output, [1, 2, 1, 2, 3, 4, 3, 4]);
+        assert_eq!(output, [1, 2, 0, 0, 3, 4, 0, 0]);
     }
 
     #[test]
     fn len_more() {
-        let input = vec![1u16, 2, 3, 4];
+        let input = vec![1i16, 2, 3, 4];
         let output = ChannelCountConverter::new(input.into_iter(), 2, 3);
         assert_eq!(output.len(), 6);
     }
 
     #[test]
     fn len_less() {
-        let input = vec![1u16, 2, 3, 4];
+        let input = vec![1i16, 2, 3, 4];
         let output = ChannelCountConverter::new(input.into_iter(), 2, 1);
         assert_eq!(output.len(), 2);
     }


### PR DESCRIPTION
This changes channel upscaling so all input samples are spread out across the output channels, instead of repeating the last sample over and over. This approach should yield more accurate results. Fixes #558.