### PR TITLE
Optimistic update to controls.position in try_seek

### DIFF
--- a/src/sink.rs
+++ b/src/sink.rs
@@ -238,7 +238,10 @@ impl Sink {
         }
 
         match feedback.recv() {
-            Ok(seek_res) => seek_res,
+            Ok(seek_res) => {
+                *self.controls.position.lock().unwrap() = pos;
+                seek_res
+            },
             // The feedback channel closed. Probably another seekorder was set
             // invalidating this one and closing the feedback channel
             // ... or the audio thread panicked.


### PR DESCRIPTION
Hi! Big fan of Rodio here. I've been using it in a project of mine for about a month and absolutely love it. Thanks for maintaining it :heart: 

I'm using this change and it's working, but I haven't thoroughly tested it, nor deeply thought about possible side effects, and I'm pretty new to Rust... so I hope this PR isn't too bad :pray: 

The goal of this PR is that the following no longer happens:

```rs
let pos_a = sink.get_pos();
let target = pos_a + Duration::from_seconds(30);

sink.try_seek(target).unwrap();

let pos_b = sink.get_pos();
// At this point, pos_b is usually pos_a + ~5ms, not target

thread::sleep(Duration::from_millis(20)); // 20ms = arbitrary number, bigger than the hard-coded 5ms + some (exaggerated) room for imprecision.

let pos_b = sink.get_pos();
// At this point, pos_b is, roughly, target
```


With this PR, we won't need the `thread::sleep(Duration::from_millis(20));`. Since the `try_seek` blocks, `get_pos` should return the correct value immediately after calling `try_seek` (if it succeeds).

What comes to mind when I think of what this change could break is: is anything relying on `controls.position` not changing at all here? As far as I can see, we only read this value in `pub fn get_pos(&self)`, and don't do any math with it, so I guess it should be fine.

Maybe there could be a race condition here, if `periodic_access` happens to run after `TrackPosition.samples_counted` has been updated with the new position but before we get to run `*self.controls.position.lock().unwrap() = pos;`, or, more generally, if `Source.try_seek()` isn't in sync with `TrackPosition.next()`, in which case we'd overwrite the correct value with a less-correct one. But, even then, wouldn't that error be better than the current one?

Also now `try_seek` locks on `controls.position`, but I think all read/writes from/to it are pseudo-atomic (lock, read/write, release). I can't think of a way this could dead-lock, but I n ever did any professional work with threads.