### PR TITLE
Feature/rename frame to span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Breaking: `Sink::try_new` renamed to `connect_new` and does not return error anymore.
             `Sink::new_idle` was renamed to `new`.
 - Breaking: In the `Source` trait, the method `current_frame_len()` was renamed to `current_span_len()`.
-            The term 'frame' was renamed to 'span' in the crate and documentation.
+- The term 'frame' was renamed to 'span' in the crate and documentation.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Breaking: `DynamicMixerController` renamed to `Mixer`, `DynamicMixer` renamed to `MixerSource`.
 - Breaking: `Sink::try_new` renamed to `connect_new` and does not return error anymore.
             `Sink::new_idle` was renamed to `new`.
+- Breaking: In the `Source` trait, the method `current_frame_len()` was renamed to `current_span_len()`.
+            The term 'frame' was renamed to 'span' in the crate and documentation.
 
 ### Fixed
 

--- a/benches/shared.rs
+++ b/benches/shared.rs
@@ -26,7 +26,7 @@ impl<T> ExactSizeIterator for TestSource<T> {
 }
 
 impl<T: rodio::Sample> Source for TestSource<T> {
-    fn current_frame_len(&self) -> Option<usize> {
+    fn current_span_len(&self) -> Option<usize> {
         None // forever
     }
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -69,7 +69,7 @@ where
     S: Sample,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
+    fn current_span_len(&self) -> Option<usize> {
         None
     }
 

--- a/src/decoder/flac.rs
+++ b/src/decoder/flac.rs
@@ -59,7 +59,7 @@ where
     R: Read + Seek,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
+    fn current_span_len(&self) -> Option<usize> {
         None
     }
 

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -101,18 +101,18 @@ impl<R: Read + Seek> DecoderImpl<R> {
     }
 
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
+    fn current_span_len(&self) -> Option<usize> {
         match self {
             #[cfg(all(feature = "wav", not(feature = "symphonia-wav")))]
-            DecoderImpl::Wav(source) => source.current_frame_len(),
+            DecoderImpl::Wav(source) => source.current_span_len(),
             #[cfg(all(feature = "vorbis", not(feature = "symphonia-vorbis")))]
-            DecoderImpl::Vorbis(source) => source.current_frame_len(),
+            DecoderImpl::Vorbis(source) => source.current_span_len(),
             #[cfg(all(feature = "flac", not(feature = "symphonia-flac")))]
-            DecoderImpl::Flac(source) => source.current_frame_len(),
+            DecoderImpl::Flac(source) => source.current_span_len(),
             #[cfg(all(feature = "minimp3", not(feature = "symphonia-mp3")))]
-            DecoderImpl::Mp3(source) => source.current_frame_len(),
+            DecoderImpl::Mp3(source) => source.current_span_len(),
             #[cfg(feature = "symphonia")]
-            DecoderImpl::Symphonia(source) => source.current_frame_len(),
+            DecoderImpl::Symphonia(source) => source.current_span_len(),
             DecoderImpl::None(_) => Some(0),
         }
     }
@@ -413,8 +413,8 @@ where
     R: Read + Seek,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
-        self.0.current_frame_len()
+    fn current_span_len(&self) -> Option<usize> {
+        self.0.current_span_len()
     }
 
     #[inline]
@@ -511,8 +511,8 @@ where
     R: Read + Seek,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
-        self.0.current_frame_len()
+    fn current_span_len(&self) -> Option<usize> {
+        self.0.current_span_len()
     }
 
     #[inline]

--- a/src/decoder/mp3.rs
+++ b/src/decoder/mp3.rs
@@ -14,7 +14,7 @@ where
 {
     // decoder: SeekDecoder<R>,
     decoder: Decoder<R>,
-    // minimp3 Frames are mapped onto rodio spans
+    // minimp3 Frames are interpreted as rodio spans
     current_span: Frame,
     current_span_offset: usize,
 }

--- a/src/decoder/mp3.rs
+++ b/src/decoder/mp3.rs
@@ -14,8 +14,8 @@ where
 {
     // decoder: SeekDecoder<R>,
     decoder: Decoder<R>,
-    // minimp3 Frames are interpreted as rodio spans
-    current_span: Frame,
+    // what minimp3 calls frames rodio calls spans
+    current_span: minimp3::Frame,
     current_span_offset: usize,
 }
 

--- a/src/decoder/mp3.rs
+++ b/src/decoder/mp3.rs
@@ -14,8 +14,9 @@ where
 {
     // decoder: SeekDecoder<R>,
     decoder: Decoder<R>,
-    current_frame: Frame,
-    current_frame_offset: usize,
+    // minimp3 Frames are mapped onto rodio spans
+    current_span: Frame,
+    current_span_offset: usize,
 }
 
 impl<R> Mp3Decoder<R>
@@ -31,16 +32,16 @@ where
         // parameters are correct and minimp3 is used correctly
         // thus if we crash here one of these invariants is broken:
         // .expect("should be able to allocate memory, perform IO");
-        // let current_frame = decoder.decode_frame()
-        let current_frame = decoder.next_frame()
+        // let current_span = decoder.decode_frame()
+        let current_span = decoder.next_frame()
             // the reader makes enough data available therefore 
             // if we crash here the invariant broken is:
             .expect("data should not corrupt");
 
         Ok(Mp3Decoder {
             decoder,
-            current_frame,
-            current_frame_offset: 0,
+            current_span,
+            current_span_offset: 0,
         })
     }
     pub fn into_inner(self) -> R {
@@ -53,18 +54,18 @@ where
     R: Read + Seek,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
-        Some(self.current_frame.data.len())
+    fn current_span_len(&self) -> Option<usize> {
+        Some(self.current_span.data.len())
     }
 
     #[inline]
     fn channels(&self) -> u16 {
-        self.current_frame.channels as _
+        self.current_span.channels as _
     }
 
     #[inline]
     fn sample_rate(&self) -> u32 {
-        self.current_frame.sample_rate as _
+        self.current_span.sample_rate as _
     }
 
     #[inline]
@@ -76,8 +77,8 @@ where
         // TODO waiting for PR in minimp3_fixed or minimp3
 
         // let pos = (pos.as_secs_f32() * self.sample_rate() as f32) as u64;
-        // // do not trigger a sample_rate, channels and frame len update
-        // // as the seek only takes effect after the current frame is done
+        // // do not trigger a sample_rate, channels and frame/span len update
+        // // as the seek only takes effect after the current frame/span is done
         // self.decoder.seek_samples(pos)?;
         // Ok(())
 
@@ -94,18 +95,18 @@ where
     type Item = i16;
 
     fn next(&mut self) -> Option<i16> {
-        if self.current_frame_offset == self.current_frame_len().unwrap() {
-            if let Ok(frame) = self.decoder.next_frame() {
-                // if let Ok(frame) = self.decoder.decode_frame() {
-                self.current_frame = frame;
-                self.current_frame_offset = 0;
+        if self.current_span_offset == self.current_span_len().unwrap() {
+            if let Ok(span) = self.decoder.next_frame() {
+                // if let Ok(span) = self.decoder.decode_frame() {
+                self.current_span = span;
+                self.current_span_offset = 0;
             } else {
                 return None;
             }
         }
 
-        let v = self.current_frame.data[self.current_frame_offset];
-        self.current_frame_offset += 1;
+        let v = self.current_span.data[self.current_span_offset];
+        self.current_span_offset += 1;
 
         Some(v)
     }

--- a/src/decoder/symphonia.rs
+++ b/src/decoder/symphonia.rs
@@ -25,7 +25,7 @@ const MAX_DECODE_RETRIES: usize = 3;
 
 pub(crate) struct SymphoniaDecoder {
     decoder: Box<dyn Decoder>,
-    current_frame_offset: usize,
+    current_span_offset: usize,
     format: Box<dyn FormatReader>,
     total_duration: Option<Time>,
     buffer: SampleBuffer<i16>,
@@ -101,22 +101,22 @@ impl SymphoniaDecoder {
             .codec_params
             .time_base
             .zip(stream.codec_params.n_frames)
-            .map(|(base, frames)| base.calc_time(frames));
+            .map(|(base, spans)| base.calc_time(spans));
 
         let mut decode_errors: usize = 0;
         let decoded = loop {
-            let current_frame = match probed.format.next_packet() {
+            let current_span = match probed.format.next_packet() {
                 Ok(packet) => packet,
                 Err(Error::IoError(_)) => break decoder.last_decoded(),
                 Err(e) => return Err(e),
             };
 
             // If the packet does not belong to the selected track, skip over it
-            if current_frame.track_id() != track_id {
+            if current_span.track_id() != track_id {
                 continue;
             }
 
-            match decoder.decode(&current_frame) {
+            match decoder.decode(&current_span) {
                 Ok(decoded) => break decoded,
                 Err(e) => match e {
                     Error::DecodeError(_) => {
@@ -135,7 +135,7 @@ impl SymphoniaDecoder {
         let buffer = SymphoniaDecoder::get_buffer(decoded, &spec);
         Ok(Some(SymphoniaDecoder {
             decoder,
-            current_frame_offset: 0,
+            current_span_offset: 0,
             format: probed.format,
             total_duration,
             buffer,
@@ -154,7 +154,7 @@ impl SymphoniaDecoder {
 
 impl Source for SymphoniaDecoder {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
+    fn current_span_len(&self) -> Option<usize> {
         Some(self.buffer.samples().len())
     }
 
@@ -188,7 +188,7 @@ impl Source for SymphoniaDecoder {
         };
 
         // make sure the next sample is for the right channel
-        let to_skip = self.current_frame_offset % self.channels() as usize;
+        let to_skip = self.current_span_offset % self.channels() as usize;
 
         let seek_res = self
             .format
@@ -202,7 +202,7 @@ impl Source for SymphoniaDecoder {
             .map_err(SeekError::BaseSeek)?;
 
         self.refine_position(seek_res)?;
-        self.current_frame_offset += to_skip;
+        self.current_span_offset += to_skip;
 
         Ok(())
     }
@@ -262,7 +262,7 @@ impl std::error::Error for SeekError {
 }
 
 impl SymphoniaDecoder {
-    /// Note frame offset must be set after
+    /// Note span offset must be set after
     fn refine_position(&mut self, seek_res: SeekedTo) -> Result<(), source::SeekError> {
         let mut samples_to_pass = seek_res.required_ts - seek_res.actual_ts;
         let packet = loop {
@@ -285,7 +285,7 @@ impl SymphoniaDecoder {
         let decoded = decoded.map_err(SeekError::Decoding)?;
         decoded.spec().clone_into(&mut self.spec);
         self.buffer = SymphoniaDecoder::get_buffer(decoded, &self.spec);
-        self.current_frame_offset = samples_to_pass as usize * self.channels() as usize;
+        self.current_span_offset = samples_to_pass as usize * self.channels() as usize;
         Ok(())
     }
 }
@@ -320,7 +320,7 @@ impl Iterator for SymphoniaDecoder {
 
     #[inline]
     fn next(&mut self) -> Option<i16> {
-        if self.current_frame_offset >= self.buffer.len() {
+        if self.current_span_offset >= self.buffer.len() {
             let packet = self.format.next_packet().ok()?;
             let mut decoded = self.decoder.decode(&packet);
             for _ in 0..MAX_DECODE_RETRIES {
@@ -332,11 +332,11 @@ impl Iterator for SymphoniaDecoder {
             let decoded = decoded.ok()?;
             decoded.spec().clone_into(&mut self.spec);
             self.buffer = SymphoniaDecoder::get_buffer(decoded, &self.spec);
-            self.current_frame_offset = 0;
+            self.current_span_offset = 0;
         }
 
-        let sample = *self.buffer.samples().get(self.current_frame_offset)?;
-        self.current_frame_offset += 1;
+        let sample = *self.buffer.samples().get(self.current_span_offset)?;
+        self.current_span_offset += 1;
 
         Some(sample)
     }

--- a/src/decoder/vorbis.rs
+++ b/src/decoder/vorbis.rs
@@ -57,7 +57,7 @@ where
     R: Read + Seek,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
+    fn current_span_len(&self) -> Option<usize> {
         Some(self.current_data.len())
     }
 

--- a/src/decoder/wav.rs
+++ b/src/decoder/wav.rs
@@ -110,7 +110,7 @@ where
     R: Read + Seek,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
+    fn current_span_len(&self) -> Option<usize> {
         None
     }
 

--- a/src/mixer.rs
+++ b/src/mixer.rs
@@ -85,7 +85,7 @@ where
     S: Sample + Send + 'static,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
+    fn current_span_len(&self) -> Option<usize> {
         None
     }
 

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -122,20 +122,20 @@ where
     S: Sample + Send + 'static,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
+    fn current_span_len(&self) -> Option<usize> {
         // This function is non-trivial because the boundary between two sounds in the queue should
-        // be a frame boundary as well.
+        // be a span boundary as well.
         //
-        // The current sound is free to return `None` for `current_frame_len()`, in which case
+        // The current sound is free to return `None` for `current_span_len()`, in which case
         // we *should* return the number of samples remaining the current sound.
         // This can be estimated with `size_hint()`.
         //
         // If the `size_hint` is `None` as well, we are in the worst case scenario. To handle this
-        // situation we force a frame to have a maximum number of samples indicate by this
+        // situation we force a span to have a maximum number of samples indicate by this
         // constant.
 
-        // Try the current `current_frame_len`.
-        if let Some(val) = self.current.current_frame_len() {
+        // Try the current `current_span_len`.
+        if let Some(val) = self.current.current_span_len() {
             if val != 0 {
                 return Some(val);
             } else if self.input.keep_alive_if_empty.load(Ordering::Acquire)

--- a/src/source/agc.rs
+++ b/src/source/agc.rs
@@ -467,8 +467,8 @@ where
     I::Item: Sample,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
-        self.input.current_frame_len()
+    fn current_span_len(&self) -> Option<usize> {
+        self.input.current_span_len()
     }
 
     #[inline]

--- a/src/source/amplify.rs
+++ b/src/source/amplify.rs
@@ -77,8 +77,8 @@ where
     I::Item: Sample,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
-        self.input.current_frame_len()
+    fn current_span_len(&self) -> Option<usize> {
+        self.input.current_span_len()
     }
 
     #[inline]

--- a/src/source/blt.rs
+++ b/src/source/blt.rs
@@ -116,7 +116,7 @@ where
 
     #[inline]
     fn next(&mut self) -> Option<f32> {
-        let last_in_frame = self.input.current_frame_len() == Some(1);
+        let last_in_span = self.input.current_span_len() == Some(1);
 
         if self.applier.is_none() {
             self.applier = Some(self.formula.to_applier(self.input.sample_rate()));
@@ -138,7 +138,7 @@ where
         self.y_n1 = result;
         self.x_n1 = sample;
 
-        if last_in_frame {
+        if last_in_span {
             self.applier = None;
         }
 
@@ -158,8 +158,8 @@ where
     I: Source<Item = f32>,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
-        self.input.current_frame_len()
+    fn current_span_len(&self) -> Option<usize> {
+        self.input.current_span_len()
     }
 
     #[inline]

--- a/src/source/buffered.rs
+++ b/src/source/buffered.rs
@@ -15,11 +15,11 @@ where
     I::Item: Sample,
 {
     let total_duration = input.total_duration();
-    let first_frame = extract(input);
+    let first_span = extract(input);
 
     Buffered {
-        current_frame: first_frame,
-        position_in_frame: 0,
+        current_span: first_span,
+        position_in_span: 0,
         total_duration,
     }
 }
@@ -30,24 +30,24 @@ where
     I: Source,
     I::Item: Sample,
 {
-    /// Immutable reference to the next frame of data. Cannot be `Frame::Input`.
-    current_frame: Arc<Frame<I>>,
+    /// Immutable reference to the next span of data. Cannot be `Span::Input`.
+    current_span: Arc<Span<I>>,
 
-    /// The position in number of samples of this iterator inside `current_frame`.
-    position_in_frame: usize,
+    /// The position in number of samples of this iterator inside `current_span`.
+    position_in_span: usize,
 
     /// Obtained once at creation and never modified again.
     total_duration: Option<Duration>,
 }
 
-enum Frame<I>
+enum Span<I>
 where
     I: Source,
     I::Item: Sample,
 {
     /// Data that has already been extracted from the iterator. Also contains a pointer to the
-    /// next frame.
-    Data(FrameData<I>),
+    /// next span.
+    Data(SpanData<I>),
 
     /// No more data.
     End,
@@ -57,7 +57,7 @@ where
     Input(Mutex<Option<I>>),
 }
 
-struct FrameData<I>
+struct SpanData<I>
 where
     I: Source,
     I::Item: Sample,
@@ -65,27 +65,27 @@ where
     data: Vec<I::Item>,
     channels: u16,
     rate: u32,
-    next: Mutex<Arc<Frame<I>>>,
+    next: Mutex<Arc<Span<I>>>,
 }
 
-impl<I> Drop for FrameData<I>
+impl<I> Drop for SpanData<I>
 where
     I: Source,
     I::Item: Sample,
 {
     fn drop(&mut self) {
         // This is necessary to prevent stack overflows deallocating long chains of the mutually
-        // recursive `Frame` and `FrameData` types. This iteratively traverses as much of the
+        // recursive `Span` and `SpanData` types. This iteratively traverses as much of the
         // chain as needs to be deallocated, and repeatedly "pops" the head off the list. This
-        // solves the problem, as when the time comes to actually deallocate the `FrameData`,
-        // the `next` field will contain a `Frame::End`, or an `Arc` with additional references,
+        // solves the problem, as when the time comes to actually deallocate the `SpanData`,
+        // the `next` field will contain a `Span::End`, or an `Arc` with additional references,
         // so the depth of recursive drops will be bounded.
         while let Ok(arc_next) = self.next.get_mut() {
             if let Some(next_ref) = Arc::get_mut(arc_next) {
-                // This allows us to own the next Frame.
-                let next = mem::replace(next_ref, Frame::End);
-                if let Frame::Data(next_data) = next {
-                    // Swap the current FrameData with the next one, allowing the current one
+                // This allows us to own the next Span.
+                let next = mem::replace(next_ref, Span::End);
+                if let Span::Data(next_data) = next {
+                    // Swap the current SpanData with the next one, allowing the current one
                     // to go out of scope.
                     *self = next_data;
                 } else {
@@ -98,34 +98,34 @@ where
     }
 }
 
-/// Builds a frame from the input iterator.
-fn extract<I>(mut input: I) -> Arc<Frame<I>>
+/// Builds a span from the input iterator.
+fn extract<I>(mut input: I) -> Arc<Span<I>>
 where
     I: Source,
     I::Item: Sample,
 {
-    let frame_len = input.current_frame_len();
+    let span_len = input.current_span_len();
 
-    if frame_len == Some(0) {
-        return Arc::new(Frame::End);
+    if span_len == Some(0) {
+        return Arc::new(Span::End);
     }
 
     let channels = input.channels();
     let rate = input.sample_rate();
     let data: Vec<I::Item> = input
         .by_ref()
-        .take(cmp::min(frame_len.unwrap_or(32768), 32768))
+        .take(cmp::min(span_len.unwrap_or(32768), 32768))
         .collect();
 
     if data.is_empty() {
-        return Arc::new(Frame::End);
+        return Arc::new(Span::End);
     }
 
-    Arc::new(Frame::Data(FrameData {
+    Arc::new(Span::Data(SpanData {
         data,
         channels,
         rate,
-        next: Mutex::new(Arc::new(Frame::Input(Mutex::new(Some(input))))),
+        next: Mutex::new(Arc::new(Span::Input(Mutex::new(Some(input))))),
     }))
 }
 
@@ -134,29 +134,29 @@ where
     I: Source,
     I::Item: Sample,
 {
-    /// Advances to the next frame.
-    fn next_frame(&mut self) {
-        let next_frame = {
-            let mut next_frame_ptr = match &*self.current_frame {
-                Frame::Data(FrameData { next, .. }) => next.lock().unwrap(),
+    /// Advances to the next span.
+    fn next_span(&mut self) {
+        let next_span = {
+            let mut next_span_ptr = match &*self.current_span {
+                Span::Data(SpanData { next, .. }) => next.lock().unwrap(),
                 _ => unreachable!(),
             };
 
-            let next_frame = match &**next_frame_ptr {
-                Frame::Data(_) => next_frame_ptr.clone(),
-                Frame::End => next_frame_ptr.clone(),
-                Frame::Input(input) => {
+            let next_span = match &**next_span_ptr {
+                Span::Data(_) => next_span_ptr.clone(),
+                Span::End => next_span_ptr.clone(),
+                Span::Input(input) => {
                     let input = input.lock().unwrap().take().unwrap();
                     extract(input)
                 }
             };
 
-            *next_frame_ptr = next_frame.clone();
-            next_frame
+            *next_span_ptr = next_span.clone();
+            next_span
         };
 
-        self.current_frame = next_frame;
-        self.position_in_frame = 0;
+        self.current_span = next_span;
+        self.position_in_span = 0;
     }
 }
 
@@ -170,25 +170,25 @@ where
     #[inline]
     fn next(&mut self) -> Option<I::Item> {
         let current_sample;
-        let advance_frame;
+        let advance_span;
 
-        match &*self.current_frame {
-            Frame::Data(FrameData { data, .. }) => {
-                current_sample = Some(data[self.position_in_frame]);
-                self.position_in_frame += 1;
-                advance_frame = self.position_in_frame >= data.len();
+        match &*self.current_span {
+            Span::Data(SpanData { data, .. }) => {
+                current_sample = Some(data[self.position_in_span]);
+                self.position_in_span += 1;
+                advance_span = self.position_in_span >= data.len();
             }
 
-            Frame::End => {
+            Span::End => {
                 current_sample = None;
-                advance_frame = false;
+                advance_span = false;
             }
 
-            Frame::Input(_) => unreachable!(),
+            Span::Input(_) => unreachable!(),
         };
 
-        if advance_frame {
-            self.next_frame();
+        if advance_span {
+            self.next_span();
         }
 
         current_sample
@@ -211,29 +211,29 @@ where
     I::Item: Sample,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
-        match &*self.current_frame {
-            Frame::Data(FrameData { data, .. }) => Some(data.len() - self.position_in_frame),
-            Frame::End => Some(0),
-            Frame::Input(_) => unreachable!(),
+    fn current_span_len(&self) -> Option<usize> {
+        match &*self.current_span {
+            Span::Data(SpanData { data, .. }) => Some(data.len() - self.position_in_span),
+            Span::End => Some(0),
+            Span::Input(_) => unreachable!(),
         }
     }
 
     #[inline]
     fn channels(&self) -> u16 {
-        match *self.current_frame {
-            Frame::Data(FrameData { channels, .. }) => channels,
-            Frame::End => 1,
-            Frame::Input(_) => unreachable!(),
+        match *self.current_span {
+            Span::Data(SpanData { channels, .. }) => channels,
+            Span::End => 1,
+            Span::Input(_) => unreachable!(),
         }
     }
 
     #[inline]
     fn sample_rate(&self) -> u32 {
-        match *self.current_frame {
-            Frame::Data(FrameData { rate, .. }) => rate,
-            Frame::End => 44100,
-            Frame::Input(_) => unreachable!(),
+        match *self.current_span {
+            Span::Data(SpanData { rate, .. }) => rate,
+            Span::End => 44100,
+            Span::Input(_) => unreachable!(),
         }
     }
 
@@ -260,8 +260,8 @@ where
     #[inline]
     fn clone(&self) -> Buffered<I> {
         Buffered {
-            current_frame: self.current_frame.clone(),
-            position_in_frame: self.position_in_frame,
+            current_span: self.current_span.clone(),
+            position_in_span: self.position_in_span,
             total_duration: self.total_duration,
         }
     }

--- a/src/source/channel_volume.rs
+++ b/src/source/channel_volume.rs
@@ -124,8 +124,8 @@ where
     I::Item: Sample,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
-        self.input.current_frame_len()
+    fn current_span_len(&self) -> Option<usize> {
+        self.input.current_span_len()
     }
 
     #[inline]

--- a/src/source/chirp.rs
+++ b/src/source/chirp.rs
@@ -57,7 +57,7 @@ impl Iterator for Chirp {
 }
 
 impl Source for Chirp {
-    fn current_frame_len(&self) -> Option<usize> {
+    fn current_span_len(&self) -> Option<usize> {
         None
     }
 

--- a/src/source/delay.rs
+++ b/src/source/delay.rs
@@ -88,9 +88,9 @@ where
     I::Item: Sample,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
+    fn current_span_len(&self) -> Option<usize> {
         self.input
-            .current_frame_len()
+            .current_span_len()
             .map(|val| val + self.remaining_samples)
     }
 

--- a/src/source/done.rs
+++ b/src/source/done.rs
@@ -73,8 +73,8 @@ where
     I::Item: Sample,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
-        self.input.current_frame_len()
+    fn current_span_len(&self) -> Option<usize> {
+        self.input.current_span_len()
     }
 
     #[inline]

--- a/src/source/empty.rs
+++ b/src/source/empty.rs
@@ -39,7 +39,7 @@ where
     S: Sample,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
+    fn current_span_len(&self) -> Option<usize> {
         None
     }
 

--- a/src/source/empty_callback.rs
+++ b/src/source/empty_callback.rs
@@ -42,7 +42,7 @@ where
     S: Sample,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
+    fn current_span_len(&self) -> Option<usize> {
         None
     }
 

--- a/src/source/fadein.rs
+++ b/src/source/fadein.rs
@@ -76,8 +76,8 @@ where
     I::Item: Sample,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
-        self.inner().current_frame_len()
+    fn current_span_len(&self) -> Option<usize> {
+        self.inner().current_span_len()
     }
 
     #[inline]

--- a/src/source/fadeout.rs
+++ b/src/source/fadeout.rs
@@ -76,8 +76,8 @@ where
     I::Item: Sample,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
-        self.inner().current_frame_len()
+    fn current_span_len(&self) -> Option<usize> {
+        self.inner().current_span_len()
     }
 
     #[inline]

--- a/src/source/from_iter.rs
+++ b/src/source/from_iter.rs
@@ -78,22 +78,22 @@ where
     <I::Item as Iterator>::Item: Sample,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
+    fn current_span_len(&self) -> Option<usize> {
         // This function is non-trivial because the boundary between the current source and the
-        // next must be a frame boundary as well.
+        // next must be a span boundary as well.
         //
-        // The current sound is free to return `None` for `current_frame_len()`, in which case
+        // The current sound is free to return `None` for `current_span_len()`, in which case
         // we *should* return the number of samples remaining the current sound.
         // This can be estimated with `size_hint()`.
         //
         // If the `size_hint` is `None` as well, we are in the worst case scenario. To handle this
-        // situation we force a frame to have a maximum number of samples indicate by this
+        // situation we force a span to have a maximum number of samples indicate by this
         // constant.
         const THRESHOLD: usize = 10240;
 
-        // Try the current `current_frame_len`.
+        // Try the current `current_span_len`.
         if let Some(src) = &self.current_source {
-            if let Some(val) = src.current_frame_len() {
+            if let Some(val) = src.current_span_len() {
                 if val != 0 {
                     return Some(val);
                 }

--- a/src/source/linear_ramp.rs
+++ b/src/source/linear_ramp.rs
@@ -116,8 +116,8 @@ where
     I::Item: Sample,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
-        self.input.current_frame_len()
+    fn current_span_len(&self) -> Option<usize> {
+        self.input.current_span_len()
     }
 
     #[inline]

--- a/src/source/mix.rs
+++ b/src/source/mix.rs
@@ -90,9 +90,9 @@ where
     I2::Item: Sample,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
-        let f1 = self.input1.current_frame_len();
-        let f2 = self.input2.current_frame_len();
+    fn current_span_len(&self) -> Option<usize> {
+        let f1 = self.input1.current_span_len();
+        let f2 = self.input2.current_span_len();
 
         match (f1, f2) {
             (Some(f1), Some(f2)) => Some(cmp::min(f1, f2)),

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -135,7 +135,7 @@ pub use self::noise::{pink, white, PinkNoise, WhiteNoise};
 ///   that the `Iterator` trait be implemented as well. When a `Source` returns None the
 ///   sound has ended.
 ///
-/// # Frames
+/// # Spans
 ///
 /// The samples rate and number of channels of some sound sources can change by itself from time
 /// to time.
@@ -148,7 +148,7 @@ pub use self::noise::{pink, white, PinkNoise, WhiteNoise};
 /// stay the same for long periods of time and avoids calling `channels()` and
 /// `sample_rate` too frequently.
 ///
-/// In order to properly handle this situation, the `current_frame_len()` method should return
+/// In order to properly handle this situation, the `current_span_len()` method should return
 /// the number of samples that remain in the iterator before the samples rate and number of
 /// channels can potentially change.
 ///
@@ -156,13 +156,13 @@ pub trait Source: Iterator
 where
     Self::Item: Sample,
 {
-    /// Returns the number of samples before the current frame ends. `None` means "infinite" or
+    /// Returns the number of samples before the current span ends. `None` means "infinite" or
     /// "until the sound ends".
     /// Should never return 0 unless there's no more data.
     ///
     /// After the engine has finished reading the specified number of samples, it will check
     /// whether the value of `channels()` and/or `sample_rate()` have changed.
-    fn current_frame_len(&self) -> Option<usize>;
+    fn current_span_len(&self) -> Option<usize>;
 
     /// Returns the number of channels. Channels are always interleaved.
     fn channels(&self) -> u16;
@@ -219,7 +219,7 @@ where
 
     /// Delays the sound by a certain duration.
     ///
-    /// The rate and channels of the silence will use the same format as the first frame of the
+    /// The rate and channels of the silence will use the same format as the first span of the
     /// source.
     #[inline]
     fn delay(self, duration: Duration) -> Delay<Self>
@@ -664,8 +664,8 @@ macro_rules! source_pointer_impl {
     ($($sig:tt)+) => {
         impl $($sig)+ {
             #[inline]
-            fn current_frame_len(&self) -> Option<usize> {
-                (**self).current_frame_len()
+            fn current_span_len(&self) -> Option<usize> {
+                (**self).current_span_len()
             }
 
             #[inline]

--- a/src/source/noise.rs
+++ b/src/source/noise.rs
@@ -59,7 +59,7 @@ impl Iterator for WhiteNoise {
 
 impl Source for WhiteNoise {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
+    fn current_span_len(&self) -> Option<usize> {
         None
     }
 
@@ -134,7 +134,7 @@ impl Iterator for PinkNoise {
 }
 
 impl Source for PinkNoise {
-    fn current_frame_len(&self) -> Option<usize> {
+    fn current_span_len(&self) -> Option<usize> {
         None
     }
 

--- a/src/source/pausable.rs
+++ b/src/source/pausable.rs
@@ -105,8 +105,8 @@ where
     I::Item: Sample,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
-        self.input.current_frame_len()
+    fn current_span_len(&self) -> Option<usize> {
+        self.input.current_span_len()
     }
 
     #[inline]

--- a/src/source/periodic.rs
+++ b/src/source/periodic.rs
@@ -101,8 +101,8 @@ where
     F: FnMut(&mut I),
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
-        self.input.current_frame_len()
+    fn current_span_len(&self) -> Option<usize> {
+        self.input.current_span_len()
     }
 
     #[inline]

--- a/src/source/position.rs
+++ b/src/source/position.rs
@@ -11,9 +11,9 @@ pub fn track_position<I>(source: I) -> TrackPosition<I> {
         input: source,
         samples_counted: 0,
         offset_duration: 0.0,
-        current_frame_sample_rate: 0,
-        current_frame_channels: 0,
-        current_frame_len: None,
+        current_span_sample_rate: 0,
+        current_span_channels: 0,
+        current_span_len: None,
     }
 }
 
@@ -23,9 +23,9 @@ pub struct TrackPosition<I> {
     input: I,
     samples_counted: usize,
     offset_duration: f64,
-    current_frame_sample_rate: u32,
-    current_frame_channels: u16,
-    current_frame_len: Option<usize>,
+    current_span_sample_rate: u32,
+    current_span_channels: u16,
+    current_span_len: Option<usize>,
 }
 
 impl<I> TrackPosition<I> {
@@ -73,10 +73,10 @@ where
     }
 
     #[inline]
-    fn set_current_frame(&mut self) {
-        self.current_frame_len = self.current_frame_len();
-        self.current_frame_sample_rate = self.sample_rate();
-        self.current_frame_channels = self.channels();
+    fn set_current_span(&mut self) {
+        self.current_span_len = self.current_span_len();
+        self.current_span_sample_rate = self.sample_rate();
+        self.current_span_channels = self.channels();
     }
 }
 
@@ -90,24 +90,24 @@ where
     #[inline]
     fn next(&mut self) -> Option<I::Item> {
         // This should only be executed once at the first call to next.
-        if self.current_frame_len.is_none() {
-            self.set_current_frame();
+        if self.current_span_len.is_none() {
+            self.set_current_span();
         }
 
         let item = self.input.next();
         if item.is_some() {
             self.samples_counted += 1;
 
-            // At the end of a frame add the duration of this frame to
+            // At the end of a span add the duration of this span to
             // offset_duration and start collecting samples again.
-            if Some(self.samples_counted) == self.current_frame_len() {
+            if Some(self.samples_counted) == self.current_span_len() {
                 self.offset_duration += self.samples_counted as f64
-                    / self.current_frame_sample_rate as f64
-                    / self.current_frame_channels as f64;
+                    / self.current_span_sample_rate as f64
+                    / self.current_span_channels as f64;
 
                 // Reset.
                 self.samples_counted = 0;
-                self.set_current_frame();
+                self.set_current_span();
             };
         };
         item
@@ -125,8 +125,8 @@ where
     I::Item: Sample,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
-        self.input.current_frame_len()
+    fn current_span_len(&self) -> Option<usize> {
+        self.input.current_span_len()
     }
 
     #[inline]
@@ -150,7 +150,7 @@ where
         if result.is_ok() {
             self.offset_duration = pos.as_secs_f64();
             // This assumes that the seek implementation of the codec always
-            // starts again at the beginning of a frame. Which is the case with
+            // starts again at the beginning of a span. Which is the case with
             // symphonia.
             self.samples_counted = 0;
         }

--- a/src/source/repeat.rs
+++ b/src/source/repeat.rs
@@ -59,16 +59,16 @@ where
     I::Item: Sample,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
-        match self.inner.current_frame_len() {
-            Some(0) => self.next.current_frame_len(),
+    fn current_span_len(&self) -> Option<usize> {
+        match self.inner.current_span_len() {
+            Some(0) => self.next.current_span_len(),
             a => a,
         }
     }
 
     #[inline]
     fn channels(&self) -> u16 {
-        match self.inner.current_frame_len() {
+        match self.inner.current_span_len() {
             Some(0) => self.next.channels(),
             _ => self.inner.channels(),
         }
@@ -76,7 +76,7 @@ where
 
     #[inline]
     fn sample_rate(&self) -> u32 {
-        match self.inner.current_frame_len() {
+        match self.inner.current_span_len() {
             Some(0) => self.next.sample_rate(),
             _ => self.inner.sample_rate(),
         }

--- a/src/source/samples_converter.rs
+++ b/src/source/samples_converter.rs
@@ -78,8 +78,8 @@ where
     D: FromSample<I::Item> + Sample,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
-        self.inner.current_frame_len()
+    fn current_span_len(&self) -> Option<usize> {
+        self.inner.current_span_len()
     }
 
     #[inline]

--- a/src/source/sawtooth.rs
+++ b/src/source/sawtooth.rs
@@ -40,7 +40,7 @@ impl Iterator for SawtoothWave {
 
 impl Source for SawtoothWave {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
+    fn current_span_len(&self) -> Option<usize> {
         None
     }
 

--- a/src/source/signal_generator.rs
+++ b/src/source/signal_generator.rs
@@ -137,7 +137,7 @@ impl Iterator for SignalGenerator {
 
 impl Source for SignalGenerator {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
+    fn current_span_len(&self) -> Option<usize> {
         None
     }
 

--- a/src/source/sine.rs
+++ b/src/source/sine.rs
@@ -40,7 +40,7 @@ impl Iterator for SineWave {
 
 impl Source for SineWave {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
+    fn current_span_len(&self) -> Option<usize> {
         None
     }
 

--- a/src/source/skip.rs
+++ b/src/source/skip.rs
@@ -26,33 +26,33 @@ where
     I::Item: Sample,
 {
     while duration > Duration::new(0, 0) {
-        if input.current_frame_len().is_none() {
+        if input.current_span_len().is_none() {
             // Sample rate and the amount of channels will be the same till the end.
             do_skip_duration_unchecked(input, duration);
             return;
         }
 
-        // .unwrap() safety: if `current_frame_len()` is None, the body of the `if` statement
+        // .unwrap() safety: if `current_span_len()` is None, the body of the `if` statement
         // above returns before we get here.
-        let frame_len: usize = input.current_frame_len().unwrap();
-        // If frame_len is zero, then there is no more data to skip. Instead
+        let span_len: usize = input.current_span_len().unwrap();
+        // If span_len is zero, then there is no more data to skip. Instead
         // just bail out.
-        if frame_len == 0 {
+        if span_len == 0 {
             return;
         }
 
         let ns_per_sample: u128 =
             NS_PER_SECOND / input.sample_rate() as u128 / input.channels() as u128;
 
-        // Check if we need to skip only part of the current frame.
-        if frame_len as u128 * ns_per_sample > duration.as_nanos() {
+        // Check if we need to skip only part of the current span.
+        if span_len as u128 * ns_per_sample > duration.as_nanos() {
             skip_samples(input, (duration.as_nanos() / ns_per_sample) as usize);
             return;
         }
 
-        skip_samples(input, frame_len);
+        skip_samples(input, span_len);
 
-        duration -= Duration::from_nanos((frame_len * ns_per_sample as usize) as u64);
+        duration -= Duration::from_nanos((span_len * ns_per_sample as usize) as u64);
     }
 }
 
@@ -138,8 +138,8 @@ where
     I::Item: Sample,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
-        self.input.current_frame_len()
+    fn current_span_len(&self) -> Option<usize> {
+        self.input.current_span_len()
     }
 
     #[inline]

--- a/src/source/skippable.rs
+++ b/src/source/skippable.rs
@@ -78,8 +78,8 @@ where
     I::Item: Sample,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
-        self.input.current_frame_len()
+    fn current_span_len(&self) -> Option<usize> {
+        self.input.current_span_len()
     }
 
     #[inline]

--- a/src/source/spatial.rs
+++ b/src/source/spatial.rs
@@ -103,8 +103,8 @@ where
     I::Item: Sample,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
-        self.input.current_frame_len()
+    fn current_span_len(&self) -> Option<usize> {
+        self.input.current_span_len()
     }
 
     #[inline]

--- a/src/source/speed.rs
+++ b/src/source/speed.rs
@@ -124,8 +124,8 @@ where
     I::Item: Sample,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
-        self.input.current_frame_len()
+    fn current_span_len(&self) -> Option<usize> {
+        self.input.current_span_len()
     }
 
     #[inline]

--- a/src/source/square.rs
+++ b/src/source/square.rs
@@ -40,7 +40,7 @@ impl Iterator for SquareWave {
 
 impl Source for SquareWave {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
+    fn current_span_len(&self) -> Option<usize> {
         None
     }
 

--- a/src/source/stoppable.rs
+++ b/src/source/stoppable.rs
@@ -73,8 +73,8 @@ where
     I::Item: Sample,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
-        self.input.current_frame_len()
+    fn current_span_len(&self) -> Option<usize> {
+        self.input.current_span_len()
     }
 
     #[inline]

--- a/src/source/take.rs
+++ b/src/source/take.rs
@@ -11,7 +11,7 @@ where
     I::Item: Sample,
 {
     TakeDuration {
-        current_frame_len: input.current_frame_len(),
+        current_span_len: input.current_span_len(),
         duration_per_sample: TakeDuration::get_duration_per_sample(&input),
         input,
         remaining_duration: duration,
@@ -54,9 +54,9 @@ pub struct TakeDuration<I> {
     remaining_duration: Duration,
     requested_duration: Duration,
     filter: Option<DurationFilter>,
-    // Remaining samples in current frame.
-    current_frame_len: Option<usize>,
-    // Only updated when the current frame len is exhausted.
+    // Remaining samples in current span.
+    current_span_len: Option<usize>,
+    // Only updated when the current span len is exhausted.
     duration_per_sample: Duration,
 }
 
@@ -111,11 +111,11 @@ where
     type Item = <I as Iterator>::Item;
 
     fn next(&mut self) -> Option<<I as Iterator>::Item> {
-        if let Some(frame_len) = self.current_frame_len.take() {
-            if frame_len > 0 {
-                self.current_frame_len = Some(frame_len - 1);
+        if let Some(span_len) = self.current_span_len.take() {
+            if span_len > 0 {
+                self.current_span_len = Some(span_len - 1);
             } else {
-                self.current_frame_len = self.input.current_frame_len();
+                self.current_span_len = self.input.current_span_len();
                 // Sample rate might have changed
                 self.duration_per_sample = Self::get_duration_per_sample(&self.input);
             }
@@ -146,7 +146,7 @@ where
     I::Item: Sample,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
+    fn current_span_len(&self) -> Option<usize> {
         let remaining_nanos = self.remaining_duration.as_secs() * NANOS_PER_SEC
             + self.remaining_duration.subsec_nanos() as u64;
         let nanos_per_sample = self.duration_per_sample.as_secs() * NANOS_PER_SEC
@@ -154,7 +154,7 @@ where
         let remaining_samples = (remaining_nanos / nanos_per_sample) as usize;
 
         self.input
-            .current_frame_len()
+            .current_span_len()
             .filter(|value| *value < remaining_samples)
             .or(Some(remaining_samples))
     }

--- a/src/source/triangle.rs
+++ b/src/source/triangle.rs
@@ -40,7 +40,7 @@ impl Iterator for TriangleWave {
 
 impl Source for TriangleWave {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
+    fn current_span_len(&self) -> Option<usize> {
         None
     }
 

--- a/src/source/uniform.rs
+++ b/src/source/uniform.rs
@@ -12,7 +12,7 @@ use super::SeekError;
 /// specific type, sample-rate and channels count.
 ///
 /// It implements `Source` as well, but all the data is guaranteed to be in a
-/// single frame whose channels and samples rate have been passed to `new`.
+/// single span whose channels and samples rate have been passed to `new`.
 #[derive(Clone)]
 pub struct UniformSourceIterator<I, D>
 where
@@ -57,15 +57,15 @@ where
         target_channels: u16,
         target_sample_rate: u32,
     ) -> DataConverter<ChannelCountConverter<SampleRateConverter<Take<I>>>, D> {
-        // Limit the frame length to something reasonable
-        let frame_len = input.current_frame_len().map(|x| x.min(32768));
+        // Limit the span length to something reasonable
+        let span_len = input.current_span_len().map(|x| x.min(32768));
 
         let from_channels = input.channels();
         let from_sample_rate = input.sample_rate();
 
         let input = Take {
             iter: input,
-            n: frame_len,
+            n: span_len,
         };
         let input = SampleRateConverter::new(
             input,
@@ -123,7 +123,7 @@ where
     D: FromSample<I::Item> + Sample,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
+    fn current_span_len(&self) -> Option<usize> {
         None
     }
 

--- a/src/source/zero.rs
+++ b/src/source/zero.rs
@@ -65,7 +65,7 @@ where
     S: Sample,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
+    fn current_span_len(&self) -> Option<usize> {
         self.num_samples
     }
 

--- a/src/static_buffer.rs
+++ b/src/static_buffer.rs
@@ -67,7 +67,7 @@ where
     S: Sample,
 {
     #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
+    fn current_span_len(&self) -> Option<usize> {
         None
     }
 


### PR DESCRIPTION
This PR renames frame -> span in the code and documentation, where applicable (see issue #660 and discussion in #652). 

One question that is open is about some differing terminology in the minimp3 decoder. Specifically, the mp3  `Frame`s from the minimp3 crate are interpreted as spans in the new rodio terminology. Therefore, when renaming values used by this decoder, should the term "frame" or "span" be preferred where possible? 

This code snippet from `src/decoder/mp3.rs`  illustrates this question:

```rust
pub struct Mp3Decoder<R>
where
    R: Read + Seek,
{
    // decoder: SeekDecoder<R>,
    decoder: Decoder<R>,
    // minimp3 Frames are interpreted as rodio spans
    current_span: Frame,
    current_span_offset: usize,
}
```
I went with this approach for now, because it seems quite explicit about the interpretation of `Frame`s, but I can also see the argument for matching the struct member name to its type.

Thanks