### PR TITLE
Add AGC example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,3 +67,7 @@ required-features = ["symphonia-isomp4", "symphonia-aac"]
 [[example]]
 name = "noise_generator"
 required-features = ["noise"]
+
+[[example]]
+name = "automatic_gain_control"
+required-features = ["dep:atomic_float"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,4 +70,4 @@ required-features = ["noise"]
 
 [[example]]
 name = "automatic_gain_control"
-required-features = ["dep:atomic_float"]
+required-features = ["atomic_float"]

--- a/examples/automatic_gain_control.rs
+++ b/examples/automatic_gain_control.rs
@@ -16,12 +16,10 @@ fn main() {
     let agc_source = source.automatic_gain_control(1.0, 4.0, 0.005, 5.0);
 
     // Get a handle to control the AGC's enabled state (only when using experimental feature)
-    #[cfg(feature = "experimental")]
     let agc_control = agc_source.get_agc_control();
 
     // Disable AGC by default when using experimental feature
-    #[cfg(feature = "experimental")]
-    agc_control.store(false, std::sync::atomic::Ordering::Relaxed);
+    agc_control.store(true, std::sync::atomic::Ordering::Relaxed);
 
     // Add the AGC-processed source to the sink for playback
     sink.append(agc_source);

--- a/examples/automatic_gain_control.rs
+++ b/examples/automatic_gain_control.rs
@@ -1,0 +1,31 @@
+use rodio::source::Source;
+use rodio::Decoder;
+use std::fs::File;
+use std::io::BufReader;
+
+fn main() {
+    let (_stream, handle) = rodio::OutputStream::try_default().unwrap();
+    let sink = rodio::Sink::try_new(&handle).unwrap();
+
+    let file = BufReader::new(File::open("assets/music.flac").unwrap());
+
+    // Decode the sound file into a source
+    let source = Decoder::new(file).unwrap();
+
+    // Apply automatic gain control to the source
+    let agc_source = source.automatic_gain_control(1.0, 4.0, 0.005, 5.0);
+
+    // Get a handle to control the AGC's enabled state (only when using experimental feature)
+    #[cfg(feature = "experimental")]
+    let agc_control = agc_source.get_agc_control();
+
+    // Disable AGC by default when using experimental feature
+    #[cfg(feature = "experimental")]
+    agc_control.store(false, std::sync::atomic::Ordering::Relaxed);
+
+    // Add the AGC-processed source to the sink for playback
+    sink.append(agc_source);
+
+    // Keep the program running until playback is complete
+    sink.sleep_until_end();
+}


### PR DESCRIPTION
Here is a quick AGC example

I don't know how to use set_enabled() outside the setup area, so I'm using the experimental atomicbool

close #629