### PR TITLE
Add TrackPosition to Source

### DIFF
--- a/src/sink.rs
+++ b/src/sink.rs
@@ -64,6 +64,7 @@ struct Controls {
     speed: Mutex<f32>,
     to_clear: Mutex<u32>,
     seek: Mutex<Option<SeekOrder>>,
+    position: Mutex<f64>,
 }
 
 impl Sink {
@@ -90,6 +91,7 @@ impl Sink {
                 speed: Mutex::new(1.0),
                 to_clear: Mutex::new(0),
                 seek: Mutex::new(None),
+                position: Mutex::new(0.0),
             }),
             sound_count: Arc::new(AtomicUsize::new(0)),
             detached: false,
@@ -119,6 +121,7 @@ impl Sink {
 
         let source = source
             .speed(1.0)
+            .trackable()
             .pausable(false)
             .amplify(1.0)
             .skippable()
@@ -127,12 +130,16 @@ impl Sink {
             .periodic_access(Duration::from_millis(5), move |src| {
                 if controls.stopped.load(Ordering::SeqCst) {
                     src.stop();
+                    *controls.position.lock().unwrap() = 0.0;
                 }
                 {
                     let mut to_clear = controls.to_clear.lock().unwrap();
                     if *to_clear > 0 {
                         src.inner_mut().skip();
                         *to_clear -= 1;
+                        *controls.position.lock().unwrap() = 0.0;
+                    } else {
+                        *controls.position.lock().unwrap() = src.inner().inner().inner().inner().get_pos();
                     }
                 }
                 let amp = src.inner_mut().inner_mut();
@@ -140,6 +147,7 @@ impl Sink {
                 amp.inner_mut()
                     .set_paused(controls.pause.load(Ordering::SeqCst));
                 amp.inner_mut()
+                    .inner_mut()
                     .inner_mut()
                     .set_factor(*controls.speed.lock().unwrap());
                 if let Some(seek) = controls.seek.lock().unwrap().take() {
@@ -308,6 +316,12 @@ impl Sink {
     #[inline]
     pub fn len(&self) -> usize {
         self.sound_count.load(Ordering::Relaxed)
+    }
+
+    /// Returns the position of the sound that's being played.
+    #[inline]
+    pub fn get_pos(&self) -> f64 {
+        *self.controls.position.lock().unwrap()
     }
 }
 

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -12,6 +12,28 @@ use crate::stream::{OutputStreamHandle, PlayError};
 use crate::{queue, source::Done, Sample, Source};
 use cpal::FromSample;
 
+#[derive(Debug)]
+pub struct AtomicF64 {
+    storage: AtomicU64,
+}
+
+impl AtomicF64 {
+    pub fn new(value: f64) -> Self {
+        let as_u64 = value.to_bits();
+        Self {
+            storage: AtomicU64::new(as_u64),
+        }
+    }
+    pub fn store(&self, value: f64, ordering: Ordering) {
+        let as_u64 = value.to_bits();
+        self.storage.store(as_u64, ordering)
+    }
+    pub fn load(&self, ordering: Ordering) -> f64 {
+        let as_u64 = self.storage.load(ordering);
+        f64::from_bits(as_u64)
+    }
+}
+
 /// Handle to a device that outputs sounds.
 ///
 /// Dropping the `Sink` stops all sounds. You can use `detach` if you want the sounds to continue
@@ -22,6 +44,7 @@ pub struct Sink {
 
     controls: Arc<Controls>,
     sound_count: Arc<AtomicUsize>,
+    position: Arc<AtomicF64>,
 
     detached: bool,
 }
@@ -64,7 +87,6 @@ struct Controls {
     speed: Mutex<f32>,
     to_clear: Mutex<u32>,
     seek: Mutex<Option<SeekOrder>>,
-    position: Mutex<f64>,
 }
 
 impl Sink {
@@ -91,9 +113,9 @@ impl Sink {
                 speed: Mutex::new(1.0),
                 to_clear: Mutex::new(0),
                 seek: Mutex::new(None),
-                position: Mutex::new(0.0),
             }),
             sound_count: Arc::new(AtomicUsize::new(0)),
+            position: Arc::new(AtomicF64::new(0.0)),
             detached: false,
         };
         (sink, queue_rx)
@@ -121,7 +143,7 @@ impl Sink {
 
         let source = source
             .speed(1.0)
-            .trackable()
+            .trackable(self.position.clone())
             .pausable(false)
             .amplify(1.0)
             .skippable()
@@ -130,16 +152,12 @@ impl Sink {
             .periodic_access(Duration::from_millis(5), move |src| {
                 if controls.stopped.load(Ordering::SeqCst) {
                     src.stop();
-                    *controls.position.lock().unwrap() = 0.0;
                 }
                 {
                     let mut to_clear = controls.to_clear.lock().unwrap();
                     if *to_clear > 0 {
                         src.inner_mut().skip();
                         *to_clear -= 1;
-                        *controls.position.lock().unwrap() = 0.0;
-                    } else {
-                        *controls.position.lock().unwrap() = src.inner().inner().inner().inner().get_pos();
                     }
                 }
                 let amp = src.inner_mut().inner_mut();
@@ -321,7 +339,7 @@ impl Sink {
     /// Returns the position of the sound that's being played.
     #[inline]
     pub fn get_pos(&self) -> f64 {
-        *self.controls.position.lock().unwrap()
+        self.position.load(Ordering::Relaxed)
     }
 }
 

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -121,7 +121,7 @@ impl Sink {
 
         let source = source
             .speed(1.0)
-            .trackable()
+            .track_position()
             .pausable(false)
             .amplify(1.0)
             .skippable()

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -1,11 +1,9 @@
 //! Sources of sound and various filters.
 
-use std::sync::Arc;
 use std::time::Duration;
 
 use cpal::FromSample;
 
-use crate::sink::AtomicF64;
 use crate::Sample;
 
 pub use self::amplify::Amplify;
@@ -337,11 +335,11 @@ where
         skippable::skippable(self)
     }
 
-    fn trackable(self, position: Arc<AtomicF64>) -> TrackPosition<Self>
+    fn trackable(self) -> TrackPosition<Self>
     where
         Self: Sized,
     {
-        position::trackable(self, position)
+        position::trackable(self)
     }
 
     /// Applies a low-pass filter to the source.

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -335,11 +335,11 @@ where
         skippable::skippable(self)
     }
 
-    fn trackable(self) -> TrackPosition<Self>
+    fn track_position(self) -> TrackPosition<Self>
     where
         Self: Sized,
     {
-        position::trackable(self)
+        position::track_position(self)
     }
 
     /// Applies a low-pass filter to the source.

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -21,6 +21,7 @@ pub use self::from_iter::{from_iter, FromIter};
 pub use self::mix::Mix;
 pub use self::pausable::Pausable;
 pub use self::periodic::PeriodicAccess;
+pub use self::position::TrackPosition;
 pub use self::repeat::Repeat;
 pub use self::samples_converter::SamplesConverter;
 pub use self::sine::SineWave;
@@ -48,6 +49,7 @@ mod from_iter;
 mod mix;
 mod pausable;
 mod periodic;
+mod position;
 mod repeat;
 mod samples_converter;
 mod sine;
@@ -331,6 +333,13 @@ where
         Self: Sized,
     {
         skippable::skippable(self)
+    }
+
+    fn trackable(self) -> TrackPosition<Self>
+    where
+        Self: Sized,
+    {
+        position::trackable(self)
     }
 
     /// Applies a low-pass filter to the source.

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -1,9 +1,11 @@
 //! Sources of sound and various filters.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use cpal::FromSample;
 
+use crate::sink::AtomicF64;
 use crate::Sample;
 
 pub use self::amplify::Amplify;
@@ -335,11 +337,11 @@ where
         skippable::skippable(self)
     }
 
-    fn trackable(self) -> TrackPosition<Self>
+    fn trackable(self, position: Arc<AtomicF64>) -> TrackPosition<Self>
     where
         Self: Sized,
     {
-        position::trackable(self)
+        position::trackable(self, position)
     }
 
     /// Applies a low-pass filter to the source.

--- a/src/source/position.rs
+++ b/src/source/position.rs
@@ -5,7 +5,7 @@ use crate::{Sample, Source};
 use super::SeekError;
 
 /// Internal function that builds a `TrackPosition` object.
-pub fn trackable<I>(source: I) -> TrackPosition<I> {
+pub fn track_position<I>(source: I) -> TrackPosition<I> {
     TrackPosition {
         input: source,
         samples_counted: 0,
@@ -154,7 +154,7 @@ mod tests {
     #[test]
     fn test_position() {
         let inner = SamplesBuffer::new(1, 1, vec![10i16, -10, 10, -10, 20, -20]);
-        let mut source = inner.trackable();
+        let mut source = inner.track_position();
 
         assert_eq!(source.get_pos(), 0.0);
         source.next();

--- a/src/source/position.rs
+++ b/src/source/position.rs
@@ -1,19 +1,15 @@
-use std::{
-    sync::{atomic::Ordering, Arc},
-    time::Duration,
-};
+use std::time::Duration;
 
-use crate::{sink::AtomicF64, Sample, Source};
+use crate::{Sample, Source};
 
 use super::SeekError;
 
 /// Internal function that builds a `TrackPosition` object.
-pub fn trackable<I>(source: I, position: Arc<AtomicF64>) -> TrackPosition<I> {
+pub fn trackable<I>(source: I) -> TrackPosition<I> {
     TrackPosition {
         input: source,
         samples_counted: 0,
         offset_duration: 0.0,
-        position,
         current_frame_sample_rate: 0,
         current_frame_channels: 0,
         current_frame_len: None,
@@ -25,7 +21,6 @@ pub struct TrackPosition<I> {
     input: I,
     samples_counted: usize,
     offset_duration: f64,
-    position: Arc<AtomicF64>,
     current_frame_sample_rate: u32,
     current_frame_channels: u16,
     current_frame_len: Option<usize>,
@@ -58,7 +53,7 @@ where
 {
     /// Returns the position of the source.
     #[inline]
-    fn get_pos(&self) -> f64 {
+    pub fn get_pos(&self) -> f64 {
         self.samples_counted as f64 / self.input.sample_rate() as f64 / self.input.channels() as f64
             + self.offset_duration
     }
@@ -101,7 +96,6 @@ where
                 self.set_current_frame();
             };
         };
-        self.position.store(self.get_pos(), Ordering::Relaxed);
         item
     }
 
@@ -145,7 +139,6 @@ where
             // starts again at the beginning of a frame. Which is the case with
             // symphonia.
             self.samples_counted = 0;
-            self.position.store(self.get_pos(), Ordering::Relaxed);
         }
         result
     }
@@ -153,28 +146,24 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::Ordering;
-    use std::sync::Arc;
     use std::time::Duration;
 
     use crate::buffer::SamplesBuffer;
-    use crate::sink::AtomicF64;
     use crate::source::Source;
 
     #[test]
     fn test_position() {
         let inner = SamplesBuffer::new(1, 1, vec![10i16, -10, 10, -10, 20, -20]);
-        let position = Arc::new(AtomicF64::new(0.0));
-        let mut source = inner.trackable(position.clone());
+        let mut source = inner.trackable();
 
-        assert_eq!(position.load(Ordering::Relaxed), 0.0);
+        assert_eq!(source.get_pos(), 0.0);
         source.next();
-        assert_eq!(position.load(Ordering::Relaxed), 1.0);
+        assert_eq!(source.get_pos(), 1.0);
 
         source.next();
-        assert_eq!(position.load(Ordering::Relaxed), 2.0);
+        assert_eq!(source.get_pos(), 2.0);
 
         assert_eq!(source.try_seek(Duration::new(1, 0)).is_ok(), true);
-        assert_eq!(position.load(Ordering::Relaxed), 1.0);
+        assert_eq!(source.get_pos(), 1.0);
     }
 }

--- a/src/source/position.rs
+++ b/src/source/position.rs
@@ -1,0 +1,133 @@
+use std::time::Duration;
+
+use crate::{Sample, Source};
+
+use super::SeekError;
+
+/// Internal function that builds a `TrackPosition` object.
+pub fn trackable<I>(source: I) -> TrackPosition<I> {
+    TrackPosition {
+        input: source,
+        samples_elapsed: 0,
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct TrackPosition<I> {
+    input: I,
+    samples_elapsed: usize,
+}
+
+impl<I> TrackPosition<I> {
+    /// Returns a reference to the inner source.
+    #[inline]
+    pub fn inner(&self) -> &I {
+        &self.input
+    }
+
+    /// Returns a mutable reference to the inner source.
+    #[inline]
+    pub fn inner_mut(&mut self) -> &mut I {
+        &mut self.input
+    }
+
+    /// Returns the inner source.
+    #[inline]
+    pub fn into_inner(self) -> I {
+        self.input
+    }
+}
+
+impl<I> TrackPosition<I>
+where
+    I: Source,
+    I::Item: Sample,
+{
+    /// Returns the inner source.
+    #[inline]
+    pub fn get_pos(&self) -> f64 {
+        self.samples_elapsed as f64 / self.input.sample_rate() as f64 / self.input.channels() as f64
+    }
+}
+
+impl<I> Iterator for TrackPosition<I>
+where
+    I: Source,
+    I::Item: Sample,
+{
+    type Item = I::Item;
+
+    #[inline]
+    fn next(&mut self) -> Option<I::Item> {
+        let item = self.input.next();
+        if item.is_some() {
+            self.samples_elapsed += 1;
+        };
+        item
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.input.size_hint()
+    }
+}
+
+impl<I> Source for TrackPosition<I>
+where
+    I: Source,
+    I::Item: Sample,
+{
+    #[inline]
+    fn current_frame_len(&self) -> Option<usize> {
+        self.input.current_frame_len()
+    }
+
+    #[inline]
+    fn channels(&self) -> u16 {
+        self.input.channels()
+    }
+
+    #[inline]
+    fn sample_rate(&self) -> u32 {
+        self.input.sample_rate()
+    }
+
+    #[inline]
+    fn total_duration(&self) -> Option<Duration> {
+        self.input.total_duration()
+    }
+
+    #[inline]
+    fn try_seek(&mut self, pos: Duration) -> Result<(), SeekError> {
+        let result = self.input.try_seek(pos);
+        if result.is_ok() {
+            self.samples_elapsed = (pos.as_secs_f64()
+                * self.input.sample_rate() as f64
+                * self.input.channels() as f64) as usize;
+        }
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use crate::buffer::SamplesBuffer;
+    use crate::source::Source;
+
+    #[test]
+    fn test_position() {
+        let inner = SamplesBuffer::new(1, 1, vec![10i16, -10, 10, -10, 20, -20]);
+        let mut source = inner.trackable();
+
+        assert_eq!(source.get_pos(), 0.0);
+        source.next();
+        assert_eq!(source.get_pos(), 1.0);
+        source.next();
+        assert_eq!(source.get_pos(), 2.0);
+
+        assert_eq!(source.try_seek(Duration::new(1, 0)).is_ok(), true);
+        assert_eq!(source.get_pos(), 1.0);
+    }
+}

--- a/src/spatial_sink.rs
+++ b/src/spatial_sink.rs
@@ -195,4 +195,10 @@ impl SpatialSink {
     pub fn try_seek(&self, pos: Duration) -> Result<(), SeekError> {
         self.sink.try_seek(pos)
     }
+
+    /// Returns the position of the sound that's being played.
+    #[inline]
+    pub fn get_pos(&self) -> f64 {
+        self.sink.get_pos()
+    }
 }


### PR DESCRIPTION
This adds a new TrackPosition wrapper which counts the amount of times `next()` is called (where it returns `Some`) and provide a function to get the position, which is a simple calculation.

This is added to Sink by default and the accuracy of this depends on the interval of `periodic_access`.

I wasn't able to add testing to the sink counter part, because I wanted to also test `try_seek`, but it seems like I would need to have some threading code to call `next` on sink in another thread, which didn't look that good and resulted in a flaky test so only a 'unit test' in ``position.rs`.

Resolves #457
Closes #510