### PR TITLE
Add Automatic Gain Control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Support for *ALAC/AIFF* 
+- Support for *ALAC/AIFF*
+- Add `automatic_gain_control` source for dynamic audio level adjustment.
 - New sources:
     - `fade_out` fades an input out using a linear gain fade.
     - `linear_gain_ramp` applies a linear gain change to a sound over a
       given duration. `fade_out` is implemented as a `linear_gain_ramp` and
-      `fade_in` has been refactored to use the `linear_gain_ramp` 
+      `fade_in` has been refactored to use the `linear_gain_ramp`
       implementation.
 
 ### Fixed
 - `Sink.try_seek` now updates `controls.position` before returning. Calls to `Sink.get_pos`
-  done immediately after a seek will now return the correct value.  
+  done immediately after a seek will now return the correct value.
 
 ### Changed
 - `SamplesBuffer` is now `Clone`
@@ -44,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Source` trait is now also implemented for `Box<dyn Source>` and `&mut Source`
 - `fn new_vorbis` is now also available when the `symphonia-vorbis` feature is enabled
 
-### Added 
+### Added
 - Adds a new method `try_seek` to all sources. It returns either an error or
   seeks to the given position. A few sources are "unsupported" they return the
   error `Unsupported`.
@@ -52,7 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - channel upscaling now follows the 'WAVEFORMATEXTENSIBLE' format and no longer
-  repeats the last source channel on all extra output channels. 
+  repeats the last source channel on all extra output channels.
   Stereo content playing on a 5.1 speaker set will now only use the front left
   and front right speaker instead of repeating the right sample on all speakers
   except the front left one.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ lewton = { version = "0.10", optional = true }
 minimp3_fixed = { version = "0.5.4", optional = true}
 symphonia = { version = "0.5.4", optional = true, default-features = false }
 crossbeam-channel = { version = "0.5.8", optional = true }
+atomic_float = "1.1.0"
 
 thiserror = "1.0.49"
 tracing = { version = "0.1.40", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,14 +17,16 @@ lewton = { version = "0.10", optional = true }
 minimp3_fixed = { version = "0.5.4", optional = true}
 symphonia = { version = "0.5.4", optional = true, default-features = false }
 crossbeam-channel = { version = "0.5.8", optional = true }
-atomic_float = "1.1.0"
 
 thiserror = "1.0.49"
 tracing = { version = "0.1.40", optional = true }
 
+atomic_float = { version = "1.1.0", optional = true }
+
 [features]
 default = ["flac", "vorbis", "wav", "mp3"]
 tracing = ["dep:tracing"]
+experimental = ["dep:atomic_float"]
 
 flac = ["claxon"]
 vorbis = ["lewton"]

--- a/benches/effects.rs
+++ b/benches/effects.rs
@@ -64,7 +64,6 @@ fn agc_enabled(bencher: Bencher) {
 }
 
 #[cfg(feature = "experimental")]
-// Do note you will need to pass --features experimental to run this benchmark
 #[divan::bench]
 fn agc_disabled(bencher: Bencher) {
     bencher

--- a/benches/effects.rs
+++ b/benches/effects.rs
@@ -54,10 +54,10 @@ fn agc(bencher: Bencher) {
         .bench_values(|source| {
             source
                 .automatic_gain_control(
-                    1.0,  // target_level
-                    2.0,  // attack_time (in seconds)
-                    0.01, // release_time (in seconds)
-                    5.0,  // absolute_max_gain
+                    1.0,   // target_level
+                    4.0,   // attack_time (in seconds)
+                    0.005, // release_time (in seconds)
+                    5.0,   // absolute_max_gain
                 )
                 .for_each(divan::black_box_drop)
         })

--- a/benches/effects.rs
+++ b/benches/effects.rs
@@ -63,6 +63,8 @@ fn agc_enabled(bencher: Bencher) {
         })
 }
 
+#[cfg(feature = "experimental")]
+// Do note you will need to pass --features experimental to run this benchmark
 #[divan::bench]
 fn agc_disabled(bencher: Bencher) {
     bencher

--- a/benches/effects.rs
+++ b/benches/effects.rs
@@ -46,3 +46,19 @@ fn amplify(bencher: Bencher) {
         .with_inputs(|| TestSource::music_wav().to_f32s())
         .bench_values(|source| source.amplify(0.8).for_each(divan::black_box_drop))
 }
+
+#[divan::bench]
+fn agc(bencher: Bencher) {
+    bencher
+        .with_inputs(|| TestSource::music_wav().to_f32s())
+        .bench_values(|source| {
+            source
+                .automatic_gain_control(
+                    1.0,  // target_level
+                    2.0,  // attack_time (in seconds)
+                    0.01, // release_time (in seconds)
+                    5.0,  // absolute_max_gain
+                )
+                .for_each(divan::black_box_drop)
+        })
+}

--- a/src/conversions/sample.rs
+++ b/src/conversions/sample.rs
@@ -80,6 +80,9 @@ pub trait Sample: CpalSample {
     /// Multiplies the value of this sample by the given amount.
     fn amplify(self, value: f32) -> Self;
 
+    /// Converts the sample to an f32 value.
+    fn to_f32(self) -> f32;
+
     /// Calls `saturating_add` on the sample.
     fn saturating_add(self, other: Self) -> Self;
 
@@ -100,6 +103,12 @@ impl Sample for u16 {
     #[inline]
     fn amplify(self, value: f32) -> u16 {
         ((self as f32) * value) as u16
+    }
+
+    #[inline]
+    fn to_f32(self) -> f32 {
+        // Convert u16 to f32 in the range [-1.0, 1.0]
+        (self as f32 - 32768.0) / 32768.0
     }
 
     #[inline]
@@ -126,6 +135,12 @@ impl Sample for i16 {
     }
 
     #[inline]
+    fn to_f32(self) -> f32 {
+        // Convert i16 to f32 in the range [-1.0, 1.0]
+        self as f32 / 32768.0
+    }
+
+    #[inline]
     fn saturating_add(self, other: i16) -> i16 {
         self.saturating_add(other)
     }
@@ -145,6 +160,12 @@ impl Sample for f32 {
     #[inline]
     fn amplify(self, value: f32) -> f32 {
         self * value
+    }
+
+    #[inline]
+    fn to_f32(self) -> f32 {
+        // f32 is already in the correct format
+        self
     }
 
     #[inline]

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -221,10 +221,10 @@ impl Sink {
     ///
     /// # Errors
     /// This function will return [`SeekError::NotSupported`] if one of the underlying
-    /// sources does not support seeking.  
+    /// sources does not support seeking.
     ///
     /// It will return an error if an implementation ran
-    /// into one during the seek.  
+    /// into one during the seek.
     ///
     /// When seeking beyond the end of a source this
     /// function might return an error if the duration of the source is not known.

--- a/src/source/agc.rs
+++ b/src/source/agc.rs
@@ -59,6 +59,10 @@ pub struct AutomaticGainControl<I> {
 }
 
 #[cfg(not(feature = "experimental"))]
+/// Automatic Gain Control filter for maintaining consistent output levels.
+///
+/// This struct implements an AGC algorithm that dynamically adjusts audio levels
+/// based on both **peak** and **RMS** (Root Mean Square) measurements.
 #[derive(Clone, Debug)]
 pub struct AutomaticGainControl<I> {
     input: I,

--- a/src/source/agc.rs
+++ b/src/source/agc.rs
@@ -1,3 +1,17 @@
+//
+//      Automatic Gain Control (AGC) Algorithm
+//      Designed by @UnknownSuperficialNight
+//
+//   Features:
+//   • Adaptive peak detection
+//   • RMS-based level estimation
+//   • Asymmetric attack/release
+//
+//   Optimized for smooth and responsive gain control
+//
+//   Crafted with love. Enjoy! :)
+//
+
 use super::SeekError;
 use crate::{Sample, Source};
 use std::time::Duration;

--- a/src/source/agc.rs
+++ b/src/source/agc.rs
@@ -16,6 +16,9 @@ use super::SeekError;
 use crate::{Sample, Source};
 use std::time::Duration;
 
+#[cfg(feature = "tracing")]
+use tracing;
+
 /// Constructs an `AutomaticGainControl` object with specified parameters.
 ///
 /// # Arguments
@@ -224,12 +227,9 @@ where
             // Ensure the calculated gain stays within the defined operational range
             self.current_gain = self.current_gain.clamp(0.1, self.absolute_max_gain);
 
-            // Output current gain value for monitoring and debugging purposes
-            // Must be deleted before merge:
-            // Added flag so its usable without the debug temporarily during development
-            if std::env::args().any(|arg| arg == "--debug-gain") {
-                println!("Current gain: {}", self.current_gain);
-            }
+            // Output current gain value for developers to fine tune their inputs to automatic_gain_control
+            #[cfg(feature = "tracing")]
+            tracing::debug!("AGC gain: {}", self.current_gain);
 
             // Apply the computed gain to the input sample and return the result
             value.amplify(self.current_gain)

--- a/src/source/agc.rs
+++ b/src/source/agc.rs
@@ -74,6 +74,7 @@ pub struct AutomaticGainControl<I> {
     min_attack_coeff: f32,
     peak_level: f32,
     rms_window: CircularBuffer,
+    is_enabled: bool,
 }
 
 /// A circular buffer for efficient RMS calculation over a sliding window.
@@ -174,6 +175,7 @@ where
             min_attack_coeff: release_time,
             peak_level: 0.0,
             rms_window: CircularBuffer::new(),
+            is_enabled: true,
         }
     }
 }
@@ -239,7 +241,7 @@ where
         }
         #[cfg(not(feature = "experimental"))]
         {
-            true
+            self.is_enabled
         }
     }
 
@@ -293,6 +295,16 @@ where
     #[inline]
     pub fn get_agc_control(&self) -> Arc<AtomicBool> {
         Arc::clone(&self.is_enabled)
+    }
+
+    #[cfg(not(feature = "experimental"))]
+    /// Enable or disable AGC processing.
+    ///
+    /// Use this to enable or disable AGC processing.
+    /// Useful for comparing processed and unprocessed audio or for disabling/enabling AGC.
+    #[inline]
+    pub fn set_enabled(&mut self, enabled: bool) {
+        self.is_enabled = enabled;
     }
 
     /// Updates the peak level with an adaptive attack coefficient

--- a/src/source/agc.rs
+++ b/src/source/agc.rs
@@ -23,9 +23,18 @@ use std::time::Duration;
 #[cfg(feature = "tracing")]
 use tracing;
 
+// Ensures RMS_WINDOW_SIZE is a power of two
+const fn power_of_two(n: usize) -> usize {
+    assert!(
+        n.is_power_of_two(),
+        "RMS_WINDOW_SIZE must be a power of two"
+    );
+    n
+}
+
 /// Size of the circular buffer used for RMS calculation.
 /// A larger size provides more stable RMS values but increases latency.
-const RMS_WINDOW_SIZE: usize = 8192;
+const RMS_WINDOW_SIZE: usize = power_of_two(8192);
 
 /// Automatic Gain Control filter for maintaining consistent output levels.
 ///

--- a/src/source/agc.rs
+++ b/src/source/agc.rs
@@ -1,0 +1,175 @@
+use super::SeekError;
+use crate::{Sample, Source};
+use std::time::Duration;
+
+/// Constructs an `AutomaticGainControl` object with specified parameters.
+///
+/// # Arguments
+///
+/// * `input` - The input audio source
+/// * `target_level` - The desired output level
+/// * `attack_time` - Time constant for gain adjustment
+/// * `absolute_max_gain` - Maximum allowable gain
+pub fn automatic_gain_control<I>(
+    input: I,
+    target_level: f32,
+    attack_time: f32,
+    absolute_max_gain: f32,
+) -> AutomaticGainControl<I>
+where
+    I: Source,
+    I::Item: Sample,
+{
+    let sample_rate = input.sample_rate();
+
+    AutomaticGainControl {
+        input,
+        target_level,
+        absolute_max_gain,
+        current_gain: 1.0,
+        attack_coeff: (-1.0 / (attack_time * sample_rate as f32)).exp(),
+        peak_level: 0.0,
+        rms_level: 0.0,
+        rms_window: vec![0.0; 1024],
+        rms_index: 0,
+    }
+}
+
+/// Automatic Gain Control filter for maintaining consistent output levels.
+#[derive(Clone, Debug)]
+pub struct AutomaticGainControl<I> {
+    input: I,
+    target_level: f32,
+    absolute_max_gain: f32,
+    current_gain: f32,
+    attack_coeff: f32,
+    peak_level: f32,
+    rms_level: f32,
+    rms_window: Vec<f32>,
+    rms_index: usize,
+}
+
+impl<I> AutomaticGainControl<I>
+where
+    I: Source,
+    I::Item: Sample,
+{
+    // Sets a new target output level.
+    #[inline]
+    pub fn set_target_level(&mut self, level: f32) {
+        self.target_level = level;
+    }
+
+    // Add this method to allow changing the attack coefficient
+    pub fn set_attack_coeff(&mut self, attack_time: f32) {
+        let sample_rate = self.input.sample_rate();
+        self.attack_coeff = (-1.0 / (attack_time * sample_rate as f32)).exp();
+    }
+}
+
+impl<I> Iterator for AutomaticGainControl<I>
+where
+    I: Source,
+    I::Item: Sample,
+{
+    type Item = I::Item;
+
+    #[inline]
+    fn next(&mut self) -> Option<I::Item> {
+        self.input.next().map(|value| {
+            let sample_value = value.to_f32().abs();
+
+            // Update peak level with adaptive attack coefficient
+            let attack_coeff = if sample_value > self.peak_level {
+                self.attack_coeff.min(0.1) // Faster response to sudden increases
+            } else {
+                self.attack_coeff
+            };
+            self.peak_level = attack_coeff * self.peak_level + (1.0 - attack_coeff) * sample_value;
+
+            // Update RMS level using a sliding window
+            self.rms_level -= self.rms_window[self.rms_index] / self.rms_window.len() as f32;
+            self.rms_window[self.rms_index] = sample_value * sample_value;
+            self.rms_level += self.rms_window[self.rms_index] / self.rms_window.len() as f32;
+            self.rms_index = (self.rms_index + 1) % self.rms_window.len();
+
+            let rms = self.rms_level.sqrt();
+
+            // Calculate gain adjustments based on peak and RMS levels
+            let peak_gain = if self.peak_level > 0.0 {
+                self.target_level / self.peak_level
+            } else {
+                1.0
+            };
+
+            let rms_gain = if rms > 0.0 {
+                self.target_level / rms
+            } else {
+                1.0
+            };
+
+            // Choose the more conservative gain adjustment
+            let desired_gain = peak_gain.min(rms_gain);
+
+            // Set target gain to the middle of the allowable range
+            let target_gain = 1.0; // Midpoint between 0.1 and 3.0
+
+            // Smoothly adjust current gain towards the target
+            let adjustment_speed = 0.05; // Balance between responsiveness and stability
+            self.current_gain = self.current_gain * (1.0 - adjustment_speed)
+                + (desired_gain * target_gain) * adjustment_speed;
+
+            // Constrain gain within predefined limits
+            self.current_gain = self.current_gain.clamp(0.1, self.absolute_max_gain);
+
+            // Uncomment for debugging:
+            println!("Current gain: {}", self.current_gain);
+
+            // Apply calculated gain to the sample
+            value.amplify(self.current_gain)
+        })
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.input.size_hint()
+    }
+}
+
+impl<I> ExactSizeIterator for AutomaticGainControl<I>
+where
+    I: Source + ExactSizeIterator,
+    I::Item: Sample,
+{
+}
+
+impl<I> Source for AutomaticGainControl<I>
+where
+    I: Source,
+    I::Item: Sample,
+{
+    #[inline]
+    fn current_frame_len(&self) -> Option<usize> {
+        self.input.current_frame_len()
+    }
+
+    #[inline]
+    fn channels(&self) -> u16 {
+        self.input.channels()
+    }
+
+    #[inline]
+    fn sample_rate(&self) -> u32 {
+        self.input.sample_rate()
+    }
+
+    #[inline]
+    fn total_duration(&self) -> Option<Duration> {
+        self.input.total_duration()
+    }
+
+    #[inline]
+    fn try_seek(&mut self, pos: Duration) -> Result<(), SeekError> {
+        self.input.try_seek(pos)
+    }
+}

--- a/src/source/agc.rs
+++ b/src/source/agc.rs
@@ -19,6 +19,7 @@ use crate::{Sample, Source};
 use atomic_float::AtomicF32;
 #[cfg(feature = "experimental")]
 use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(feature = "experimental")]
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/src/source/agc.rs
+++ b/src/source/agc.rs
@@ -176,7 +176,10 @@ where
 
             // Output current gain value for monitoring and debugging purposes
             // Must be deleted before merge:
-            println!("Current gain: {}", self.current_gain);
+            // Added flag so its usable without the debug temporarily during development
+            if std::env::args().any(|arg| arg == "--debug-gain") {
+                println!("Current gain: {}", self.current_gain);
+            }
 
             // Apply the computed gain to the input sample and return the result
             value.amplify(self.current_gain)

--- a/src/source/agc.rs
+++ b/src/source/agc.rs
@@ -165,13 +165,13 @@ where
     ///
     /// This method adjusts the peak level using a variable attack coefficient.
     /// It responds faster to sudden increases in signal level by using a
-    /// minimum attack coefficient of MIN_ATTACK_COEFF when the sample value exceeds the
+    /// minimum attack coefficient of min_attack_coeff when the sample value exceeds the
     /// current peak level. This adaptive behavior helps capture transients
     /// more accurately while maintaining smoother behavior for gradual changes.
     #[inline]
-    fn update_peak_level(&mut self, sample_value: f32, release_time: f32) {
+    fn update_peak_level(&mut self, sample_value: f32) {
         let attack_coeff = if sample_value > self.peak_level {
-            self.attack_coeff.min(release_time) // Faster response to sudden increases
+            self.attack_coeff.min(self.min_attack_coeff) // User-defined attack time limited via release_time
         } else {
             self.release_coeff
         };
@@ -216,7 +216,7 @@ where
             let sample_value = value.to_f32().abs();
 
             // Dynamically adjust peak level using an adaptive attack coefficient
-            self.update_peak_level(sample_value, self.min_attack_coeff);
+            self.update_peak_level(sample_value);
 
             // Calculate the current RMS (Root Mean Square) level using a sliding window approach
             let rms = self.update_rms(sample_value);

--- a/src/source/agc.rs
+++ b/src/source/agc.rs
@@ -28,9 +28,6 @@ const RMS_WINDOW_SIZE: usize = 1024;
 /// Balances between responsiveness and stability.
 const MIN_ATTACK_COEFF: f32 = 0.05;
 
-/// Maximum allowed peak level to prevent clipping
-const MAX_PEAK_LEVEL: f32 = 0.99;
-
 /// Automatic Gain Control filter for maintaining consistent output levels.
 ///
 /// This struct implements an AGC algorithm that dynamically adjusts audio levels
@@ -186,7 +183,7 @@ where
     #[inline]
     fn calculate_peak_gain(&self) -> f32 {
         if self.peak_level > 0.0 {
-            (MAX_PEAK_LEVEL / self.peak_level).min(self.absolute_max_gain)
+            (self.target_level / self.peak_level).min(self.absolute_max_gain)
         } else {
             self.absolute_max_gain
         }

--- a/src/source/agc.rs
+++ b/src/source/agc.rs
@@ -59,6 +59,7 @@ impl CircularBuffer {
     /// Creates a new CircularBuffer with a fixed size determined at compile time.
     ///
     /// The `_size` parameter is ignored as the buffer size is set by `RMS_WINDOW_SIZE`.
+    #[inline]
     fn new(_size: usize) -> Self {
         CircularBuffer {
             buffer: [0.0; RMS_WINDOW_SIZE],
@@ -70,6 +71,7 @@ impl CircularBuffer {
     /// Pushes a new value into the buffer and returns the old value.
     ///
     /// This method maintains a running sum for efficient mean calculation.
+    #[inline]
     fn push(&mut self, value: f32) -> f32 {
         let old_value = self.buffer[self.index];
         self.buffer[self.index] = value;
@@ -81,6 +83,7 @@ impl CircularBuffer {
     /// Calculates the mean of all values in the buffer.
     ///
     /// This operation is O(1) due to the maintained running sum.
+    #[inline]
     fn mean(&self) -> f32 {
         self.sum / self.buffer.len() as f32
     }
@@ -95,6 +98,7 @@ impl CircularBuffer {
 /// * `attack_time` - Time constant for gain increase
 /// * `release_time` - Time constant for gain decrease
 /// * `absolute_max_gain` - Maximum allowable gain
+#[inline]
 pub fn automatic_gain_control<I>(
     input: I,
     target_level: f32,

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -241,17 +241,17 @@ where
     ///
     /// # Parameters
     ///
-    /// * `target_level`:
-    ///   TL;DR: Desired output level. 1.0 = original level, > 1.0 amplifies, < 1.0 reduces.
+    ///* `target_level`:
+    ///   **TL;DR**: Desired output level. 1.0 = original level, > 1.0 amplifies, < 1.0 reduces.
     ///
     ///   The desired output level, where 1.0 represents the original sound level.
     ///   Values above 1.0 will amplify the sound, while values below 1.0 will lower it.
     ///   For example, a target_level of 1.4 means that at normal sound levels, the AGC
     ///   will aim to increase the gain by a factor of 1.4, resulting in a minimum 40% amplification.
-    ///   A recommended level is 1.0, which maintains the original sound level.
+    ///   A recommended level is `1.0`, which maintains the original sound level.
     ///
-    /// * `attack_time`:
-    ///   TL;DR: Response time for volume increases. Shorter = faster but may cause abrupt changes. Recommended: 2.0 seconds.
+    ///* `attack_time`:
+    ///   **TL;DR**: Response time for volume increases. Shorter = faster but may cause abrupt changes. **Recommended: `4.0` seconds**.
     ///
     ///   The time (in seconds) for the AGC to respond to input level increases.
     ///   Shorter times mean faster response but may cause abrupt changes. Longer times result
@@ -260,10 +260,10 @@ where
     ///   AGC miss important volume changes or react too slowly to sudden loud passages. Very
     ///   high values might result in excessively loud output or sluggish response, as the AGC's
     ///   adjustment speed is limited by the attack time. Balance is key for optimal performance.
-    ///   A recommended attack_time of 2.0 seconds provides a sweet spot for most applications.
+    ///   A recommended attack_time of `4.0` seconds provides a sweet spot for most applications.
     ///
-    /// * `release_time`:
-    ///   TL;DR: Response time for volume decreases. Shorter = faster gain reduction. Recommended: 0.01 seconds.
+    ///* `release_time`:
+    ///   **TL;DR**: Response time for volume decreases. Shorter = faster gain reduction. **Recommended: `0.005` seconds**.
     ///
     ///   The time (in seconds) for the AGC to respond to input level decreases.
     ///   This parameter controls how quickly the gain is reduced when the signal level drops.
@@ -273,18 +273,18 @@ where
     ///   However, if the release_time is too high, the AGC may not be able to lower the gain
     ///   quickly enough, potentially leading to clipping and distorted sound before it can adjust.
     ///   Finding the right balance is crucial for maintaining natural-sounding dynamics and
-    ///   preventing distortion. A recommended release_time of 0.01 seconds often works well for
+    ///   preventing distortion. A recommended release_time of `0.005` seconds often works well for
     ///   general use, providing a good balance between responsiveness and smooth transitions.
     ///
-    /// * `absolute_max_gain`:
-    ///   TL;DR: Maximum allowed gain. Prevents over-amplification. Recommended: 4.0.
+    ///* `absolute_max_gain`:
+    ///   **TL;DR**: Maximum allowed gain. Prevents over-amplification. **Recommended: `5.0`**.
     ///
     ///   The maximum gain that can be applied to the signal.
     ///   This parameter acts as a safeguard against excessive amplification of quiet signals
     ///   or background noise. It establishes an upper boundary for the AGC's signal boost,
     ///   effectively preventing distortion or overamplification of low-level sounds.
     ///   This is crucial for maintaining audio quality and preventing unexpected volume spikes.
-    ///   A recommended value for `absolute_max_gain` is 4, which provides a good balance between
+    ///   A recommended value for `absolute_max_gain` is `5`, which provides a good balance between
     ///   amplification capability and protection against distortion in most scenarios.
     #[inline]
     fn automatic_gain_control(

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -241,15 +241,28 @@ where
     ///
     /// # Parameters
     ///
-    /// * `target_level`: The desired output level, typically between 0.9 and 1.0.
-    ///   This is the level that the AGC will try to maintain.
+    /// * `target_level`: The desired output level, where 1.0 represents the original sound level.
+    ///   Values above 1.0 will amplify the sound, while values below 1.0 will lower it.
+    ///   For example, a target_level of 1.4 means that at normal sound levels, the AGC
+    ///   will aim to increase the gain by a factor of 1.4, resulting in a minimum 40% amplification.
+    ///   A recommended level is 1.0, which maintains the original sound level.
     ///
-    /// * `attack_time`: The time (in seconds) it takes for the AGC to respond to
-    ///   an increase in input level. A shorter attack time means faster response
-    ///   but may lead to more abrupt changes.
+    /// * `attack_time`: The time (in seconds) for the AGC to respond to input level increases.
+    ///   Shorter times mean faster response but may cause abrupt changes. Longer times result
+    ///   in smoother transitions but slower reactions to sudden volume changes. Too short can
+    ///   lead to overreaction to peaks, causing unnecessary adjustments. Too long can make the
+    ///   AGC miss important volume changes or react too slowly to sudden loud passages. Very
+    ///   high values might result in excessively loud output or sluggish response, as the AGC's
+    ///   adjustment speed is limited by the attack time. Balance is key for optimal performance.
+    ///   A recommended attack_time of 2.0 seconds provides a sweet spot for most applications.
     ///
     /// * `absolute_max_gain`: The maximum gain that can be applied to the signal.
-    ///   This prevents excessive amplification of quiet signals or background noise.
+    ///   This parameter acts as a safeguard against excessive amplification of quiet signals
+    ///   or background noise. It establishes an upper boundary for the AGC's signal boost,
+    ///   effectively preventing distortion or overamplification of low-level sounds.
+    ///   This is crucial for maintaining audio quality and preventing unexpected volume spikes.
+    ///   A recommended value for `absolute_max_gain` is 4, which provides a good balance between
+    ///   amplification capability and protection against distortion in most scenarios.
     #[inline]
     fn automatic_gain_control(
         self,

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -6,6 +6,7 @@ use cpal::FromSample;
 
 use crate::Sample;
 
+pub use self::agc::AutomaticGainControl;
 pub use self::amplify::Amplify;
 pub use self::blt::BltFilter;
 pub use self::buffered::Buffered;
@@ -36,6 +37,7 @@ pub use self::take::TakeDuration;
 pub use self::uniform::UniformSourceIterator;
 pub use self::zero::Zero;
 
+mod agc;
 mod amplify;
 mod blt;
 mod buffered;
@@ -230,6 +232,20 @@ where
         Self: Sized,
     {
         amplify::amplify(self, value)
+    }
+
+    /// Applies automatic gain control to the sound.
+    #[inline]
+    fn automatic_gain_control(
+        self,
+        target_level: f32,
+        attack_time: f32,
+        absolute_max_gain: f32,
+    ) -> AutomaticGainControl<Self>
+    where
+        Self: Sized,
+    {
+        agc::automatic_gain_control(self, target_level, attack_time, absolute_max_gain)
     }
 
     /// Mixes this sound fading out with another sound fading in for the given duration.
@@ -445,7 +461,7 @@ where
     /// sources does not support seeking.
     ///
     /// It will return an error if an implementation ran
-    /// into one during the seek.  
+    /// into one during the seek.
     ///
     /// Seeking beyond the end of a source might return an error if the total duration of
     /// the source is not known.

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -241,7 +241,7 @@ where
     ///
     /// # Parameters
     ///
-    ///* `target_level`:
+    /// `target_level`:
     ///   **TL;DR**: Desired output level. 1.0 = original level, > 1.0 amplifies, < 1.0 reduces.
     ///
     ///   The desired output level, where 1.0 represents the original sound level.
@@ -250,7 +250,7 @@ where
     ///   will aim to increase the gain by a factor of 1.4, resulting in a minimum 40% amplification.
     ///   A recommended level is `1.0`, which maintains the original sound level.
     ///
-    ///* `attack_time`:
+    /// `attack_time`:
     ///   **TL;DR**: Response time for volume increases. Shorter = faster but may cause abrupt changes. **Recommended: `4.0` seconds**.
     ///
     ///   The time (in seconds) for the AGC to respond to input level increases.
@@ -262,7 +262,7 @@ where
     ///   adjustment speed is limited by the attack time. Balance is key for optimal performance.
     ///   A recommended attack_time of `4.0` seconds provides a sweet spot for most applications.
     ///
-    ///* `release_time`:
+    /// `release_time`:
     ///   **TL;DR**: Response time for volume decreases. Shorter = faster gain reduction. **Recommended: `0.005` seconds**.
     ///
     ///   The time (in seconds) for the AGC to respond to input level decreases.
@@ -276,7 +276,7 @@ where
     ///   preventing distortion. A recommended release_time of `0.005` seconds often works well for
     ///   general use, providing a good balance between responsiveness and smooth transitions.
     ///
-    ///* `absolute_max_gain`:
+    /// `absolute_max_gain`:
     ///   **TL;DR**: Maximum allowed gain. Prevents over-amplification. **Recommended: `5.0`**.
     ///
     ///   The maximum gain that can be applied to the signal.

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -260,6 +260,10 @@ where
     where
         Self: Sized,
     {
+        // Added Limits to prevent the AGC from blowing up. ;)
+        const MIN_ATTACK_TIME: f32 = 10.0;
+        let attack_time = attack_time.min(MIN_ATTACK_TIME);
+
         agc::automatic_gain_control(self, target_level, attack_time, absolute_max_gain)
     }
 

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -286,6 +286,27 @@ where
     ///   This is crucial for maintaining audio quality and preventing unexpected volume spikes.
     ///   A recommended value for `absolute_max_gain` is `5`, which provides a good balance between
     ///   amplification capability and protection against distortion in most scenarios.
+    ///
+    /// Use `get_agc_control` to obtain a handle for real-time enabling/disabling of the AGC.
+    ///
+    /// # Example (Quick start)
+    ///
+    /// ```rust
+    /// // Apply Automatic Gain Control to the source (AGC is on by default)
+    /// let agc_source = source.automatic_gain_control(1.0, 4.0, 0.005, 5.0);
+    ///
+    /// // Get a handle to control the AGC's enabled state (optional)
+    /// let agc_control = agc_source.get_agc_control();
+    ///
+    /// // You can toggle AGC on/off at any time (optional)
+    /// agc_control.store(false, std::sync::atomic::Ordering::Relaxed);
+    ///
+    /// // Add the AGC-controlled source to the sink
+    /// sink.append(agc_source);
+    ///
+    /// // Note: Using agc_control is optional. If you don't need to toggle AGC,
+    /// // you can simply use the agc_source directly without getting agc_control.
+    /// ```
     #[inline]
     fn automatic_gain_control(
         self,

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -235,6 +235,21 @@ where
     }
 
     /// Applies automatic gain control to the sound.
+    ///
+    /// Automatic Gain Control (AGC) adjusts the amplitude of the audio signal
+    /// to maintain a consistent output level.
+    ///
+    /// # Parameters
+    ///
+    /// * `target_level`: The desired output level, typically between 0.9 and 1.0.
+    ///   This is the level that the AGC will try to maintain.
+    ///
+    /// * `attack_time`: The time (in seconds) it takes for the AGC to respond to
+    ///   an increase in input level. A shorter attack time means faster response
+    ///   but may lead to more abrupt changes.
+    ///
+    /// * `absolute_max_gain`: The maximum gain that can be applied to the signal.
+    ///   This prevents excessive amplification of quiet signals or background noise.
     #[inline]
     fn automatic_gain_control(
         self,

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -241,13 +241,19 @@ where
     ///
     /// # Parameters
     ///
-    /// * `target_level`: The desired output level, where 1.0 represents the original sound level.
+    /// * `target_level`:
+    ///   TL;DR: Desired output level. 1.0 = original level, > 1.0 amplifies, < 1.0 reduces.
+    ///
+    ///   The desired output level, where 1.0 represents the original sound level.
     ///   Values above 1.0 will amplify the sound, while values below 1.0 will lower it.
     ///   For example, a target_level of 1.4 means that at normal sound levels, the AGC
     ///   will aim to increase the gain by a factor of 1.4, resulting in a minimum 40% amplification.
     ///   A recommended level is 1.0, which maintains the original sound level.
     ///
-    /// * `attack_time`: The time (in seconds) for the AGC to respond to input level increases.
+    /// * `attack_time`:
+    ///   TL;DR: Response time for volume increases. Shorter = faster but may cause abrupt changes. Recommended: 2.0 seconds.
+    ///
+    ///   The time (in seconds) for the AGC to respond to input level increases.
     ///   Shorter times mean faster response but may cause abrupt changes. Longer times result
     ///   in smoother transitions but slower reactions to sudden volume changes. Too short can
     ///   lead to overreaction to peaks, causing unnecessary adjustments. Too long can make the
@@ -256,7 +262,24 @@ where
     ///   adjustment speed is limited by the attack time. Balance is key for optimal performance.
     ///   A recommended attack_time of 2.0 seconds provides a sweet spot for most applications.
     ///
-    /// * `absolute_max_gain`: The maximum gain that can be applied to the signal.
+    /// * `release_time`:
+    ///   TL;DR: Response time for volume decreases. Shorter = faster gain reduction. Recommended: 0.01 seconds.
+    ///
+    ///   The time (in seconds) for the AGC to respond to input level decreases.
+    ///   This parameter controls how quickly the gain is reduced when the signal level drops.
+    ///   Shorter release times result in faster gain reduction, which can be useful for quick
+    ///   adaptation to quieter passages but may lead to pumping effects. Longer release times
+    ///   provide smoother transitions but may be slower to respond to sudden decreases in volume.
+    ///   However, if the release_time is too high, the AGC may not be able to lower the gain
+    ///   quickly enough, potentially leading to clipping and distorted sound before it can adjust.
+    ///   Finding the right balance is crucial for maintaining natural-sounding dynamics and
+    ///   preventing distortion. A recommended release_time of 0.01 seconds often works well for
+    ///   general use, providing a good balance between responsiveness and smooth transitions.
+    ///
+    /// * `absolute_max_gain`:
+    ///   TL;DR: Maximum allowed gain. Prevents over-amplification. Recommended: 4.0.
+    ///
+    ///   The maximum gain that can be applied to the signal.
     ///   This parameter acts as a safeguard against excessive amplification of quiet signals
     ///   or background noise. It establishes an upper boundary for the AGC's signal boost,
     ///   effectively preventing distortion or overamplification of low-level sounds.
@@ -268,6 +291,7 @@ where
         self,
         target_level: f32,
         attack_time: f32,
+        release_time: f32,
         absolute_max_gain: f32,
     ) -> AutomaticGainControl<Self>
     where
@@ -275,9 +299,17 @@ where
     {
         // Added Limits to prevent the AGC from blowing up. ;)
         const MIN_ATTACK_TIME: f32 = 10.0;
+        const MIN_RELEASE_TIME: f32 = 10.0;
         let attack_time = attack_time.min(MIN_ATTACK_TIME);
+        let release_time = release_time.min(MIN_RELEASE_TIME);
 
-        agc::automatic_gain_control(self, target_level, attack_time, absolute_max_gain)
+        agc::automatic_gain_control(
+            self,
+            target_level,
+            attack_time,
+            release_time,
+            absolute_max_gain,
+        )
     }
 
     /// Mixes this sound fading out with another sound fading in for the given duration.


### PR DESCRIPTION
Implemented automatic gain control (AGC)

I implemented a [to_f32](https://github.com/UnknownSuperficialNight/rodio/blob/feature/automatic-gain-control/src/conversions/sample.rs#L83C1-L84C28) conversion for the sample as it was missing. I'm not entirely certain if this is optimal, so I welcome feedback on the implementation.

This pull request is in relation to. Closes #620 

**Here is my `main.rs` and `Cargo.toml` i used to test while developing:**
```rust
use rodio::source::Source;
use rodio::{Decoder, OutputStream, Sink};
use std::fs::File;
use std::io::BufReader;

fn main() {
    // Get a output stream handle to the default physical sound device
    let (_stream, stream_handle) = OutputStream::try_default().unwrap();
    // Create a sink
    let sink = Sink::try_new(&stream_handle).unwrap();

    // Load a sound from a file, using a path relative to Cargo.toml
    let file =
        BufReader::new(File::open(env!("CARGO_MANIFEST_DIR").to_owned() + "/OOTW.mp3").unwrap());
    // Decode that sound file into a source
    let source = Decoder::new(file).unwrap();

    // Amplify the source
    let amplified_source = source.automatic_gain_control(1.0, 0.3, 3.0);

    // Add the amplified source to the sink
    sink.append(amplified_source);

    // The sound plays in a separate thread.
    sink.sleep_until_end();
}
```

```rust
[workspace]
members = [".", "rodio"]

[package]
name = "test_area"
version = "0.1.0"
edition = "2021"

[dependencies]
rodio = { path = "rodio" }
```


Id suggest an attack_time of around 0.5 to 2.5 that seems to be a sweet spot for songs I tested.
~~Also, target_level I adjusted to be 0.9 just to make sure it does not clip the audio; it was clipping for me at 1.0.~~

Don't know where to write documentation or if I should be the one writing it. Idk, let me know; thanks :)