### PR TITLE
CI: Tweaks for the tag creating jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   create-tags-for-past-releases:
     name: Create tags for past releases
+    # This job has to be removed once it is ran succesfully
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
@@ -130,6 +131,7 @@ jobs:
           [ $empty -eq 1 ] || grep -q "is already uploaded" < $RODIO_TMP
 
   create-git-tag:
+    needs: create-tags-for-past-releases # This line needs to be removed once the `create-tags-for-past-releases` job is removed
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
@@ -144,6 +146,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
+        fetch-depth: 0  # Fetch all history to list all existing tags
         token: ${{ secrets.WORKFLOW_TOKEN }}
     - name: Extract version from Cargo.toml
       id: extract_version


### PR DESCRIPTION
Hello there, this is a follow up to #589

## Code changes

Some tweaks for the Github actions:
* **Makes sure the `create-tags-for-past-releases` job runs before `create-git-tag`.**  
Since jobs run in parallel `create-git-tag` could run before `create-tags-for-past-releases` and would create a tag for 0.19.0 on the latest commit on `master`. The job `create-git-tag` will now always run after `create-tags-for-past-releases`.
* **Have the `create-git-tag` fetch all Git history to actually be able to detect past tags.**
Now the checkout fetches the whole git history allowing it to see if the current version is indeed tagged or not.

## Fine grain token

I have tested with the fine-grain tokens and the following setting works. @est31 may I ask you to do the following please

1. Regenerate a fine-grain personal access token [here](https://github.com/settings/personal-access-tokens/new) with the following settings:
  * Token name: Something like "Token for Rodio CI release tagging"
  * Expiration: Any value you would like, you understand that it will have to be periodically regenerated. The [secrets scanning page for the project](https://github.com/RustAudio/rodio/security/secret-scanning) should theoretically warn you when it is expired.
  * Repository access: You only need to select the `RustAudio/Rodio` repo.
  * Permissions:
    * Contents: Read and Write (in order to create releases/tags)
    * Metadata: Read (mandatory)
    * Workflows (at the very bottom of the list): Read and Write (because apparently tagging commits which are anywhere near something that modified a workflow file counts as modifying that workflow?)
2. Edit the [`WORKFLOW_TOKEN` repo secret here](https://github.com/RustAudio/rodio/settings/secrets/actions/WORKFLOW_TOKEN) (or create the `WORKFLOW_TOKEN` secret if it doesn't exist) and paste the newly created fine-grained PAT.
3. Finally merging this very PR.

Here's a screenshot of my fine-grained PAT that succesfully ran on the `master` of my fork: 

![Screenshot from 2024-07-09 12-51-55](https://github.com/RustAudio/rodio/assets/929716/a778424c-dad7-42ed-9c55-6ec04e28ac30)

Thanks!