### PR TITLE
Test fixes, upgrade quickcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,10 @@ jobs:
         if: matrix.toolchain == 'stable' && matrix.os == 'ubuntu-latest'
 
       - run: cargo test --all-targets
-      - run: cargo test --features=symphonia-all --all-targets
+      - run: cargo test --all-targets --features=experimental
+      - run: cargo test --all-targets --features=symphonia-all
+      - run: cargo test --doc
+      - run: cargo test --doc --features=experimental
   cargo-publish:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ symphonia-alac = ["symphonia/isomp4", "symphonia/alac"]
 symphonia-aiff = ["symphonia/aiff", "symphonia/pcm"]
 
 [dev-dependencies]
-quickcheck = "0.9.2"
+quickcheck = "1.0.3"
 rstest = "0.18.2"
 rstest_reuse = "0.6.0"
 approx = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ symphonia-alac = ["symphonia/isomp4", "symphonia/alac"]
 symphonia-aiff = ["symphonia/aiff", "symphonia/pcm"]
 
 [dev-dependencies]
-quickcheck = "1.0.3"
+quickcheck = "1"
 rstest = "0.18.2"
 rstest_reuse = "0.6.0"
 approx = "0.5.1"

--- a/examples/automatic_gain_control.rs
+++ b/examples/automatic_gain_control.rs
@@ -18,18 +18,28 @@ fn main() {
     // Apply automatic gain control to the source
     let agc_source = source.automatic_gain_control(1.0, 4.0, 0.005, 5.0);
 
-    // Make it so that the source checks if automatic gain control should be
-    // enabled or disabled every 5 milliseconds. We must clone `agc_enabled`
-    // or we would lose it when we move it into the periodic access.
-    let agc_enabled = Arc::new(AtomicBool::new(true));
-    let agc_enabled_clone = agc_enabled.clone();
-    let controlled = agc_source.periodic_access(Duration::from_millis(5), move |agc_source| {
-        agc_source.set_enabled(agc_enabled_clone.load(Ordering::Relaxed));
-    });
+    let agc_enabled : Arc<AtomicBool>;
 
-    // Add the source now equipped with automatic gain control and controlled via
-    // periodic_access to the sink for playback
-    sink.append(controlled);
+    #[cfg(not(feature = "experimental"))]
+    {
+        agc_enabled = Arc::new(AtomicBool::new(true));
+        // Make it so that the source checks if automatic gain control should be
+        // enabled or disabled every 5 milliseconds. We must clone `agc_enabled`,
+        // or we would lose it when we move it into the periodic access.
+        let agc_enabled_clone = agc_enabled.clone();
+        let controlled = agc_source.periodic_access(Duration::from_millis(5), move |agc_source| {
+            agc_source.set_enabled(agc_enabled_clone.load(Ordering::Relaxed));
+        });
+        
+        // Add the source now equipped with automatic gain control and controlled via
+        // periodic_access to the sink for playback
+        sink.append(controlled);
+    }
+    #[cfg(feature = "experimental")]
+    {
+        agc_enabled = agc_source.get_agc_control();
+        sink.append(agc_source);
+    }
 
     // after 5 seconds of playback disable automatic gain control using the
     // shared AtomicBool `agc_enabled`. You could do this from another part
@@ -39,6 +49,11 @@ fn main() {
     // Note that disabling the AGC takes up to 5 millis because periodic_access
     // controls the source every 5 millis.
     thread::sleep(Duration::from_secs(5));
+    #[cfg(not(feature = "experimental"))]
+    agc_enabled.store(false, Ordering::Relaxed);
+
+    // AGC on/off control using direct access to the boolean variable.
+    #[cfg(feature = "experimental")]
     agc_enabled.store(false, Ordering::Relaxed);
 
     // Keep the program running until playback is complete

--- a/examples/automatic_gain_control.rs
+++ b/examples/automatic_gain_control.rs
@@ -18,7 +18,7 @@ fn main() {
     // Apply automatic gain control to the source
     let agc_source = source.automatic_gain_control(1.0, 4.0, 0.005, 5.0);
 
-    let agc_enabled : Arc<AtomicBool>;
+    let agc_enabled: Arc<AtomicBool>;
 
     #[cfg(not(feature = "experimental"))]
     {
@@ -30,7 +30,7 @@ fn main() {
         let controlled = agc_source.periodic_access(Duration::from_millis(5), move |agc_source| {
             agc_source.set_enabled(agc_enabled_clone.load(Ordering::Relaxed));
         });
-        
+
         // Add the source now equipped with automatic gain control and controlled via
         // periodic_access to the sink for playback
         sink.append(controlled);

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -42,8 +42,8 @@ where
     where
         D: Into<Vec<S>>,
     {
-        assert!(channels != 0);
-        assert!(sample_rate != 0);
+        assert!(channels > 0);
+        assert!(sample_rate > 0);
 
         let data = data.into();
         let duration_ns = 1_000_000_000u64.checked_mul(data.len() as u64).unwrap()

--- a/src/conversions/sample.rs
+++ b/src/conversions/sample.rs
@@ -243,7 +243,7 @@ mod test {
             let b = second as f64;
             let c = numerator as f64 / denominator as f64;
             if c < 0.0 || c > 1.0 { return TestResult::discard(); };
-            let reference = a + (b - a) * c;
+            let reference = a * (1.0 - c) + b * c;
             let x = Sample::lerp(first, second, numerator, denominator) as f64;
             let d = x - reference;
             TestResult::from_bool(d.abs() < 1.0)

--- a/src/conversions/sample.rs
+++ b/src/conversions/sample.rs
@@ -55,8 +55,7 @@ where
     I: ExactSizeIterator,
     I::Item: Sample,
     O: FromSample<I::Item> + Sample,
-{
-}
+{}
 
 /// Represents a value of a single sample.
 ///
@@ -93,10 +92,10 @@ pub trait Sample: CpalSample {
 impl Sample for u16 {
     #[inline]
     fn lerp(first: u16, second: u16, numerator: u32, denominator: u32) -> u16 {
-        let a = first as i32;
-        let b = second as i32;
-        let n = numerator as i32;
-        let d = denominator as i32;
+        let a = first as i64;
+        let b = second as i64;
+        let n = numerator as i64;
+        let d = denominator as i64;
         (a + (b - a) * n / d) as u16
     }
 
@@ -176,5 +175,28 @@ impl Sample for f32 {
     #[inline]
     fn zero_value() -> f32 {
         0.0
+    }
+}
+
+
+#[cfg(test)]
+mod test {
+    use quickcheck::{quickcheck, TestResult};
+    use super::*;
+
+    quickcheck! {
+        fn lerp_u16(first: u16, second: u16, numerator: u32, denominator: u32) -> TestResult {
+            if denominator == 0 { return TestResult::discard(); }
+            let a = first as f64;
+            let b = second as f64;
+            let c = numerator as f64 / denominator as f64;
+            // if c < 0.0 || c > 1.0 { return TestResult::discard(); };
+            // let reference = a * c + b * (1.0 - c);
+            let reference = a + (b - a) * c;
+            let x = Sample::lerp(first, second, numerator, denominator) as f64;
+            let d = x - reference;
+            dbg!(x, reference, d);
+            TestResult::from_bool(d.abs() < 1.0)
+        }
     }
 }

--- a/src/conversions/sample.rs
+++ b/src/conversions/sample.rs
@@ -55,7 +55,8 @@ where
     I: ExactSizeIterator,
     I::Item: Sample,
     O: FromSample<I::Item> + Sample,
-{}
+{
+}
 
 /// Represents a value of a single sample.
 ///
@@ -73,8 +74,8 @@ where
 pub trait Sample: CpalSample {
     /// Linear interpolation between two samples.
     ///
-    /// The result should be equal to
-    /// `first * numerator / denominator + second * (1 - numerator / denominator)`.
+    /// The result should be equvivalent to
+    /// `first * (1 - numerator / denominator) + second * numerator / denominator`.
     fn lerp(first: Self, second: Self, numerator: u32, denominator: u32) -> Self;
     /// Multiplies the value of this sample by the given amount.
     fn amplify(self, value: f32) -> Self;
@@ -92,9 +93,9 @@ pub trait Sample: CpalSample {
 impl Sample for u16 {
     #[inline]
     fn lerp(first: u16, second: u16, numerator: u32, denominator: u32) -> u16 {
-        let d = first as i64 + (second as i64 - first as i64) * numerator as i64 / denominator as i64;
-        u16::try_from(d)
-            .expect("numerator / denominator is within [0, 1] range")
+        let d =
+            first as i64 + (second as i64 - first as i64) * numerator as i64 / denominator as i64;
+        u16::try_from(d).expect("numerator / denominator is within [0, 1] range")
     }
 
     #[inline]
@@ -122,9 +123,9 @@ impl Sample for u16 {
 impl Sample for i16 {
     #[inline]
     fn lerp(first: i16, second: i16, numerator: u32, denominator: u32) -> i16 {
-        let d = first as i64 + (second as i64 - first as i64) * numerator as i64 / denominator as i64;
-        i16::try_from(d)
-            .expect("numerator / denominator is within [0, 1] range")
+        let d =
+            first as i64 + (second as i64 - first as i64) * numerator as i64 / denominator as i64;
+        i16::try_from(d).expect("numerator / denominator is within [0, 1] range")
     }
 
     #[inline]
@@ -177,12 +178,10 @@ impl Sample for f32 {
     }
 }
 
-
 #[cfg(test)]
 mod test {
-    use quickcheck::{quickcheck, TestResult};
     use super::*;
-
+    use quickcheck::{quickcheck, TestResult};
 
     #[test]
     fn lerp_u16_constraints() {

--- a/src/conversions/sample_rate.rs
+++ b/src/conversions/sample_rate.rs
@@ -50,6 +50,7 @@ where
         let from = from.0;
         let to = to.0;
 
+        assert!(num_channels >= 1);
         assert!(from >= 1);
         assert!(to >= 1);
 
@@ -262,9 +263,9 @@ mod test {
     quickcheck! {
         /// Check that resampling an empty input produces no output.
         fn empty(from: u32, to: u32, n: u16) -> () {
+            if n == 0 { return; }
             let from = if from == 0 { return; } else { SampleRate(from) };
             let to   = if   to == 0 { return; } else { SampleRate(to)   };
-            if n == 0 { return; }
 
             let input: Vec<u16> = Vec::new();
             let output =
@@ -276,8 +277,8 @@ mod test {
 
         /// Check that resampling to the same rate does not change the signal.
         fn identity(from: u32, n: u16, input: Vec<u16>) -> () {
-            let from = if from == 0 { return; } else { SampleRate(from) };
             if n == 0 { return; }
+            let from = if from == 0 { return; } else { SampleRate(from) };
 
             let output =
                 SampleRateConverter::new(input.clone().into_iter(), from, from, n)
@@ -289,9 +290,9 @@ mod test {
         /// Check that dividing the sample rate by k (integer) is the same as
         ///   dropping a sample from each channel.
         fn divide_sample_rate(to: u32, k: u32, input: Vec<u16>, n: u16) -> () {
+            if k == 0 || n == 0 || to.checked_mul(k).is_none() { return; }
             let to = if to == 0 { return; } else { SampleRate(to) };
             let from = to * k;
-            if k == 0 || n == 0 { return; }
 
             // Truncate the input, so it contains an integer number of frames.
             let input = {
@@ -313,9 +314,9 @@ mod test {
         /// Check that, after multiplying the sample rate by k, every k-th
         ///  sample in the output matches exactly with the input.
         fn multiply_sample_rate(from: u32, k: u32, input: Vec<u16>, n: u16) -> () {
+            if k == 0 || n == 0 || from.checked_mul(k).is_none() { return; }
             let from = if from == 0 { return; } else { SampleRate(from) };
             let to = from * k;
-            if k == 0 || n == 0 { return; }
 
             // Truncate the input, so it contains an integer number of frames.
             let input = {

--- a/src/conversions/sample_rate.rs
+++ b/src/conversions/sample_rate.rs
@@ -53,7 +53,7 @@ where
         assert!(from >= 1);
         assert!(to >= 1);
 
-        // finding greatest common divisor
+        // finding the greatest common divisor
         let gcd = {
             #[inline]
             fn gcd(a: u32, b: u32) -> u32 {
@@ -259,12 +259,6 @@ mod test {
     use cpal::SampleRate;
     use quickcheck::quickcheck;
 
-    // TODO: Remove once cpal 0.12.2 is released and the dependency is updated
-    //  (cpal#483 implemented ops::Mul on SampleRate)
-    const fn multiply_rate(r: SampleRate, k: u32) -> SampleRate {
-        SampleRate(k * r.0)
-    }
-
     quickcheck! {
         /// Check that resampling an empty input produces no output.
         fn empty(from: u32, to: u32, n: u16) -> () {
@@ -296,7 +290,7 @@ mod test {
         ///   dropping a sample from each channel.
         fn divide_sample_rate(to: u32, k: u32, input: Vec<u16>, n: u16) -> () {
             let to = if to == 0 { return; } else { SampleRate(to) };
-            let from = multiply_rate(to, k);
+            let from = to * k;
             if k == 0 || n == 0 { return; }
 
             // Truncate the input, so it contains an integer number of frames.
@@ -320,7 +314,7 @@ mod test {
         ///  sample in the output matches exactly with the input.
         fn multiply_sample_rate(from: u32, k: u32, input: Vec<u16>, n: u16) -> () {
             let from = if from == 0 { return; } else { SampleRate(from) };
-            let to = multiply_rate(from, k);
+            let to = from * k;
             if k == 0 || n == 0 { return; }
 
             // Truncate the input, so it contains an integer number of frames.

--- a/src/conversions/sample_rate.rs
+++ b/src/conversions/sample_rate.rs
@@ -253,7 +253,8 @@ impl<I> ExactSizeIterator for SampleRateConverter<I>
 where
     I: ExactSizeIterator,
     I::Item: Sample + Clone,
-{}
+{
+}
 
 #[cfg(test)]
 mod test {
@@ -374,9 +375,16 @@ mod test {
         let input = vec![2u16, 16, 4, 18, 6, 20, 8, 22];
         let output =
             SampleRateConverter::new(input.into_iter(), SampleRate(2000), SampleRate(3000), 2);
-        assert_eq!(output.len(), 12);
-
         let output = output.collect::<Vec<_>>();
         assert_eq!(output, [2, 16, 3, 17, 4, 18, 6, 20, 7, 21, 8, 22]);
+    }
+
+    #[test]
+    fn upsample2() {
+        let input = vec![1u16, 14];
+        let output =
+            SampleRateConverter::new(input.into_iter(), SampleRate(1000), SampleRate(7000), 1);
+        let output = output.collect::<Vec<_>>();
+        assert_eq!(output, [1, 2, 4, 6, 8, 10, 12, 14]);
     }
 }

--- a/src/source/agc.rs
+++ b/src/source/agc.rs
@@ -288,10 +288,13 @@ where
     }
 
     #[cfg(feature = "experimental")]
-    /// Access the AGC on/off control for real-time adjustment.
-    ///
+    /// Access the AGC on/off control.
     /// Use this to dynamically enable or disable AGC processing during runtime.
-    /// Useful for comparing processed and unprocessed audio or for disabling/enabling AGC at runtime.
+    ///
+    /// AGC is on by default. `false` is disabled state, `true` is enabled.
+    /// In disabled state the sound is passed through AGC unchanged.
+    ///
+    /// In particular, this control is useful for comparing processed and unprocessed audio.
     #[inline]
     pub fn get_agc_control(&self) -> Arc<AtomicBool> {
         Arc::clone(&self.is_enabled)

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -93,7 +93,7 @@ pub use self::noise::{pink, white, PinkNoise, WhiteNoise};
 /// amplitude every 20µs). By doing so we obtain a list of numerical values, each value being
 /// called a *sample*.
 ///
-/// Therefore a sound can be represented in memory by a frequency and a list of samples. The
+/// Therefore, a sound can be represented in memory by a frequency and a list of samples. The
 /// frequency is expressed in hertz and corresponds to the number of samples that have been
 /// read per second. For example if we read one sample every 20µs, the frequency would be
 /// 50000 Hz. In reality, common values for the frequency are 44100, 48000 and 96000.
@@ -114,7 +114,7 @@ pub use self::noise::{pink, white, PinkNoise, WhiteNoise};
 /// channel, then the second sample of the second channel, and so on. The same applies if you have
 /// more than two channels. The rodio library only supports this schema.
 ///
-/// Therefore in order to represent a sound in memory in fact we need three characteristics: the
+/// Therefore, in order to represent a sound in memory in fact we need three characteristics: the
 /// frequency, the number of channels, and the list of samples.
 ///
 /// ## The `Source` trait
@@ -297,25 +297,32 @@ where
     ///   A recommended value for `absolute_max_gain` is `5`, which provides a good balance between
     ///   amplification capability and protection against distortion in most scenarios.
     ///
-    /// Use `get_agc_control` to obtain a handle for real-time enabling/disabling of the AGC.
+    /// Use [AutomaticGainControl::get_agc_control()] to obtain a handle for real-time
+    /// enabling/disabling of the AGC.
     ///
     /// # Example (Quick start)
     ///
     /// ```rust
-    /// // Apply Automatic Gain Control to the source (AGC is on by default)
+    /// // Apply Automatic Gain Control to the source.
+    /// use rodio::source::{Source, SineWave, AutomaticGainControl};
+    /// use rodio::Sink;
+    /// let source = SineWave::new(444.0); // An example.
+    /// let (sink, output) = Sink::new_idle(); // An example, makes no sound unless connected to an output.
+    ///
     /// let agc_source = source.automatic_gain_control(1.0, 4.0, 0.005, 5.0);
     ///
-    /// // Get a handle to control the AGC's enabled state (optional)
-    /// let agc_control = agc_source.get_agc_control();
-    ///
-    /// // You can toggle AGC on/off at any time (optional)
-    /// agc_control.store(false, std::sync::atomic::Ordering::Relaxed);
+    /// #[cfg(feature = "experimental")]
+    /// {
+    ///     // It is possible to get or change AGC's enabled state. AGC is on by default.
+    ///     // See documentation for `AutomaticGainControl::get_agc_control()` for details.
+    ///     let agc_enabled = agc_source.get_agc_control();
+    ///     // You can toggle AGC on/off at any time.
+    ///     agc_enabled.store(false, std::sync::atomic::Ordering::Relaxed);
+    /// }
     ///
     /// // Add the AGC-controlled source to the sink
     /// sink.append(agc_source);
     ///
-    /// // Note: Using agc_control is optional. If you don't need to toggle AGC,
-    /// // you can simply use the agc_source directly without getting agc_control.
     /// ```
     #[inline]
     fn automatic_gain_control(

--- a/src/source/skip.rs
+++ b/src/source/skip.rs
@@ -179,9 +179,9 @@ mod tests {
         seconds: u32,
         seconds_to_skip: u32,
     ) {
-        let data: Vec<f32> = (1..=(sample_rate * channels as u32 * seconds))
-            .map(|_| 0f32)
-            .collect();
+        let buf_len = (sample_rate * channels as u32 * seconds) as usize;
+        assert!(buf_len < 10 * 1024 * 1024);
+        let data: Vec<f32> = vec![0f32; buf_len];
         let test_buffer = SamplesBuffer::new(channels, sample_rate, data);
         let seconds_left = seconds.saturating_sub(seconds_to_skip);
 

--- a/src/source/speed.rs
+++ b/src/source/speed.rs
@@ -4,12 +4,12 @@
 //! encapsulates playback speed controls of the current sink.
 //!
 //! In order to speed up a sink, the speed struct:
-//! - Increases the current sample rate by the given factor
-//! - Updates the total duration function to cover for the new factor by dividing by the factor
-//! - Updates the try_seek function by multiplying the audio position by the factor
+//! - Increases the current sample rate by the given factor.
+//! - Updates the total duration function to cover for the new factor by dividing by the factor.
+//! - Updates the try_seek function by multiplying the audio position by the factor.
 //!
 //! To speed up a source from sink all you need to do is call the   `set_speed(factor: f32)` function
-//! For example, here is how you speed up your sound by using sink or playing raw
+//! For example, here is how you speed up your sound by using sink or playing raw.
 //!
 //! ```no_run
 //!# use std::fs::File;
@@ -17,24 +17,23 @@
 //!# use rodio::{Decoder, Sink, OutputStream, source::{Source, SineWave}};
 //!
 //! // Get an output stream handle to the default physical sound device.
-//! // Note that no sound will be played if _stream is dropped
+//! // Note that no sound will be played if _stream is dropped.
 //! let (_stream, stream_handle) = OutputStream::try_default().unwrap();
 //! // Load a sound from a file, using a path relative to Cargo.toml
-//! let file = BufReader::new(File::open("examples/music.ogg").unwrap());
+//! let file = BufReader::new(File::open("assets/music.ogg").unwrap());
 //! // Decode that sound file into a source
 //! let source = Decoder::new(file).unwrap();
 //! // Play the sound directly on the device 2x faster
-//! stream_handle.play_raw(source.convert_samples().speed(2.0));
-
+//! stream_handle.play_raw(source.convert_samples().speed(2.0)).unwrap();
 //! std::thread::sleep(std::time::Duration::from_secs(5));
-//! ```
-//! here is how you would do it using the sink
-//! ```
-//! let source = SineWave::new(440.0)
-//! .take_duration(Duration::from_secs_f32(20.25))
-//! .amplify(0.20);
 //!
-//! let sink = Sink::try_new(&stream_handle)?;
+//! // Here is how you would do it using the sink.
+//!
+//! let source = SineWave::new(440.0)
+//!     .take_duration(std::time::Duration::from_secs_f32(3.25))
+//!     .amplify(0.20);
+//!
+//! let sink = Sink::try_new(&stream_handle).unwrap();
 //! sink.set_speed(2.0);
 //! sink.append(source);
 //! std::thread::sleep(std::time::Duration::from_secs(5));

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -11,7 +11,7 @@ use cpal::{Sample, SupportedStreamConfig};
 
 /// `cpal::Stream` container. Also see the more useful `OutputStreamHandle`.
 ///
-/// If this is dropped playback will end & attached `OutputStreamHandle`s will no longer work.
+/// If this is dropped, playback will end & attached `OutputStreamHandle`s will no longer work.
 pub struct OutputStream {
     mixer: Arc<DynamicMixerController<f32>>,
     _stream: cpal::Stream,


### PR DESCRIPTION
1. `quickcheck`  1.x input values vary more than in 0.9 which finds overflow cases and excessive memory allocation problems in `Sample::lerp`.  Calculations now use f64 to avoid that. Conversion back to 16 bit resolution is done explicitly since `as` conversion may silently discard most significant bits. Alternatively, interpolation coefficient (`numerator/dividor`) may use e.g. `u16` instead of `u32`, or maybe even floating point. I believe `u32` precision is unnecessary there. But that requires updating sample rate converter which at the moment is the only user of this interpolation.
2. Documentation for `Sample::lerp` was incorrect. It said that calculations should follow `c * first + (c - 1) * second`. which gives `first` at `c==1` and `second` at `c==0` but actual implementations use the opposite `first` at `c==0` and `second` at `c==1`.
3. Fix documentation examples. Some of the examples are marked as `no_run` since they require audio devices and may actually make sounds while `cargo test` command is running.
4. Include documentation tests into CI. `--all-targets` switch excludes doc tests, so those are executed separately.
5. Non `experimental` builds exclude some code and in some code parts use mutually exclusive implementations, so I included those in CI too to keep experimental code compilable.