### PR TITLE
adds upgrade guide draft (frame->span + stream open)

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,4 +6,8 @@ This guide will help you update your code when upgrading from rodio 0.20 or earl
 ## OutputStream
 - The outputstream is now more configurable. Where you used `OutputStream::try_default()` you have a choice:
     - *(recommended)* Get an error when the default stream could not be opened: `OutputStreamBuilder::open_default_stream()?`
-    - Keep the old behavior using: `OutputStreamBuilder::open_stream_or_fallback()`, which tries to open the default (audio) stream trying others when the default stream could not be opened.
+    - Stay close to the old behavior using:
+      `OutputStreamBuilder::open_stream_or_fallback()`, which tries to open the
+      default (audio) stream. If that fails it tries all other combinations of
+      device and settings. The old behavior was only trying all settings of the
+      default device.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,9 @@
+This guide will help you update your code when upgrading from rodio 0.20 or earlier to the current version.
+
+## Source implementations
+- Source had a required method `current_frame_len`. In the latest version of rodio *frame* has been renamed to *span*. You will need to change every occurrence of `current_frame_len` to `current_span_len`.
+
+## OutputStream
+- The outputstream is now more configurable. Where you used `OutputStream::try_default()` you have a choice:
+    - *(recommended)* Get an error when the default stream could not be opened: `OutputStreamBuilder::open_default_stream()?`
+    - Keep the old behavior using: `OutputStreamBuilder::open_stream_or_fallback()`, which tries to open the default (audio) stream trying others when the default stream could not be opened.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,4 +1,6 @@
-This guide will help you update your code when upgrading from rodio 0.20 or earlier to the current version.
+This guide will help you update your code when upgrading from older versions of rodio.
+
+# rodio 0.20 to 0.21
 
 ## Source implementations
 - Source had a required method `current_frame_len`. In the latest version of rodio *frame* has been renamed to *span*. You will need to change every occurrence of `current_frame_len` to `current_span_len`.


### PR DESCRIPTION
We will point users who upgrade to the next rodio release to this document. It will help them upgrade (and save us a lot of confused users and issues).

I do not think I have missed anything. I suggest we merge this and then every PR that introduces a breaking change updates this document. I have already done that for still open PR #663.