### PR TITLE
Issue#628: Fix total_duration malfunction after speed mutation

### DIFF
--- a/src/source/speed.rs
+++ b/src/source/speed.rs
@@ -93,7 +93,7 @@ where
 
     #[inline]
     fn total_duration(&self) -> Option<Duration> {
-        self.input.total_duration().map(|d| d.mul_f32(self.factor))
+        self.input.total_duration().map(|d| d.div_f32(self.factor))
     }
 
     #[inline]

--- a/src/source/speed.rs
+++ b/src/source/speed.rs
@@ -98,11 +98,6 @@ where
 
     #[inline]
     fn try_seek(&mut self, pos: Duration) -> Result<(), SeekError> {
-        /* TODO: This might be wrong, I do not know how speed achieves its speedup
-         * so I can not reason about the correctness.
-         * <dvdsk noreply@davidsk.dev> */
-
-        // even after 24 hours of playback f32 has enough precision
         let pos_accounting_for_speedup = pos.mul_f32(self.factor);
         self.input.try_seek(pos_accounting_for_speedup)
     }


### PR DESCRIPTION
-- updated the speed struct function total_duration to divide instead of multiply by speed factor
-- removed redundant comment on try_seek function in the speed.rs file #628 