### PR TITLE
Fix hang seek on empty queue

### DIFF
--- a/examples/seek_mp3.rs
+++ b/examples/seek_mp3.rs
@@ -15,4 +15,8 @@ fn main() {
     sink.try_seek(Duration::from_secs(4)).unwrap();
 
     sink.sleep_until_end();
+
+    // wont do anything since the sound has ended already
+    sink.try_seek(Duration::from_secs(5)).unwrap();
+    println!("seek example ended");
 }

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -53,7 +53,7 @@ impl SeekOrder {
         S::Item: Sample + Send,
     {
         let res = maybe_seekable.try_seek(self.pos);
-        let _ignore_reciever_dropped = self.feedback.send(res);
+        let _ignore_receiver_dropped = self.feedback.send(res);
     }
 }
 
@@ -222,6 +222,12 @@ impl Sink {
     pub fn try_seek(&self, pos: Duration) -> Result<(), SeekError> {
         let (order, feedback) = SeekOrder::new(pos);
         *self.controls.seek.lock().unwrap() = Some(order);
+
+        if self.sound_count.load(Ordering::Acquire) == 0 {
+            // No sound is playing, seek will not be performed
+            return Ok(())
+        }
+
         match feedback.recv() {
             Ok(seek_res) => seek_res,
             // The feedback channel closed. Probably another seekorder was set


### PR DESCRIPTION
Addresses half of #578, specifically the hanging of the audio thread if a seek is done on an already ended item. Also expands the seek example to check for this.