### PR TITLE
[not for merge] Resampler low pass prototype

### DIFF
--- a/src/source/low_pass.rs
+++ b/src/source/low_pass.rs
@@ -1,0 +1,115 @@
+use std::time::Duration;
+use num_rational::Ratio;
+use crate::conversions::SampleRateConverter;
+use crate::{Sample, Source};
+
+pub struct LowPass<I>
+where
+    I: Iterator,
+{
+    input: I,
+    prev: Option<I::Item>
+}
+
+impl<I> LowPass<I>
+where
+    I: Iterator,
+    I::Item: Sample,
+{
+    #[inline]
+    pub fn new(
+        mut input: I,
+    ) -> LowPass<I> {
+        LowPass {
+            input,
+            prev: None
+        }
+    }
+}
+
+impl<I> Source for LowPass<I>
+where
+    I: Source,
+    I::Item: Sample,
+{
+    fn current_frame_len(&self) -> Option<usize> {
+        None
+    }
+
+    fn channels(&self) -> u16 {
+        self.input.channels()
+    }
+
+    fn sample_rate(&self) -> u32 {
+        self.input.sample_rate()
+    }
+
+    fn total_duration(&self) -> Option<Duration> {
+        self.input.total_duration()
+    }
+}
+
+impl<I> Iterator for LowPass<I>
+where
+    I: Iterator,
+    I::Item: Sample + Clone,
+{
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.input.next().and_then(|s| {
+            let x = self.prev.map(|p| (p.saturating_add(s)).amplify(0.5));
+            self.prev.replace(s);
+            x
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::conversions::SampleRateConverter;
+    use crate::source::SineWave;
+    use crate::Source;
+    use crate::{OutputStreamBuilder};
+    use std::thread;
+    use std::time::Duration;
+    use symphonia::core::meta::StandardTagKey::Encoder;
+
+    #[test]
+    fn test_low_pass() {
+        let stream_handle = OutputStreamBuilder::open_default_stream().unwrap();
+        let mixer = stream_handle.mixer();
+        {
+            // Generate sine wave.
+            let wave = SineWave::new(740.0)
+                .amplify(0.1)
+                .take_duration(Duration::from_secs(1));
+
+            let rate_in = wave.sample_rate();
+            let channels_in = wave.channels();
+            let out_freq = 44_100;
+            let output1 = SampleRateConverter::new(
+                wave,
+                cpal::SampleRate(rate_in),
+                cpal::SampleRate(out_freq * 2),
+                channels_in,
+            );
+            
+            let lo_pass = LowPass::new(output1);
+
+            let rate_in = lo_pass.sample_rate();
+            let output2 = SampleRateConverter::new(
+                lo_pass,
+                cpal::SampleRate(rate_in),
+                cpal::SampleRate(out_freq),
+                channels_in,
+            );
+
+            mixer.add(output2);
+        }
+        WavFile
+
+        thread::sleep(Duration::from_millis(1000));
+    }
+}

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -75,6 +75,8 @@ mod zero;
 
 #[cfg(feature = "noise")]
 mod noise;
+mod low_pass;
+
 #[cfg(feature = "noise")]
 pub use self::noise::{pink, white, PinkNoise, WhiteNoise};
 


### PR DESCRIPTION
For a context, we plan to introduce a high quality resampler (#647). This change is an attempt to maybe also improve existing default resampler by keeping it light but improving its sound quality slightly.

Here are some resampler changes prototype that I wanted trying. See `low_pass::tests::test_low_pass`, if this will be deemed sufficiently good, down-sampling step can be optimized (just use decimation).
I would like to have some objective evidence on how it performs, probably need some test harness for that. Or someone with better ears could listen to the output to compare asses it subjectively.
The low pass filter there is primitive has very slope edge, has cut-off frequency at about sample rate / 2 and may distort audio by boosting lows so the audio is up-sampled to 2 x target frequency first, and output is amplified by 0.5.
Low pass filter can be improved, but that will be slower as well. Maybe there are some people who are experienced in DSP so suggest better quick fix ideas.