### PR TITLE
Fix wrong total duration caused by divided by zero conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Breaking: `Sink::try_new` renamed to `connect_new` and does not return error anymore.
             `Sink::new_idle` was renamed to `new`.
 
+### Fixed
+
+- Symphonia decoder `total_duration` incorrect value caused by conversion from `Time` to `Duration`.
+
 # Version 0.20.1 (2024-11-08)
 
 ### Fixed

--- a/src/decoder/symphonia.rs
+++ b/src/decoder/symphonia.rs
@@ -170,8 +170,9 @@ impl Source for SymphoniaDecoder {
 
     #[inline]
     fn total_duration(&self) -> Option<Duration> {
-        self.total_duration
-            .map(|Time { seconds, frac }| Duration::new(seconds, (1f64 / frac) as u32))
+        self.total_duration.map(|Time { seconds, frac }| {
+            Duration::new(seconds, if frac > 0.0 { (1f64 / frac) as u32 } else { 0 })
+        })
     }
 
     fn try_seek(&mut self, pos: Duration) -> Result<(), source::SeekError> {

--- a/src/decoder/symphonia.rs
+++ b/src/decoder/symphonia.rs
@@ -170,9 +170,7 @@ impl Source for SymphoniaDecoder {
 
     #[inline]
     fn total_duration(&self) -> Option<Duration> {
-        self.total_duration.map(|Time { seconds, frac }| {
-            Duration::new(seconds, if frac > 0.0 { (1f64 / frac) as u32 } else { 0 })
-        })
+        self.total_duration.map(time_to_duration)
     }
 
     fn try_seek(&mut self, pos: Duration) -> Result<(), source::SeekError> {
@@ -306,6 +304,17 @@ fn skip_back_a_tiny_bit(
     Time { seconds, frac }
 }
 
+fn time_to_duration(time: Time) -> Duration {
+    Duration::new(
+        time.seconds,
+        if time.frac > 0.0 {
+            (1f64 / time.frac) as u32
+        } else {
+            0
+        },
+    )
+}
+
 impl Iterator for SymphoniaDecoder {
     type Item = i16;
 
@@ -330,5 +339,36 @@ impl Iterator for SymphoniaDecoder {
         self.current_frame_offset += 1;
 
         Some(sample)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use symphonia::core::units::Time;
+
+    use crate::decoder::symphonia::time_to_duration;
+
+    #[test]
+    fn test_time_to_dur_zero_frac() {
+        let time = Time {
+            seconds: 7,
+            frac: 0.0,
+        };
+        let duration = Duration::new(7, 0);
+
+        assert_eq!(time_to_duration(time), duration);
+    }
+
+    #[test]
+    fn test_time_to_dur_non_zero_frac() {
+        let time = Time {
+            seconds: 7,
+            frac: 0.3,
+        };
+        let duration = Duration::new(7, (1.0 / 0.3) as u32);
+
+        assert_eq!(time_to_duration(time), duration);
     }
 }

--- a/src/decoder/symphonia.rs
+++ b/src/decoder/symphonia.rs
@@ -356,7 +356,14 @@ mod tests {
             seconds: 7,
             frac: 0.0,
         };
-        let duration = Duration::new(7, 0);
+        let duration = Duration::new(
+            time.seconds,
+            if time.frac > 0.0 {
+                (1f64 / time.frac) as u32
+            } else {
+                0
+            },
+        );
 
         assert_eq!(time_to_duration(time), duration);
     }
@@ -367,7 +374,14 @@ mod tests {
             seconds: 7,
             frac: 0.3,
         };
-        let duration = Duration::new(7, (1.0 / 0.3) as u32);
+        let duration = Duration::new(
+            time.seconds,
+            if time.frac > 0.0 {
+                (1f64 / time.frac) as u32
+            } else {
+                0
+            },
+        );
 
         assert_eq!(time_to_duration(time), duration);
     }


### PR DESCRIPTION
fixes #601

I came into this issue when trying to create music player as my learning project and notice that total duration is not quite right as the music ended before total duration reached.

The cause seems to be related to 0 division and convert to u32.

I also added test case for the conversion, I'm not sure if it is needed.
Any feedback is welcome.

Code:
```rs
        let total_duration = track
            .codec_params
            .time_base
            .zip(track.codec_params.n_frames)
            .map(|(time_base, n_frames)| time_base.calc_time(n_frames));

        total_duration.map(|time| {
            let hours = time.seconds / (60 * 60);
            let mins = (time.seconds % (60 * 60)) / 60;
            let secs = f64::from((time.seconds % 60) as u32) + time.frac;

            println!("Time: {}", format!("{}:{:0>2}:{:0>6.3}", hours, mins, secs))
        });

        total_duration.map(|Time { seconds, frac }| {
            let dur = Duration::new(seconds, (1f64 / frac) as u32).as_secs();

            let hours = dur / (60 * 60);
            let mins = dur / 60;
            let secs = dur % 60;

            println!(
                "Duration: {}",
                format!("{}:{:0>2}:{:0>2}", hours, mins, secs)
            );
        });

        total_duration.map(|Time { seconds, frac }| {
            let dur =
                Duration::new(seconds, if frac > 0.0 { (1f64 / frac) as u32 } else { 0 }).as_secs();

            let hours = dur / (60 * 60);
            let mins = dur / 60;
            let secs = dur % 60;

            println!(
                "Fixed Divided by 0 Duration: {}",
                format!("{}:{:0>2}:{:0>2}", hours, mins, secs)
            );
        });
```

Result:
```
Time: 0:00:07.000
Duration: 0:00:11
Fixed Divided by 0 Duration: 0:00:07
```