### PR TITLE
This fixes all clippy warnings

### DIFF
--- a/src/decoder/flac.rs
+++ b/src/decoder/flac.rs
@@ -107,7 +107,7 @@ where
 
             // Load the next block.
             self.current_block_off = 0;
-            let buffer = mem::replace(&mut self.current_block, Vec::new());
+            let buffer = mem::take(&mut self.current_block);
             match self.reader.blocks().read_next_or_eof(buffer) {
                 Ok(Some(block)) => {
                     self.current_block_channel_len = (block.len() / block.channels()) as usize;

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -39,6 +39,9 @@ pub struct LoopedDecoder<R>(DecoderImpl<R>)
 where
     R: Read + Seek;
 
+// can not really reduce the size of the VorbisDecoder. There are not any
+// arrays just a lot of struct fields.
+#[allow(clippy::large_enum_variant)]
 enum DecoderImpl<R>
 where
     R: Read + Seek,

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -43,9 +43,12 @@ where
 
 // TODO: consider reimplementing this with `from_factory`
 
+type Sound<S> = Box<dyn Source<Item = S> + Send>;
+type SignalDone = Option<Sender<()>>;
+
 /// The input of the queue.
 pub struct SourcesQueueInput<S> {
-    next_sounds: Mutex<Vec<(Box<dyn Source<Item = S> + Send>, Option<Sender<()>>)>>,
+    next_sounds: Mutex<Vec<(Sound<S>, SignalDone)>>,
 
     // See constructor.
     keep_alive_if_empty: AtomicBool,

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -226,6 +226,7 @@ impl Sink {
     }
 
     /// Returns the number of sounds currently in the queue.
+    #[allow(clippy::len_without_is_empty)]
     #[inline]
     pub fn len(&self) -> usize {
         self.sound_count.load(Ordering::Relaxed)

--- a/src/source/sine.rs
+++ b/src/source/sine.rs
@@ -17,7 +17,7 @@ impl SineWave {
     #[inline]
     pub fn new(freq: f32) -> SineWave {
         SineWave {
-            freq: freq,
+            freq,
             num_sample: 0,
         }
     }

--- a/src/spatial_sink.rs
+++ b/src/spatial_sink.rs
@@ -168,6 +168,7 @@ impl SpatialSink {
     }
 
     /// Returns the number of sounds currently in the queue.
+    #[allow(clippy::len_without_is_empty)]
     #[inline]
     pub fn len(&self) -> usize {
         self.sink.len()


### PR DESCRIPTION
Made an issue for missing `is_empty()`, see:
https://github.com/RustAudio/rodio/issues/562

The DecoderImpl enum triggerd large_enum_variant. There is not an easy fix for that. We could box the VorbisDecoder but at 572 bytes I really do not think thats worth it. Annotated it with an allow