### PR TITLE
Introduce a public constant for Rodio's default sample rate

### DIFF
--- a/examples/mix_multiple_sources.rs
+++ b/examples/mix_multiple_sources.rs
@@ -2,10 +2,11 @@ use rodio::mixer;
 use rodio::source::{SineWave, Source};
 use std::error::Error;
 use std::time::Duration;
+use rodio::constants::DEFAULT_SAMPLE_RATE;
 
 fn main() -> Result<(), Box<dyn Error>> {
     // Construct a dynamic controller and mixer, stream_handle, and sink.
-    let (controller, mixer) = mixer::mixer::<f32>(2, 44_100);
+    let (controller, mixer) = mixer::mixer::<f32>(2, DEFAULT_SAMPLE_RATE);
     let stream_handle = rodio::OutputStreamBuilder::open_default_stream()?;
     let sink = rodio::Sink::connect_new(&stream_handle.mixer());
 

--- a/examples/noise_generator.rs
+++ b/examples/noise_generator.rs
@@ -1,6 +1,7 @@
 //! Noise generator example. Use the "noise" feature to enable the noise generator sources.
 
 use std::error::Error;
+use rodio::constants::DEFAULT_SAMPLE_RATE;
 
 #[cfg(feature = "noise")]
 fn main() -> Result<(), Box<dyn Error>> {
@@ -14,7 +15,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let interval_duration = Duration::from_millis(1500);
 
     stream_handle.mixer().add(
-        white(cpal::SampleRate(48000))
+        white(cpal::SampleRate(DEFAULT_SAMPLE_RATE))
             .amplify(0.1)
             .take_duration(noise_duration),
     );
@@ -23,7 +24,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     thread::sleep(interval_duration);
 
     stream_handle.mixer().add(
-        pink(cpal::SampleRate(48000))
+        pink(cpal::SampleRate(DEFAULT_SAMPLE_RATE))
             .amplify(0.1)
             .take_duration(noise_duration),
     );

--- a/examples/signal_generator.rs
+++ b/examples/signal_generator.rs
@@ -1,6 +1,7 @@
 //! Test signal generator example.
 
 use std::error::Error;
+use rodio::constants::DEFAULT_SAMPLE_RATE;
 
 fn main() -> Result<(), Box<dyn Error>> {
     use rodio::source::{chirp, Function, SignalGenerator, Source};
@@ -11,7 +12,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let test_signal_duration = Duration::from_millis(1000);
     let interval_duration = Duration::from_millis(1500);
-    let sample_rate = cpal::SampleRate(48000);
+    let sample_rate = cpal::SampleRate(DEFAULT_SAMPLE_RATE);
 
     println!("Playing 1000 Hz tone");
     stream_handle.mixer().add(

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,6 @@
+//! Rodio common constants
+
+/// The sample rate (Hz) output stream uses by default.
+/// Prefer this one in the processing chain to minimize sample rate conversions.
+pub const DEFAULT_SAMPLE_RATE: u32 = 44_100;
+

--- a/src/conversions/mod.rs
+++ b/src/conversions/mod.rs
@@ -2,7 +2,6 @@
 This module contains function that will convert from one PCM format to another.
 
 This includes conversion between sample formats, channels or sample rates.
-
 */
 
 pub use self::channels::ChannelCountConverter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,6 +166,7 @@ pub mod mixer;
 pub mod queue;
 pub mod source;
 pub mod static_buffer;
+pub mod constants;
 
 pub use crate::conversions::Sample;
 pub use crate::decoder::Decoder;

--- a/src/source/sine.rs
+++ b/src/source/sine.rs
@@ -1,5 +1,5 @@
 use std::time::Duration;
-
+use crate::constants::DEFAULT_SAMPLE_RATE;
 use crate::source::{Function, SignalGenerator};
 use crate::Source;
 
@@ -7,19 +7,17 @@ use super::SeekError;
 
 /// An infinite source that produces a sine.
 ///
-/// Always has a rate of 48kHz and one channel.
+/// Always has default sample rate and one channel.
 #[derive(Clone, Debug)]
 pub struct SineWave {
     test_sine: SignalGenerator,
 }
 
 impl SineWave {
-    const SAMPLE_RATE: u32 = 48000;
-
     /// The frequency of the sine.
     #[inline]
     pub fn new(freq: f32) -> SineWave {
-        let sr = cpal::SampleRate(Self::SAMPLE_RATE);
+        let sr = cpal::SampleRate(DEFAULT_SAMPLE_RATE);
         SineWave {
             test_sine: SignalGenerator::new(sr, freq, Function::Sine),
         }
@@ -48,7 +46,7 @@ impl Source for SineWave {
 
     #[inline]
     fn sample_rate(&self) -> u32 {
-        Self::SAMPLE_RATE
+        self.test_sine.sample_rate()
     }
 
     #[inline]

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -3,6 +3,7 @@ use std::marker::Sync;
 use std::sync::Arc;
 use std::{error, fmt};
 
+use crate::constants::DEFAULT_SAMPLE_RATE;
 use crate::decoder;
 use crate::mixer::{mixer, Mixer, MixerSource};
 use crate::sink::Sink;
@@ -12,7 +13,7 @@ use cpal::{
     SupportedBufferSize,
 };
 
-const HZ_44100: cpal::SampleRate = cpal::SampleRate(44_100);
+const HZ_44100: cpal::SampleRate = cpal::SampleRate(DEFAULT_SAMPLE_RATE);
 
 /// `cpal::Stream` container.
 /// Use `mixer()` method to control output.


### PR DESCRIPTION
This should help to reduce number of sample rate conversions. Setting it to current de-facto default (44.1kHz).

Also partially relieves #208. The rate converter has to be fixed still but with default sample rate less resampling is needed.
