### PR TITLE
Derive `Clone` for `buffer::SamplesBuffer`

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -16,6 +16,7 @@ use crate::source::SeekError;
 use crate::{Sample, Source};
 
 /// A buffer of samples treated as a source.
+#[derive(Debug, Clone)]
 pub struct SamplesBuffer<S> {
     data: Vec<S>,
     pos: usize,


### PR DESCRIPTION
This change applies a #derive attribute macro adding the `Clone` trait to the `SamplesBuffer` struct.