### PR TITLE
This adds long term goals for rodio

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ See [the docs](https://docs.rs/rodio/latest/rodio/#alternative-decoder-backends)
 
 Rodio uses `cpal` to send audio to the OS for playback. On Linux `cpal` needs the ALSA development files. These are provided as part of the libasound2-dev package on Debian and Ubuntu distributions and alsa-lib-devel on Fedora.
 
+# Goals
+- Simple API
+    - you should not need to know anything about audio to use rodio
+    - its hard to make mistakes
+    - easy to move rodio parts around your program
+- Optimal
+    - rodio should be a zero cost abstraction
+    - rodio should offer options between perfect and fast
+- extensible
+    - if something is missing in rodio it should be easy to add
+    - you should be able to control rodio parts easily
+
 # Contributing
 
 For information on how to contribute to this project, please see our [Contributing Guide](https://github.com/RustAudio/rodio/CONTRIBUTING.md).
@@ -33,7 +45,7 @@ For information on how to contribute to this project, please see our [Contributi
 
 Licensed under either of
 
-* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0), or
+#* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0), or
 * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
 
 at your option.


### PR DESCRIPTION
Rodio has existed for about 9 years. When it was written there where no audio libraries for rust. Therefore rodio can do everything but not everything perfectly. A lot has changed since then and new libraries have popped up for specific goals such as game-audio (kira) & digital signal processing. This is a good thing in my opinion, when developing a library you have to make choices and they exclude some use cases.

When I started maintaining rodio I had a short exchange with the bevy devs (1/3 of rodio downloads are from bevy) about their planned move from rodio to kira. Note the have not migrated to kira as of this writing. See https://github.com/bevyengine/bevy/issues/9076#issuecomment-2071835595

I also had a short exchange with the kira dev to see if kira could support all audio usecases, that seems to not be the case. See: https://github.com/tesselode/kira/issues/87

Over the past few weeks we have collected the use-cases for rodio, see issue #626.

After talking to the bevy dev and kira dev I made some goals for rodio in my head. Now that rodio is (very) actively maintained we need to write those down and discuss them. That way we do not make contradicting decisions in rodio.

Please let me know what you think.