### PR TITLE
The cpal version requirement is too low causing #573

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = ["assets/**", "tests/**"]
 edition = "2021"
 
 [dependencies]
-cpal = "0.15"
+cpal = "0.15.3"
 claxon = { version = "0.4.2", optional = true }
 hound = { version = "3.3.1", optional = true }
 lewton = { version = "0.10", optional = true }


### PR DESCRIPTION
Specifically cpal changed `SupportedStreamConfigRange` and made it Copy. As that relaxes the requirements on it its a non breaking change. Rodio was then refactored to remove the now no longer needed `.clone()` in 77c5c54. That clone however is still needed for Rodio users with a lower cpal version. This commit fixes that by requiring a higher cpal version.