### PR TITLE
The changelog is now in 'keep a changelog' format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+- `Source` trait is now also implemented for `Box<dyn Source>` and `&mut Source`
+- `fn new_vorbis` is now also available when the `symphonia-vorbis` feature is enabled
+
+### Added 
+- Adds `SpatialSink::clear()` bringing it in line with `Sink`
+
+### Fixed
+- `mp3::is_mp3()` no longer changes the position in the stream when the stream
+  is mp3
+
 # Version 0.17.3 (2023-10-23)
 
 - Build fix for `minimp3` backend.


### PR DESCRIPTION
Mainly because it means we get an unreleased section.his will save maintainers time when releasing lowering the barrier to cut a release which in turn helps out users waiting for fixes/new features. I decided not to change the old entries to the keepachangelog format, simply because it is a lot of work and I do not see an advantage.

I would like to also automate checking if the changelog was edited. Since this would further lower the workload on maintainers. The responsibility of editing the changelog will then squarly fall on the Contributor of the PR. That should give maintainers more time to review PR's.