### PR TITLE
Add an option to output to a WAV file

### DIFF
--- a/src/conversions/sample.rs
+++ b/src/conversions/sample.rs
@@ -79,6 +79,7 @@ pub trait Sample: CpalSample {
     ///
     /// To avoid numeric overflows pick smaller numerator.
     fn lerp(first: Self, second: Self, numerator: u32, denominator: u32) -> Self;
+
     /// Multiplies the value of this sample by the given amount.
     fn amplify(self, value: f32) -> Self;
 

--- a/src/file_output.rs
+++ b/src/file_output.rs
@@ -1,0 +1,39 @@
+use crate::{Sample, Source};
+use hound::{SampleFormat, WavSpec};
+use std::path;
+
+/// This procedure saves Source's output into a wav file. The output samples format is 32-bit float.
+/// This function is intended primarily for testing and diagnostics. It can be used to see
+/// the output without opening output stream to a real audio device.
+pub fn output_to_wav<S: Sample, P: AsRef<path::Path>, Src: Source<Item = S>>(
+    source: &mut Src,
+    wav_file: &P,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let format = WavSpec {
+        channels: source.channels(),
+        sample_rate: source.sample_rate(),
+        bits_per_sample: 32,
+        sample_format: SampleFormat::Float,
+    };
+    let mut writer = hound::WavWriter::create(wav_file, format)?;
+    for sample in source {
+        writer.write_sample(sample.to_f32())?;
+    }
+    writer.finalize()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::output_to_wav;
+    use crate::Source;
+    use std::time::Duration;
+
+    #[test]
+    fn test_output_to_wav() {
+        let mut new_source = crate::source::SineWave::new(745.0)
+            .amplify(0.1)
+            .take_duration(Duration::from_secs(1));
+        output_to_wav(&mut new_source, &"target/tmp/save-to-wav-test.wav").unwrap();
+    }
+}

--- a/src/file_output.rs
+++ b/src/file_output.rs
@@ -5,9 +5,9 @@ use std::path;
 /// This procedure saves Source's output into a wav file. The output samples format is 32-bit float.
 /// This function is intended primarily for testing and diagnostics. It can be used to see
 /// the output without opening output stream to a real audio device.
-pub fn output_to_wav<S: Sample, P: AsRef<path::Path>, Src: Source<Item = S>>(
-    source: &mut Src,
-    wav_file: &P,
+pub fn output_to_wav<S: Sample>(
+    source: &mut impl Source<Item = S>,
+    wav_file: impl AsRef<path::Path>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let format = WavSpec {
         channels: source.channels(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,6 +162,7 @@ mod stream;
 
 pub mod buffer;
 pub mod decoder;
+mod file_output;
 pub mod mixer;
 pub mod queue;
 pub mod source;
@@ -169,6 +170,7 @@ pub mod static_buffer;
 
 pub use crate::conversions::Sample;
 pub use crate::decoder::Decoder;
+pub use crate::file_output::output_to_wav;
 pub use crate::sink::Sink;
 pub use crate::source::Source;
 pub use crate::spatial_sink::SpatialSink;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,8 +145,8 @@
 //! it is sent to this background thread where it will be read by rodio.
 //!
 //! All the sounds are mixed together by rodio before being sent to the operating system or the
-//! hardware. Therefore there is no restriction on the number of sounds that play simultaneously or
-//! the number of sinks that can be created (except for the fact that creating too many will slow
+//! hardware. Therefore, there is no restriction on the number of sounds that play simultaneously or
+//! on the number of sinks that can be created (except for the fact that creating too many will slow
 //! down your program).
 
 #![cfg_attr(test, deny(missing_docs))]

--- a/src/source/noise.rs
+++ b/src/source/noise.rs
@@ -98,6 +98,7 @@ pub struct PinkNoise {
 }
 
 impl PinkNoise {
+    /// Create new pink noise source with given sample rate.
     pub fn new(sample_rate: cpal::SampleRate) -> Self {
         Self {
             white_noise: WhiteNoise::new(sample_rate),


### PR DESCRIPTION
Add a function that can store a Source's output to a WAV file. This will help with diagnostics and testing. For example to see whether a problem with playback is on `cpal`'s or `rodio`'s side.  The output file can then be analyzed with external software or played back. Also output is faster than real-time so this may speed-up development or testing.

Ideally this should be a part of the output stream builder but then we'll need to create a mixer and await for some input, which may be tricky. Also to make this transparent this would require to map `cpal` sample formats to `hound` parameters. It seems that this is not worth it until there are real use cases that need this.