### PR TITLE
Add ALAC / AIFF Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ symphonia-isomp4 = ["symphonia/isomp4"]
 symphonia-mp3 = ["symphonia/mp3"]
 symphonia-vorbis = ["symphonia/vorbis"]
 symphonia-wav = ["symphonia/wav", "symphonia/pcm", "symphonia/adpcm"]
+symphonia-alac = ["symphonia/isomp4", "symphonia/alac"]
+symphonia-aiff = ["symphonia/aiff", "symphonia/pcm"]
 
 [dev-dependencies]
 quickcheck = "0.9.2"


### PR DESCRIPTION
Add ALAC/AIFF playback support.

The change is just add the following feature flags that enable symphonia's feature flags.
"symphonia-alac" enable alac playback
"symphonia-aiff" enable aiff playback

- Why these flags are not added in "symphonia-all" feature?
  "symphonia/alac" and "symphonia/aiff" features are not enabled by default in symphonia.

Fix #193 