### PR TITLE
Allow retrieving the queue signal in a sink when using crossbeam-channel feature

### DIFF
--- a/src/conversions/sample.rs
+++ b/src/conversions/sample.rs
@@ -67,7 +67,7 @@ where
 /// - For `u16`, silence corresponds to the value `u16::max_value() / 2`. The minimum and maximum
 ///   amplitudes are represented by `0` and `u16::max_value()` respectively.
 /// - For `f32`, silence corresponds to the value `0.0`. The minimum and maximum amplitudes are
-///  represented by `-1.0` and `1.0` respectively.
+///   represented by `-1.0` and `1.0` respectively.
 ///
 /// You can implement this trait on your own type as well if you wish so.
 ///

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -112,7 +112,7 @@ impl Sink {
 
     /// Appends a sound to the queue of sounds to play
     ///
-    /// When using the feature flag `crossbeam-channel` in rodio the `crossbeam_channel::Receiver` will be returned when the sound has finished playing. 
+    /// When using the feature flag `crossbeam-channel` in rodio the `crossbeam_channel::Receiver` will be returned when the sound has finished playing.
     #[inline]
     pub fn append_with_signal<S>(&self, source: S) -> Option<Receiver<()>>
     where


### PR DESCRIPTION
Hi,
This commit creates a new `Sink::append_with_signal` method and make `Sink::append` a wrapper function without breaking change.
It only "works" with the `crossbeam-channel` feature flag because `crossbeam::channel::Receiver` implements `Clone` but not `std::sync::mpsc::Receiver` .
`append_with_signal` will be useful in case we have to do something at the end of a `Source` inside a `Sink`.