### PR TITLE
Decoder overhaul (16 to f32 samples + other enhancements)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Symphonia decoder `total_duration` incorrect value caused by conversion from `Time` to `Duration`.
 - An issue with `SignalGenerator` that caused it to create increasingly distorted waveforms
   over long run times has been corrected. (#201)
+- FLAC decoder duration calculation now calculated once and handles very large files correctly
+- Removed unwrap() calls in FLAC format detection for better error handling
 
 ### Deprecated
 - Deprecated `Sample::zero_value()` function in favor of `Sample::ZERO_VALUE` constant

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - An issue with `SignalGenerator` that caused it to create increasingly distorted waveforms
   over long run times has been corrected. (#201)
 - WAV and FLAC decoder duration calculation now calculated once and handles very large files correctly
-- Removed unwrap() calls in WAV and FLAC format detection for better error handling
+- Removed unwrap() calls in MP3, WAV and FLAC format detection for better error handling
 
 ### Deprecated
 - Deprecated `Sample::zero_value()` function in favor of `Sample::ZERO_VALUE` constant

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Breaking: `Sink::try_new` renamed to `connect_new` and does not return error anymore.
             `Sink::new_idle` was renamed to `new`.
 - Breaking: In the `Source` trait, the method `current_frame_len()` was renamed to `current_span_len()`.
+- Breaking: `Decoder` now outputs `f32` samples instead of `i16`.
 - The term 'frame' was renamed to 'span' in the crate and documentation.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Breaking: `Sink::try_new` renamed to `connect_new` and does not return error anymore.
             `Sink::new_idle` was renamed to `new`.
 - Breaking: In the `Source` trait, the method `current_frame_len()` was renamed to `current_span_len()`.
-- Breaking: `Decoder` now outputs `f32` samples instead of `i16`.
+- Breaking: `Decoder` now outputs `f32` samples by default instead of `i16`.
+  Enable the `integer-decoder` to revert to `i16` samples.
 - The term 'frame' was renamed to 'span' in the crate and documentation.
 
 ### Fixed
@@ -36,8 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Symphonia decoder `total_duration` incorrect value caused by conversion from `Time` to `Duration`.
 - An issue with `SignalGenerator` that caused it to create increasingly distorted waveforms
   over long run times has been corrected. (#201)
-- WAV and FLAC decoder duration calculation now calculated once and handles very large files correctly
-- Removed unwrap() calls in MP3, WAV and FLAC format detection for better error handling
+- WAV and FLAC decoder duration calculation now calculated once and handles very large files
+  correctly
+- Removed unwrap() calls in MP3, WAV, FLAC and Vorbis format detection for better error handling
 
 ### Deprecated
 - Deprecated `Sample::zero_value()` function in favor of `Sample::ZERO_VALUE` constant

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Symphonia decoder `total_duration` incorrect value caused by conversion from `Time` to `Duration`.
 - An issue with `SignalGenerator` that caused it to create increasingly distorted waveforms
   over long run times has been corrected. (#201)
-- FLAC decoder duration calculation now calculated once and handles very large files correctly
-- Removed unwrap() calls in FLAC format detection for better error handling
+- WAV and FLAC decoder duration calculation now calculated once and handles very large files correctly
+- Removed unwrap() calls in WAV and FLAC format detection for better error handling
 
 ### Deprecated
 - Deprecated `Sample::zero_value()` function in favor of `Sample::ZERO_VALUE` constant

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `GeneratorFunction`.
 - Minimal builds without `cpal` audio output are now supported.
   See `README.md` for instructions. (#349)
+- Added `Sample::is_zero()` method for checking zero samples.
 
 ### Changed
 - Breaking: `OutputStreamBuilder` should now be used to initialize an audio output stream.
@@ -35,6 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Symphonia decoder `total_duration` incorrect value caused by conversion from `Time` to `Duration`.
 - An issue with `SignalGenerator` that caused it to create increasingly distorted waveforms
   over long run times has been corrected. (#201)
+
+### Deprecated
+- Deprecated `Sample::zero_value()` function in favor of `Sample::ZERO_VALUE` constant
 
 # Version 0.20.1 (2024-11-08)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ default = ["playback", "flac", "vorbis", "wav", "mp3"]
 tracing = ["dep:tracing"]
 experimental = ["dep:atomic_float"]
 playback = ["dep:cpal"]
-integer-samples = []
+integer-decoder = []
 
 flac = ["claxon"]
 vorbis = ["lewton"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,17 +30,28 @@ default = ["playback", "flac", "vorbis", "wav", "mp3"]
 tracing = ["dep:tracing"]
 experimental = ["dep:atomic_float"]
 playback = ["dep:cpal"]
+integer-samples = []
 
 flac = ["claxon"]
 vorbis = ["lewton"]
 wav = ["hound"]
 mp3 = ["symphonia-mp3"]
 minimp3 = ["dep:minimp3_fixed"]
+
 noise = ["rand"]
+
 wasm-bindgen = ["cpal/wasm-bindgen"]
 cpal-shared-stdcxx = ["cpal/oboe-shared-stdcxx"]
+
 symphonia-aac = ["symphonia/aac"]
-symphonia-all = ["symphonia-aac", "symphonia-flac", "symphonia-isomp4", "symphonia-mp3", "symphonia-vorbis", "symphonia-wav"]
+symphonia-all = [
+    "symphonia-aac",
+    "symphonia-flac",
+    "symphonia-isomp4",
+    "symphonia-mp3",
+    "symphonia-vorbis",
+    "symphonia-wav",
+]
 symphonia-flac = ["symphonia/flac"]
 symphonia-isomp4 = ["symphonia/isomp4"]
 symphonia-mp3 = ["symphonia/mp3"]

--- a/benches/conversions.rs
+++ b/benches/conversions.rs
@@ -1,18 +1,17 @@
 use dasp_sample::FromSample;
 use divan::Bencher;
-use rodio::Source;
+use rodio::{decoder::DecoderSample, Source};
 
 mod shared;
-use shared::TestSource;
 
 fn main() {
     divan::main();
 }
 
 #[divan::bench(types = [i16, u16, f32])]
-fn from_f32_to<T: rodio::Sample + FromSample<f32>>(bencher: Bencher) {
+fn from_sample_to<T: rodio::Sample + FromSample<DecoderSample>>(bencher: Bencher) {
     bencher
-        .with_inputs(|| TestSource::music_wav())
+        .with_inputs(|| shared::music_wav())
         .bench_values(|source| {
             source
                 .convert_samples::<T>()

--- a/benches/conversions.rs
+++ b/benches/conversions.rs
@@ -10,7 +10,7 @@ fn main() {
 }
 
 #[divan::bench(types = [i16, u16, f32])]
-fn from_i16_to<T: rodio::Sample + FromSample<i16>>(bencher: Bencher) {
+fn from_f32_to<T: rodio::Sample + FromSample<f32>>(bencher: Bencher) {
     bencher
         .with_inputs(|| TestSource::music_wav())
         .bench_values(|source| {

--- a/benches/effects.rs
+++ b/benches/effects.rs
@@ -4,7 +4,7 @@ use divan::Bencher;
 use rodio::Source;
 
 mod shared;
-use shared::TestSource;
+use shared::music_wav;
 
 fn main() {
     divan::main();
@@ -12,76 +12,68 @@ fn main() {
 
 #[divan::bench]
 fn reverb(bencher: Bencher) {
-    bencher
-        .with_inputs(|| TestSource::music_wav())
-        .bench_values(|source| {
-            source
-                .buffered()
-                .reverb(Duration::from_secs_f32(0.05), 0.3)
-                .for_each(divan::black_box_drop)
-        })
+    bencher.with_inputs(|| music_wav()).bench_values(|source| {
+        source
+            .buffered()
+            .reverb(Duration::from_secs_f32(0.05), 0.3)
+            .for_each(divan::black_box_drop)
+    })
 }
 
 #[divan::bench]
 fn high_pass(bencher: Bencher) {
     bencher
-        .with_inputs(|| TestSource::music_wav().to_f32s())
+        .with_inputs(|| music_wav().to_f32s())
         .bench_values(|source| source.high_pass(200).for_each(divan::black_box_drop))
 }
 
 #[divan::bench]
 fn fade_out(bencher: Bencher) {
-    bencher
-        .with_inputs(|| TestSource::music_wav())
-        .bench_values(|source| {
-            source
-                .fade_out(Duration::from_secs(5))
-                .for_each(divan::black_box_drop)
-        })
+    bencher.with_inputs(|| music_wav()).bench_values(|source| {
+        source
+            .fade_out(Duration::from_secs(5))
+            .for_each(divan::black_box_drop)
+    })
 }
 
 #[divan::bench]
 fn amplify(bencher: Bencher) {
     bencher
-        .with_inputs(|| TestSource::music_wav().to_f32s())
+        .with_inputs(|| music_wav())
         .bench_values(|source| source.amplify(0.8).for_each(divan::black_box_drop))
 }
 
 #[divan::bench]
 fn agc_enabled(bencher: Bencher) {
-    bencher
-        .with_inputs(|| TestSource::music_wav().to_f32s())
-        .bench_values(|source| {
-            source
-                .automatic_gain_control(
-                    1.0,   // target_level
-                    4.0,   // attack_time (in seconds)
-                    0.005, // release_time (in seconds)
-                    5.0,   // absolute_max_gain
-                )
-                .for_each(divan::black_box_drop)
-        })
+    bencher.with_inputs(|| music_wav()).bench_values(|source| {
+        source
+            .automatic_gain_control(
+                1.0,   // target_level
+                4.0,   // attack_time (in seconds)
+                0.005, // release_time (in seconds)
+                5.0,   // absolute_max_gain
+            )
+            .for_each(divan::black_box_drop)
+    })
 }
 
 #[cfg(feature = "experimental")]
 #[divan::bench]
 fn agc_disabled(bencher: Bencher) {
-    bencher
-        .with_inputs(|| TestSource::music_wav().to_f32s())
-        .bench_values(|source| {
-            // Create the AGC source
-            let amplified_source = source.automatic_gain_control(
-                1.0,   // target_level
-                4.0,   // attack_time (in seconds)
-                0.005, // release_time (in seconds)
-                5.0,   // absolute_max_gain
-            );
+    bencher.with_inputs(|| music_wav()).bench_values(|source| {
+        // Create the AGC source
+        let amplified_source = source.automatic_gain_control(
+            1.0,   // target_level
+            4.0,   // attack_time (in seconds)
+            0.005, // release_time (in seconds)
+            5.0,   // absolute_max_gain
+        );
 
-            // Get the control handle and disable AGC
-            let agc_control = amplified_source.get_agc_control();
-            agc_control.store(false, std::sync::atomic::Ordering::Relaxed);
+        // Get the control handle and disable AGC
+        let agc_control = amplified_source.get_agc_control();
+        agc_control.store(false, std::sync::atomic::Ordering::Relaxed);
 
-            // Process the audio stream with AGC disabled
-            amplified_source.for_each(divan::black_box_drop)
-        })
+        // Process the audio stream with AGC disabled
+        amplified_source.for_each(divan::black_box_drop)
+    })
 }

--- a/benches/resampler.rs
+++ b/benches/resampler.rs
@@ -13,11 +13,11 @@ fn main() {
 fn no_resampling(bencher: Bencher) {
     bencher
         .with_inputs(|| {
-            let source = TestSource::<i16>::music_wav();
+            let source = TestSource::<f32>::music_wav();
             (source.channels(), source.sample_rate(), source)
         })
         .bench_values(|(channels, sample_rate, source)| {
-            UniformSourceIterator::<_, i16>::new(source, channels, sample_rate)
+            UniformSourceIterator::<_, f32>::new(source, channels, sample_rate)
                 .for_each(divan::black_box_drop)
         })
 }
@@ -32,11 +32,11 @@ const COMMON_SAMPLE_RATES: [u32; 12] = [
 fn resample_to(bencher: Bencher, target_sample_rate: u32) {
     bencher
         .with_inputs(|| {
-            let source = TestSource::<i16>::music_wav();
+            let source = TestSource::<f32>::music_wav();
             (source.channels(), source)
         })
         .bench_values(|(channels, source)| {
-            UniformSourceIterator::<_, i16>::new(source, channels, target_sample_rate)
+            UniformSourceIterator::<_, f32>::new(source, channels, target_sample_rate)
                 .for_each(divan::black_box_drop)
         })
 }

--- a/benches/resampler.rs
+++ b/benches/resampler.rs
@@ -1,9 +1,11 @@
 use divan::Bencher;
+use rodio::decoder::DecoderSample;
 use rodio::source::UniformSourceIterator;
 
 mod shared;
+use shared::music_wav;
+
 use rodio::Source;
-use shared::TestSource;
 
 fn main() {
     divan::main();
@@ -13,11 +15,11 @@ fn main() {
 fn no_resampling(bencher: Bencher) {
     bencher
         .with_inputs(|| {
-            let source = TestSource::<f32>::music_wav();
+            let source = music_wav();
             (source.channels(), source.sample_rate(), source)
         })
         .bench_values(|(channels, sample_rate, source)| {
-            UniformSourceIterator::<_, f32>::new(source, channels, sample_rate)
+            UniformSourceIterator::<_, DecoderSample>::new(source, channels, sample_rate)
                 .for_each(divan::black_box_drop)
         })
 }
@@ -32,11 +34,11 @@ const COMMON_SAMPLE_RATES: [u32; 12] = [
 fn resample_to(bencher: Bencher, target_sample_rate: u32) {
     bencher
         .with_inputs(|| {
-            let source = TestSource::<f32>::music_wav();
+            let source = music_wav();
             (source.channels(), source)
         })
         .bench_values(|(channels, source)| {
-            UniformSourceIterator::<_, f32>::new(source, channels, target_sample_rate)
+            UniformSourceIterator::<_, DecoderSample>::new(source, channels, target_sample_rate)
                 .for_each(divan::black_box_drop)
         })
 }

--- a/benches/shared.rs
+++ b/benches/shared.rs
@@ -43,7 +43,7 @@ impl<T: rodio::Sample> Source for TestSource<T> {
     }
 }
 
-impl TestSource<i16> {
+impl TestSource<f32> {
     pub fn music_wav() -> Self {
         let data = include_bytes!("../assets/music.wav");
         let cursor = Cursor::new(data);

--- a/benches/shared.rs
+++ b/benches/shared.rs
@@ -14,30 +14,36 @@ pub struct TestSource<T> {
 impl<T> Iterator for TestSource<T> {
     type Item = T;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.samples.next()
     }
 }
 
 impl<T> ExactSizeIterator for TestSource<T> {
+    #[inline]
     fn len(&self) -> usize {
         self.samples.len()
     }
 }
 
 impl<T: Sample> Source for TestSource<T> {
+    #[inline]
     fn current_span_len(&self) -> Option<usize> {
         None // forever
     }
 
+    #[inline]
     fn channels(&self) -> ChannelCount {
         self.channels
     }
 
+    #[inline]
     fn sample_rate(&self) -> SampleRate {
         self.sample_rate
     }
 
+    #[inline]
     fn total_duration(&self) -> Option<Duration> {
         Some(self.total_duration)
     }

--- a/benches/shared.rs
+++ b/benches/shared.rs
@@ -2,6 +2,7 @@ use std::io::Cursor;
 use std::time::Duration;
 use std::vec;
 
+use dasp_sample::Sample;
 use rodio::{ChannelCount, SampleRate, Source};
 
 pub struct TestSource<T> {
@@ -57,7 +58,11 @@ impl TestSource<f32> {
             channels: sound.channels(),
             sample_rate: sound.sample_rate(),
             total_duration: duration,
-            samples: sound.into_iter().collect::<Vec<_>>().into_iter(),
+            samples: sound
+                .into_iter()
+                .map(|s| s.to_sample())
+                .collect::<Vec<_>>()
+                .into_iter(),
         }
     }
 
@@ -70,7 +75,7 @@ impl TestSource<f32> {
             total_duration,
         } = self;
         let samples = samples
-            .map(|s| dasp_sample::Sample::from_sample(s))
+            .map(|s| s.to_sample())
             .collect::<Vec<_>>()
             .into_iter();
         TestSource {

--- a/src/conversions/mod.rs
+++ b/src/conversions/mod.rs
@@ -11,7 +11,5 @@ pub use self::sample::Sample;
 pub use self::sample_rate::SampleRateConverter;
 
 mod channels;
-// TODO: < shouldn't be public ; there's a bug in Rust 1.4 and below that makes This
-// `pub` mandatory
-pub mod sample;
+mod sample;
 mod sample_rate;

--- a/src/conversions/sample.rs
+++ b/src/conversions/sample.rs
@@ -72,6 +72,9 @@ where
 /// You can implement this trait on your own type as well if you wish so.
 ///
 pub trait Sample: DaspSample + ToSample<f32> {
+    /// The value corresponding to the absence of sound.
+    const ZERO_VALUE: Self = DaspSample::EQUILIBRIUM;
+
     /// Linear interpolation between two samples.
     ///
     /// The result should be equivalent to
@@ -93,9 +96,9 @@ pub trait Sample: DaspSample + ToSample<f32> {
     /// Calls `saturating_add` on the sample.
     fn saturating_add(self, other: Self) -> Self;
 
-    /// Returns the value corresponding to the absence of sound.
-    fn zero_value() -> Self {
-        Self::EQUILIBRIUM
+    /// Returns true if the sample is the zero value.
+    fn is_zero(self) -> bool {
+        self == Self::ZERO_VALUE
     }
 }
 

--- a/src/conversions/sample.rs
+++ b/src/conversions/sample.rs
@@ -144,6 +144,12 @@ impl Sample for f32 {
     fn to_f32(self) -> f32 {
         self
     }
+
+    #[inline]
+    fn is_zero(self) -> bool {
+        2.0 * (self - Self::ZERO_VALUE).abs()
+            <= f32::EPSILON * (self.abs() + Self::ZERO_VALUE.abs())
+    }
 }
 
 #[cfg(test)]

--- a/src/conversions/sample.rs
+++ b/src/conversions/sample.rs
@@ -84,21 +84,34 @@ pub trait Sample: DaspSample + ToSample<f32> {
     fn lerp(first: Self, second: Self, numerator: u32, denominator: u32) -> Self;
 
     /// Multiplies the value of this sample by the given amount.
+    #[inline]
     fn amplify(self, value: f32) -> Self {
         self.mul_amp(value.to_sample())
     }
 
-    /// Converts the sample to a f32 value.
+    /// Converts the sample to a normalized `f32` value.
+    #[inline]
     fn to_f32(self) -> f32 {
         self.to_sample()
     }
 
-    /// Calls `saturating_add` on the sample.
-    fn saturating_add(self, other: Self) -> Self;
+    /// Adds the amplitude of another sample to this one.
+    #[inline]
+    fn saturating_add(self, other: Self) -> Self {
+        self.add_amp(other.to_signed_sample())
+    }
 
     /// Returns true if the sample is the zero value.
+    #[inline]
     fn is_zero(self) -> bool {
         self == Self::ZERO_VALUE
+    }
+
+    /// Returns the value corresponding to the absence of sound.
+    #[deprecated(note = "Please use `Self::ZERO_VALUE` instead")]
+    #[inline]
+    fn zero_value() -> Self {
+        Self::ZERO_VALUE
     }
 }
 
@@ -111,11 +124,6 @@ impl Sample for u16 {
         let d = denominator as i32;
         (a + (b - a) * n / d) as u16
     }
-
-    #[inline]
-    fn saturating_add(self, other: u16) -> u16 {
-        self.saturating_add(other)
-    }
 }
 
 impl Sample for i16 {
@@ -124,22 +132,12 @@ impl Sample for i16 {
         (first as i32 + (second as i32 - first as i32) * numerator as i32 / denominator as i32)
             as i16
     }
-
-    #[inline]
-    fn saturating_add(self, other: i16) -> i16 {
-        self.saturating_add(other)
-    }
 }
 
 impl Sample for f32 {
     #[inline]
     fn lerp(first: f32, second: f32, numerator: u32, denominator: u32) -> f32 {
         first + (second - first) * numerator as f32 / denominator as f32
-    }
-
-    #[inline]
-    fn saturating_add(self, other: f32) -> f32 {
-        self + other
     }
 }
 

--- a/src/conversions/sample.rs
+++ b/src/conversions/sample.rs
@@ -139,6 +139,11 @@ impl Sample for f32 {
     fn lerp(first: f32, second: f32, numerator: u32, denominator: u32) -> f32 {
         first + (second - first) * numerator as f32 / denominator as f32
     }
+
+    #[inline]
+    fn to_f32(self) -> f32 {
+        self
+    }
 }
 
 #[cfg(test)]

--- a/src/decoder/flac.rs
+++ b/src/decoder/flac.rs
@@ -67,6 +67,7 @@ where
         })
     }
 
+    #[inline]
     pub fn into_inner(self) -> R {
         self.reader.into_inner()
     }

--- a/src/decoder/flac.rs
+++ b/src/decoder/flac.rs
@@ -123,7 +123,12 @@ where
                 let bits = self.bits_per_sample;
                 let real_val = match bits {
                     8 => (raw_val as i8).to_sample(),
-                    16 => (raw_val as i16).to_sample(),
+                    16 => {
+                        let raw_val = raw_val as i16;
+                        #[cfg(not(feature = "integer-decoder"))] // perf
+                        let raw_val = raw_val.to_sample();
+                        raw_val
+                    }
                     24 => I24::new(raw_val).unwrap_or(Sample::EQUILIBRIUM).to_sample(),
                     32 => raw_val.to_sample(),
                     _ => {

--- a/src/decoder/flac.rs
+++ b/src/decoder/flac.rs
@@ -37,7 +37,7 @@ where
             return Err(data);
         }
 
-        let reader = FlacReader::new(data).unwrap();
+        let reader = FlacReader::new(data).expect("should still be flac");
 
         let spec = reader.streaminfo();
         let sample_rate = spec.sample_rate;

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -32,7 +32,7 @@ mod vorbis;
 mod wav;
 
 /// Output format of the decoders.
-pub type DecoderFormat = f32;
+pub type DecoderSample = f32;
 
 /// Source of audio samples from decoding a file.
 ///
@@ -71,7 +71,7 @@ where
 
 impl<R: Read + Seek> DecoderImpl<R> {
     #[inline]
-    fn next(&mut self) -> Option<DecoderFormat> {
+    fn next(&mut self) -> Option<DecoderSample> {
         match self {
             #[cfg(all(feature = "wav", not(feature = "symphonia-wav")))]
             DecoderImpl::Wav(source) => source.next(),
@@ -399,7 +399,7 @@ impl<R> Iterator for Decoder<R>
 where
     R: Read + Seek,
 {
-    type Item = DecoderFormat;
+    type Item = DecoderSample;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -445,7 +445,7 @@ impl<R> Iterator for LoopedDecoder<R>
 where
     R: Read + Seek,
 {
-    type Item = DecoderFormat;
+    type Item = DecoderSample;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -31,10 +31,10 @@ mod vorbis;
 #[cfg(all(feature = "wav", not(feature = "symphonia-wav")))]
 mod wav;
 
-#[cfg(feature = "integer-samples")]
+#[cfg(feature = "integer-decoder")]
 /// Output format of the decoders.
 pub type DecoderSample = i16;
-#[cfg(not(feature = "integer-samples"))]
+#[cfg(not(feature = "integer-decoder"))]
 /// Output format of the decoders.
 pub type DecoderSample = f32;
 

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -31,6 +31,9 @@ mod vorbis;
 #[cfg(all(feature = "wav", not(feature = "symphonia-wav")))]
 mod wav;
 
+/// Output format of the decoders.
+pub type DecoderFormat = f32;
+
 /// Source of audio samples from decoding a file.
 ///
 /// Supports MP3, WAV, Vorbis and Flac.
@@ -68,7 +71,7 @@ where
 
 impl<R: Read + Seek> DecoderImpl<R> {
     #[inline]
-    fn next(&mut self) -> Option<i16> {
+    fn next(&mut self) -> Option<DecoderFormat> {
         match self {
             #[cfg(all(feature = "wav", not(feature = "symphonia-wav")))]
             DecoderImpl::Wav(source) => source.next(),
@@ -396,10 +399,10 @@ impl<R> Iterator for Decoder<R>
 where
     R: Read + Seek,
 {
-    type Item = i16;
+    type Item = DecoderFormat;
 
     #[inline]
-    fn next(&mut self) -> Option<i16> {
+    fn next(&mut self) -> Option<Self::Item> {
         self.0.next()
     }
 
@@ -442,10 +445,10 @@ impl<R> Iterator for LoopedDecoder<R>
 where
     R: Read + Seek,
 {
-    type Item = i16;
+    type Item = DecoderFormat;
 
     #[inline]
-    fn next(&mut self) -> Option<i16> {
+    fn next(&mut self) -> Option<Self::Item> {
         if let Some(sample) = self.0.next() {
             Some(sample)
         } else {

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -31,6 +31,10 @@ mod vorbis;
 #[cfg(all(feature = "wav", not(feature = "symphonia-wav")))]
 mod wav;
 
+#[cfg(feature = "integer-samples")]
+/// Output format of the decoders.
+pub type DecoderSample = i16;
+#[cfg(not(feature = "integer-samples"))]
 /// Output format of the decoders.
 pub type DecoderSample = f32;
 

--- a/src/decoder/mp3.rs
+++ b/src/decoder/mp3.rs
@@ -1,13 +1,16 @@
 use std::io::{Read, Seek, SeekFrom};
 use std::time::Duration;
 
-use super::DecoderFormat;
+use super::DecoderSample;
+use crate::common::{ChannelCount, SampleRate};
 use crate::source::SeekError;
 use crate::Source;
 
 use minimp3::Decoder;
 use minimp3::Frame;
 use minimp3_fixed as minimp3;
+
+use dasp_sample::Sample;
 
 pub struct Mp3Decoder<R>
 where
@@ -16,7 +19,7 @@ where
     // decoder: SeekDecoder<R>,
     decoder: Decoder<R>,
     // what minimp3 calls frames rodio calls spans
-    current_span: minimp3::Frame,
+    current_span: Frame,
     current_span_offset: usize,
 }
 
@@ -34,10 +37,7 @@ where
         // thus if we crash here one of these invariants is broken:
         // .expect("should be able to allocate memory, perform IO");
         // let current_span = decoder.decode_frame()
-        let current_span = decoder.next_frame()
-            // the reader makes enough data available therefore
-            // if we crash here the invariant broken is:
-            .expect("data should not corrupt");
+        let current_span = decoder.next_frame().unwrap();
 
         Ok(Mp3Decoder {
             decoder,
@@ -74,7 +74,7 @@ where
         None
     }
 
-    fn try_seek(&mut self, pos: Duration) -> Result<(), SeekError> {
+    fn try_seek(&mut self, _pos: Duration) -> Result<(), SeekError> {
         // TODO waiting for PR in minimp3_fixed or minimp3
 
         // let pos = (pos.as_secs_f32() * self.sample_rate() as f32) as u64;
@@ -93,7 +93,7 @@ impl<R> Iterator for Mp3Decoder<R>
 where
     R: Read + Seek,
 {
-    type Item = DecoderFormat;
+    type Item = DecoderSample;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.current_span_offset == self.current_span_len().unwrap() {
@@ -109,7 +109,7 @@ where
         let v = self.current_span.data[self.current_span_offset];
         self.current_span_offset += 1;
 
-        Some(v)
+        Some(v.to_sample())
     }
 }
 
@@ -118,10 +118,9 @@ fn is_mp3<R>(mut data: R) -> bool
 where
     R: Read + Seek,
 {
-    let stream_pos = data.seek(SeekFrom::Current(0)).unwrap();
+    let stream_pos = data.stream_position().unwrap_or_default();
     let mut decoder = Decoder::new(data.by_ref());
-    let ok = decoder.next_frame().is_ok();
-    data.seek(SeekFrom::Start(stream_pos)).unwrap();
-
-    ok
+    let result = decoder.next_frame().is_ok();
+    let _ = data.seek(SeekFrom::Start(stream_pos));
+    result
 }

--- a/src/decoder/mp3.rs
+++ b/src/decoder/mp3.rs
@@ -45,6 +45,8 @@ where
             current_span_offset: 0,
         })
     }
+
+    #[inline]
     pub fn into_inner(self) -> R {
         self.decoder.into_inner()
     }

--- a/src/decoder/mp3.rs
+++ b/src/decoder/mp3.rs
@@ -37,7 +37,7 @@ where
         // thus if we crash here one of these invariants is broken:
         // .expect("should be able to allocate memory, perform IO");
         // let current_span = decoder.decode_frame()
-        let current_span = decoder.next_frame().unwrap();
+        let current_span = decoder.next_frame().expect("should still be mp3");
 
         Ok(Mp3Decoder {
             decoder,
@@ -96,7 +96,8 @@ where
     type Item = DecoderSample;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.current_span_offset == self.current_span_len().unwrap() {
+        let current_span_len = self.current_span_len()?;
+        if self.current_span_offset == current_span_len {
             if let Ok(span) = self.decoder.next_frame() {
                 // if let Ok(span) = self.decoder.decode_frame() {
                 self.current_span = span;

--- a/src/decoder/mp3.rs
+++ b/src/decoder/mp3.rs
@@ -110,7 +110,9 @@ where
         let v = self.current_span.data[self.current_span_offset];
         self.current_span_offset += 1;
 
-        Some(v.to_sample())
+        #[cfg(not(feature = "integer-decoder"))] // perf
+        let v = v.to_sample();
+        Some(v)
     }
 }
 

--- a/src/decoder/mp3.rs
+++ b/src/decoder/mp3.rs
@@ -1,6 +1,7 @@
 use std::io::{Read, Seek, SeekFrom};
 use std::time::Duration;
 
+use super::DecoderFormat;
 use crate::source::SeekError;
 use crate::Source;
 
@@ -34,7 +35,7 @@ where
         // .expect("should be able to allocate memory, perform IO");
         // let current_span = decoder.decode_frame()
         let current_span = decoder.next_frame()
-            // the reader makes enough data available therefore 
+            // the reader makes enough data available therefore
             // if we crash here the invariant broken is:
             .expect("data should not corrupt");
 
@@ -92,9 +93,9 @@ impl<R> Iterator for Mp3Decoder<R>
 where
     R: Read + Seek,
 {
-    type Item = i16;
+    type Item = DecoderFormat;
 
-    fn next(&mut self) -> Option<i16> {
+    fn next(&mut self) -> Option<Self::Item> {
         if self.current_span_offset == self.current_span_len().unwrap() {
             if let Ok(span) = self.decoder.next_frame() {
                 // if let Ok(span) = self.decoder.decode_frame() {

--- a/src/decoder/read_seek_source.rs
+++ b/src/decoder/read_seek_source.rs
@@ -9,28 +9,33 @@ pub struct ReadSeekSource<T: Read + Seek + Send + Sync> {
 impl<T: Read + Seek + Send + Sync> ReadSeekSource<T> {
     /// Instantiates a new `ReadSeekSource<T>` by taking ownership and wrapping the provided
     /// `Read + Seek`er.
+    #[inline]
     pub fn new(inner: T) -> Self {
         ReadSeekSource { inner }
     }
 }
 
 impl<T: Read + Seek + Send + Sync> MediaSource for ReadSeekSource<T> {
+    #[inline]
     fn is_seekable(&self) -> bool {
         true
     }
 
+    #[inline]
     fn byte_len(&self) -> Option<u64> {
         None
     }
 }
 
 impl<T: Read + Seek + Send + Sync> Read for ReadSeekSource<T> {
+    #[inline]
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         self.inner.read(buf)
     }
 }
 
 impl<T: Read + Seek + Send + Sync> Seek for ReadSeekSource<T> {
+    #[inline]
     fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
         self.inner.seek(pos)
     }

--- a/src/decoder/symphonia.rs
+++ b/src/decoder/symphonia.rs
@@ -88,12 +88,15 @@ impl SymphoniaDecoder {
             ))?
             .id;
 
-        let track = probed
+        let track = match probed
             .format
             .tracks()
             .iter()
             .find(|track| track.id == track_id)
-            .unwrap();
+        {
+            Some(track) => track,
+            None => return Ok(None),
+        };
 
         let mut decoder = symphonia::default::get_codecs()
             .make(&track.codec_params, &DecoderOptions::default())?;

--- a/src/decoder/symphonia.rs
+++ b/src/decoder/symphonia.rs
@@ -14,7 +14,7 @@ use symphonia::{
     default::get_probe,
 };
 
-use super::{DecoderError, DecoderFormat};
+use super::{DecoderError, DecoderSample};
 use crate::common::{ChannelCount, SampleRate};
 use crate::{source, Source};
 
@@ -28,7 +28,7 @@ pub(crate) struct SymphoniaDecoder {
     current_span_offset: usize,
     format: Box<dyn FormatReader>,
     total_duration: Option<Time>,
-    buffer: SampleBuffer<DecoderFormat>,
+    buffer: SampleBuffer<DecoderSample>,
     spec: SignalSpec,
 }
 
@@ -144,9 +144,9 @@ impl SymphoniaDecoder {
     }
 
     #[inline]
-    fn get_buffer(decoded: AudioBufferRef, spec: &SignalSpec) -> SampleBuffer<DecoderFormat> {
+    fn get_buffer(decoded: AudioBufferRef, spec: &SignalSpec) -> SampleBuffer<DecoderSample> {
         let duration = units::Duration::from(decoded.capacity() as u64);
-        let mut buffer = SampleBuffer::<DecoderFormat>::new(duration, *spec);
+        let mut buffer = SampleBuffer::<DecoderSample>::new(duration, *spec);
         buffer.copy_interleaved_ref(decoded);
         buffer
     }
@@ -316,7 +316,7 @@ fn time_to_duration(time: Time) -> Duration {
 }
 
 impl Iterator for SymphoniaDecoder {
-    type Item = DecoderFormat;
+    type Item = DecoderSample;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/decoder/symphonia.rs
+++ b/src/decoder/symphonia.rs
@@ -53,6 +53,7 @@ impl SymphoniaDecoder {
         }
     }
 
+    #[inline]
     pub(crate) fn into_inner(self) -> MediaSourceStream {
         self.format.into_inner()
     }

--- a/src/decoder/vorbis.rs
+++ b/src/decoder/vorbis.rs
@@ -6,6 +6,9 @@ use crate::Source;
 
 use crate::common::{ChannelCount, SampleRate};
 use lewton::inside_ogg::OggStreamReader;
+use lewton::samples::InterleavedSamples;
+
+use super::DecoderFormat;
 
 /// Decoder for an OGG file that contains Vorbis sound format.
 pub struct VorbisDecoder<R>
@@ -13,7 +16,7 @@ where
     R: Read + Seek,
 {
     stream_reader: OggStreamReader<R>,
-    current_data: Vec<i16>,
+    current_data: Vec<DecoderFormat>,
     next: usize,
 }
 
@@ -31,15 +34,18 @@ where
         Ok(Self::from_stream_reader(stream_reader))
     }
     pub fn from_stream_reader(mut stream_reader: OggStreamReader<R>) -> Self {
-        let mut data = match stream_reader.read_dec_packet_itl() {
-            Ok(Some(d)) => d,
-            _ => Vec::new(),
-        };
+        let mut data =
+            match stream_reader.read_dec_packet_generic::<InterleavedSamples<DecoderFormat>>() {
+                Ok(Some(d)) => d.samples,
+                _ => Vec::new(),
+            };
 
         // The first packet is always empty, therefore
         // we need to read the second frame to get some data
-        if let Ok(Some(mut d)) = stream_reader.read_dec_packet_itl() {
-            data.append(&mut d);
+        if let Ok(Some(mut d)) =
+            stream_reader.read_dec_packet_generic::<InterleavedSamples<DecoderFormat>>()
+        {
+            data.append(&mut d.samples);
         }
 
         VorbisDecoder {
@@ -98,22 +104,28 @@ impl<R> Iterator for VorbisDecoder<R>
 where
     R: Read + Seek,
 {
-    type Item = i16;
+    type Item = DecoderFormat;
 
     #[inline]
-    fn next(&mut self) -> Option<i16> {
+    fn next(&mut self) -> Option<Self::Item> {
         if let Some(sample) = self.current_data.get(self.next).copied() {
             self.next += 1;
             if self.current_data.is_empty() {
-                if let Ok(Some(data)) = self.stream_reader.read_dec_packet_itl() {
-                    self.current_data = data;
+                if let Ok(Some(data)) = self
+                    .stream_reader
+                    .read_dec_packet_generic::<InterleavedSamples<DecoderFormat>>()
+                {
+                    self.current_data = data.samples;
                     self.next = 0;
                 }
             }
             Some(sample)
         } else {
-            if let Ok(Some(data)) = self.stream_reader.read_dec_packet_itl() {
-                self.current_data = data;
+            if let Ok(Some(data)) = self
+                .stream_reader
+                .read_dec_packet_generic::<InterleavedSamples<DecoderFormat>>()
+            {
+                self.current_data = data.samples;
                 self.next = 0;
             }
             let sample = self.current_data.get(self.next).copied();

--- a/src/decoder/vorbis.rs
+++ b/src/decoder/vorbis.rs
@@ -54,6 +54,8 @@ where
             next: 0,
         }
     }
+
+    #[inline]
     pub fn into_inner(self) -> OggStreamReader<R> {
         self.stream_reader
     }

--- a/src/decoder/vorbis.rs
+++ b/src/decoder/vorbis.rs
@@ -8,7 +8,7 @@ use crate::common::{ChannelCount, SampleRate};
 use lewton::inside_ogg::OggStreamReader;
 use lewton::samples::InterleavedSamples;
 
-use super::DecoderFormat;
+use super::DecoderSample;
 
 /// Decoder for an OGG file that contains Vorbis sound format.
 pub struct VorbisDecoder<R>
@@ -16,7 +16,7 @@ where
     R: Read + Seek,
 {
     stream_reader: OggStreamReader<R>,
-    current_data: Vec<DecoderFormat>,
+    current_data: Vec<DecoderSample>,
     next: usize,
 }
 
@@ -35,7 +35,7 @@ where
     }
     pub fn from_stream_reader(mut stream_reader: OggStreamReader<R>) -> Self {
         let mut data =
-            match stream_reader.read_dec_packet_generic::<InterleavedSamples<DecoderFormat>>() {
+            match stream_reader.read_dec_packet_generic::<InterleavedSamples<DecoderSample>>() {
                 Ok(Some(d)) => d.samples,
                 _ => Vec::new(),
             };
@@ -43,7 +43,7 @@ where
         // The first packet is always empty, therefore
         // we need to read the second frame to get some data
         if let Ok(Some(mut d)) =
-            stream_reader.read_dec_packet_generic::<InterleavedSamples<DecoderFormat>>()
+            stream_reader.read_dec_packet_generic::<InterleavedSamples<DecoderSample>>()
         {
             data.append(&mut d.samples);
         }
@@ -104,7 +104,7 @@ impl<R> Iterator for VorbisDecoder<R>
 where
     R: Read + Seek,
 {
-    type Item = DecoderFormat;
+    type Item = DecoderSample;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -113,7 +113,7 @@ where
             if self.current_data.is_empty() {
                 if let Ok(Some(data)) = self
                     .stream_reader
-                    .read_dec_packet_generic::<InterleavedSamples<DecoderFormat>>()
+                    .read_dec_packet_generic::<InterleavedSamples<DecoderSample>>()
                 {
                     self.current_data = data.samples;
                     self.next = 0;
@@ -123,7 +123,7 @@ where
         } else {
             if let Ok(Some(data)) = self
                 .stream_reader
-                .read_dec_packet_generic::<InterleavedSamples<DecoderFormat>>()
+                .read_dec_packet_generic::<InterleavedSamples<DecoderSample>>()
             {
                 self.current_data = data.samples;
                 self.next = 0;

--- a/src/decoder/vorbis.rs
+++ b/src/decoder/vorbis.rs
@@ -30,7 +30,7 @@ where
             return Err(data);
         }
 
-        let stream_reader = OggStreamReader::new(data).unwrap();
+        let stream_reader = OggStreamReader::new(data).expect("should still be vorbis");
         Ok(Self::from_stream_reader(stream_reader))
     }
     pub fn from_stream_reader(mut stream_reader: OggStreamReader<R>) -> Self {
@@ -145,13 +145,8 @@ fn is_vorbis<R>(mut data: R) -> bool
 where
     R: Read + Seek,
 {
-    let stream_pos = data.stream_position().unwrap();
-
-    if OggStreamReader::new(data.by_ref()).is_err() {
-        data.seek(SeekFrom::Start(stream_pos)).unwrap();
-        return false;
-    }
-
-    data.seek(SeekFrom::Start(stream_pos)).unwrap();
-    true
+    let stream_pos = data.stream_position().unwrap_or_default();
+    let result = OggStreamReader::new(data.by_ref()).is_ok();
+    let _ = data.seek(SeekFrom::Start(stream_pos));
+    result
 }

--- a/src/decoder/wav.rs
+++ b/src/decoder/wav.rs
@@ -86,7 +86,13 @@ where
                 (SampleFormat::Float, bits) => {
                     if bits == 32 {
                         let next_f32: Option<Result<f32, _>> = self.reader.samples().next();
-                        next_f32.and_then(|value| value.ok().map(|value| value.to_sample()))
+                        next_f32.and_then(|value| {
+                            value.ok().map(|value| {
+                                #[cfg(feature = "integer-decoder")] // perf
+                                let value = value.to_sample();
+                                value
+                            })
+                        })
                     } else {
                         // > 32 bits we cannot handle, so we'll just return equilibrium
                         // and let the iterator continue
@@ -100,7 +106,13 @@ where
                 }
                 (SampleFormat::Int, 16) => {
                     let next_i16: Option<Result<i16, _>> = self.reader.samples().next();
-                    next_i16.and_then(|value| value.ok().map(|value| value.to_sample()))
+                    next_i16.and_then(|value| {
+                        value.ok().map(|value| {
+                            #[cfg(not(feature = "integer-decoder"))] // perf
+                            let value = value.to_sample();
+                            value
+                        })
+                    })
                 }
                 (SampleFormat::Int, 24) => {
                     let next_i24_in_i32: Option<Result<i32, _>> = self.reader.samples().next();

--- a/src/decoder/wav.rs
+++ b/src/decoder/wav.rs
@@ -58,6 +58,7 @@ where
         })
     }
 
+    #[inline]
     pub fn into_inner(self) -> R {
         self.reader.reader.into_inner()
     }

--- a/src/decoder/wav.rs
+++ b/src/decoder/wav.rs
@@ -32,7 +32,7 @@ where
             return Err(data);
         }
 
-        let reader = WavReader::new(data).unwrap();
+        let reader = WavReader::new(data).expect("should still be wav");
         let spec = reader.spec();
         let len = reader.len() as u64;
         let reader = SamplesIterator {
@@ -57,6 +57,7 @@ where
             channels: channels as ChannelCount,
         })
     }
+
     pub fn into_inner(self) -> R {
         self.reader.reader.into_inner()
     }

--- a/src/decoder/wav.rs
+++ b/src/decoder/wav.rs
@@ -87,11 +87,10 @@ where
                     if bits == 32 {
                         let next_f32: Option<Result<f32, _>> = self.reader.samples().next();
                         next_f32.and_then(|value| {
-                            value.ok().map(|value| {
-                                #[cfg(feature = "integer-decoder")] // perf
-                                let value = value.to_sample();
-                                value
-                            })
+                            let value = value.ok();
+                            #[cfg(feature = "integer-decoder")] // perf
+                            let value = value.map(|value| value.to_sample());
+                            value
                         })
                     } else {
                         // > 32 bits we cannot handle, so we'll just return equilibrium
@@ -107,11 +106,10 @@ where
                 (SampleFormat::Int, 16) => {
                     let next_i16: Option<Result<i16, _>> = self.reader.samples().next();
                     next_i16.and_then(|value| {
-                        value.ok().map(|value| {
-                            #[cfg(not(feature = "integer-decoder"))] // perf
-                            let value = value.to_sample();
-                            value
-                        })
+                        let value = value.ok();
+                        #[cfg(not(feature = "integer-decoder"))] // perf
+                        let value = value.map(|value| value.to_sample());
+                        value
                     })
                 }
                 (SampleFormat::Int, 24) => {

--- a/src/decoder/wav.rs
+++ b/src/decoder/wav.rs
@@ -97,7 +97,7 @@ where
                         #[cfg(feature = "tracing")]
                         tracing::error!("Unsupported WAV float bit depth: {}", bits);
                         #[cfg(not(feature = "tracing"))]
-                        println!("Unsupported WAV float bit depth: {}", bits);
+                        eprintln!("Unsupported WAV float bit depth: {}", bits);
                         None
                     }
                 }
@@ -136,7 +136,7 @@ where
                         #[cfg(feature = "tracing")]
                         tracing::error!("Unsupported WAV integer bit depth: {}", bits);
                         #[cfg(not(feature = "tracing"))]
-                        println!("Unsupported WAV integer bit depth: {}", bits);
+                        eprintln!("Unsupported WAV integer bit depth: {}", bits);
                         None
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,10 +133,20 @@
 //! The "tracing" feature replaces the print to stderr when a stream error happens with a
 //! recording an error event with tracing.
 //!
-//! ### Feature "Noise"
+//! ### Feature "noise"
 //!
 //! The "noise" feature adds support for white and pink noise sources. This feature requires the
 //! "rand" crate.
+//!
+//! ### Feature "playback"
+//!
+//! The "playback" feature adds support for playing audio. This feature requires the "cpal" crate.
+//!
+//! ### Feature "integer-samples"
+//!
+//! The "integer-samples" changes the output format of the decoders to use `i16` instead of `f32`.
+//! This is useful if you want to decode audio on an exotic, low-spec or old device that does not
+//! have hardware support for floating-point operations.
 //!
 //! ## How it works under the hood
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,9 +142,9 @@
 //!
 //! The "playback" feature adds support for playing audio. This feature requires the "cpal" crate.
 //!
-//! ### Feature "integer-samples"
+//! ### Feature "integer-decoder"
 //!
-//! The "integer-samples" changes the output format of the decoders to use `i16` instead of `f32`.
+//! The "integer-decoder" changes the output format of the decoders to use `i16` instead of `f32`.
 //! This is useful if you want to decode audio on an exotic, low-spec or old device that does not
 //! have hardware support for floating-point operations.
 //!

--- a/src/mixer.rs
+++ b/src/mixer.rs
@@ -197,7 +197,7 @@ where
     }
 
     fn sum_current_sources(&mut self) -> S {
-        let mut sum = S::zero_value();
+        let mut sum = S::ZERO_VALUE;
 
         for mut source in self.current_sources.drain(..) {
             if let Some(value) = source.next() {

--- a/src/source/channel_volume.rs
+++ b/src/source/channel_volume.rs
@@ -40,7 +40,7 @@ where
             if let Some(s) = input.next() {
                 sample = Some(
                     sample
-                        .get_or_insert_with(I::Item::zero_value)
+                        .get_or_insert(I::Item::ZERO_VALUE)
                         .saturating_add(s.amplify(1.0 / num_channels as f32)),
                 );
             }
@@ -101,7 +101,7 @@ where
                 if let Some(s) = self.input.next() {
                     self.current_sample = Some(
                         self.current_sample
-                            .get_or_insert_with(I::Item::zero_value)
+                            .get_or_insert(I::Item::ZERO_VALUE)
                             .saturating_add(s.amplify(1.0 / num_channels as f32)),
                     );
                 }

--- a/src/source/delay.rs
+++ b/src/source/delay.rs
@@ -70,7 +70,7 @@ where
     fn next(&mut self) -> Option<<I as Iterator>::Item> {
         if self.remaining_samples >= 1 {
             self.remaining_samples -= 1;
-            Some(Sample::zero_value())
+            Some(Sample::ZERO_VALUE)
         } else {
             self.input.next()
         }

--- a/src/source/pausable.rs
+++ b/src/source/pausable.rs
@@ -82,12 +82,12 @@ where
     fn next(&mut self) -> Option<I::Item> {
         if self.remaining_paused_samples > 0 {
             self.remaining_paused_samples -= 1;
-            return Some(I::Item::zero_value());
+            return Some(I::Item::ZERO_VALUE);
         }
 
         if let Some(paused_channels) = self.paused_channels {
             self.remaining_paused_samples = paused_channels - 1;
-            return Some(I::Item::zero_value());
+            return Some(I::Item::ZERO_VALUE);
         }
 
         self.input.next()

--- a/src/source/zero.rs
+++ b/src/source/zero.rs
@@ -54,12 +54,12 @@ where
         if let Some(num_samples) = self.num_samples {
             if num_samples > 0 {
                 self.num_samples = Some(num_samples - 1);
-                Some(S::zero_value())
+                Some(S::ZERO_VALUE)
             } else {
                 None
             }
         } else {
-            Some(S::zero_value())
+            Some(S::ZERO_VALUE)
         }
     }
 }

--- a/tests/flac_test.rs
+++ b/tests/flac_test.rs
@@ -1,3 +1,5 @@
+#[cfg(any(feature = "flac", feature = "symphonia-flac"))]
+use rodio::Sample;
 #[cfg(all(feature = "flac", not(feature = "symphonia-flac")))]
 use rodio::Source;
 #[cfg(all(feature = "flac", not(feature = "symphonia-flac")))]
@@ -11,8 +13,9 @@ fn test_flac_encodings() {
     // 16 bit FLAC file exported from Audacity (2 channels, compression level 5)
     let file = std::fs::File::open("assets/audacity16bit_level5.flac").unwrap();
     let mut decoder = rodio::Decoder::new(BufReader::new(file)).unwrap();
+
     // File is not just silence
-    assert!(decoder.any(|x| x != 0.0));
+    assert!(!decoder.all(|x| x.is_zero()));
     // Symphonia does not expose functionality to get the duration so this check must be disabled
     #[cfg(all(feature = "flac", not(feature = "symphonia-flac")))]
     assert_eq!(decoder.total_duration(), Some(Duration::from_secs(3))); // duration is calculated correctly
@@ -21,7 +24,7 @@ fn test_flac_encodings() {
     for level in &[0, 5, 8] {
         let file = std::fs::File::open(format!("assets/audacity24bit_level{level}.flac")).unwrap();
         let mut decoder = rodio::Decoder::new(BufReader::new(file)).unwrap();
-        assert!(decoder.any(|x| x != 0.0));
+        assert!(!decoder.all(|x| x.is_zero()));
         #[cfg(all(feature = "flac", not(feature = "symphonia-flac")))]
         assert_eq!(decoder.total_duration(), Some(Duration::from_secs(3)));
     }

--- a/tests/flac_test.rs
+++ b/tests/flac_test.rs
@@ -12,7 +12,7 @@ fn test_flac_encodings() {
     let file = std::fs::File::open("assets/audacity16bit_level5.flac").unwrap();
     let mut decoder = rodio::Decoder::new(BufReader::new(file)).unwrap();
     // File is not just silence
-    assert!(decoder.any(|x| x != 0));
+    assert!(decoder.any(|x| x != 0.0));
     // Symphonia does not expose functionality to get the duration so this check must be disabled
     #[cfg(all(feature = "flac", not(feature = "symphonia-flac")))]
     assert_eq!(decoder.total_duration(), Some(Duration::from_secs(3))); // duration is calculated correctly
@@ -21,7 +21,7 @@ fn test_flac_encodings() {
     for level in &[0, 5, 8] {
         let file = std::fs::File::open(format!("assets/audacity24bit_level{level}.flac")).unwrap();
         let mut decoder = rodio::Decoder::new(BufReader::new(file)).unwrap();
-        assert!(decoder.any(|x| x != 0));
+        assert!(decoder.any(|x| x != 0.0));
         #[cfg(all(feature = "flac", not(feature = "symphonia-flac")))]
         assert_eq!(decoder.total_duration(), Some(Duration::from_secs(3)));
     }

--- a/tests/mp4a_test.rs
+++ b/tests/mp4a_test.rs
@@ -1,6 +1,8 @@
 #![cfg(all(feature = "symphonia-aac", feature = "symphonia-isomp4"))]
 use std::io::BufReader;
 
+use rodio::Sample;
+
 #[test]
 fn test_mp4a_encodings() {
     // mp4a codec downloaded from YouTube
@@ -10,5 +12,5 @@ fn test_mp4a_encodings() {
     // http://creativecommons.org/licenses/by/3.0/
     let file = std::fs::File::open("assets/monkeys.mp4a").unwrap();
     let mut decoder = rodio::Decoder::new(BufReader::new(file)).unwrap();
-    assert!(decoder.any(|x| x != 0.0)); // Assert not all zeros
+    assert!(!decoder.all(|x| x.is_zero())); // Assert not all zeros
 }

--- a/tests/mp4a_test.rs
+++ b/tests/mp4a_test.rs
@@ -10,5 +10,5 @@ fn test_mp4a_encodings() {
     // http://creativecommons.org/licenses/by/3.0/
     let file = std::fs::File::open("assets/monkeys.mp4a").unwrap();
     let mut decoder = rodio::Decoder::new(BufReader::new(file)).unwrap();
-    assert!(decoder.any(|x| x != 0)); // Assert not all zeros
+    assert!(decoder.any(|x| x != 0.0)); // Assert not all zeros
 }

--- a/tests/seek.rs
+++ b/tests/seek.rs
@@ -145,7 +145,7 @@ fn seek_does_not_break_channel_order(
         let channel0 = 0 + channel_offset;
         assert!(
             is_silent(&samples, source.channels(), channel0),
-            "channel0 should be silent, 
+            "channel0 should be silent,
     channel0 starts at idx: {channel0}
     seek: {beep_start:?} + {offset:?}
     samples: {samples:?}"
@@ -153,7 +153,7 @@ fn seek_does_not_break_channel_order(
         let channel1 = (1 + channel_offset) % 2;
         assert!(
             !is_silent(&samples, source.channels(), channel1),
-            "channel1 should not be silent, 
+            "channel1 should not be silent,
     channel1; starts at idx: {channel1}
     seek: {beep_start:?} + {offset:?}
     samples: {samples:?}"

--- a/tests/wav_test.rs
+++ b/tests/wav_test.rs
@@ -6,30 +6,30 @@ fn test_wav_encodings() {
     // 16 bit wav file exported from Audacity (1 channel)
     let file = std::fs::File::open("assets/audacity16bit.wav").unwrap();
     let mut decoder = rodio::Decoder::new(BufReader::new(file)).unwrap();
-    assert!(decoder.any(|x| x != 0)); // Assert not all zeros
+    assert!(decoder.any(|x| x != 0.0)); // Assert not all zeros
 
     // 16 bit wav file exported from LMMS (2 channels)
     let file = std::fs::File::open("assets/lmms16bit.wav").unwrap();
     let mut decoder = rodio::Decoder::new(BufReader::new(file)).unwrap();
-    assert!(decoder.any(|x| x != 0));
+    assert!(decoder.any(|x| x != 0.0));
 
     // 24 bit wav file exported from LMMS (2 channels)
     let file = std::fs::File::open("assets/lmms24bit.wav").unwrap();
     let mut decoder = rodio::Decoder::new(BufReader::new(file)).unwrap();
-    assert!(decoder.any(|x| x != 0));
+    assert!(decoder.any(|x| x != 0.0));
 
     // 32 bit wav file exported from Audacity (1 channel)
     let file = std::fs::File::open("assets/audacity32bit.wav").unwrap();
     let mut decoder = rodio::Decoder::new(BufReader::new(file)).unwrap();
-    assert!(decoder.any(|x| x != 0));
+    assert!(decoder.any(|x| x != 0.0));
 
     // 32 bit wav file exported from LMMS (2 channels)
     let file = std::fs::File::open("assets/lmms32bit.wav").unwrap();
     let mut decoder = rodio::Decoder::new(BufReader::new(file)).unwrap();
-    assert!(decoder.any(|x| x != 0));
+    assert!(decoder.any(|x| x != 0.0));
 
     // 32 bit signed integer wav file exported from Audacity (1 channel).
     let file = std::fs::File::open("assets/audacity32bit_int.wav").unwrap();
     let mut decoder = rodio::Decoder::new(BufReader::new(file)).unwrap();
-    assert!(decoder.any(|x| x != 0));
+    assert!(decoder.any(|x| x != 0.0));
 }

--- a/tests/wav_test.rs
+++ b/tests/wav_test.rs
@@ -1,4 +1,7 @@
 #[cfg(feature = "wav")]
+use rodio::Sample;
+
+#[cfg(feature = "wav")]
 #[test]
 fn test_wav_encodings() {
     use std::io::BufReader;
@@ -6,30 +9,30 @@ fn test_wav_encodings() {
     // 16 bit wav file exported from Audacity (1 channel)
     let file = std::fs::File::open("assets/audacity16bit.wav").unwrap();
     let mut decoder = rodio::Decoder::new(BufReader::new(file)).unwrap();
-    assert!(decoder.any(|x| x != 0.0)); // Assert not all zeros
+    assert!(!decoder.all(|x| x.is_zero())); // Assert not all zeros
 
     // 16 bit wav file exported from LMMS (2 channels)
     let file = std::fs::File::open("assets/lmms16bit.wav").unwrap();
     let mut decoder = rodio::Decoder::new(BufReader::new(file)).unwrap();
-    assert!(decoder.any(|x| x != 0.0));
+    assert!(!decoder.all(|x| x.is_zero()));
 
     // 24 bit wav file exported from LMMS (2 channels)
     let file = std::fs::File::open("assets/lmms24bit.wav").unwrap();
     let mut decoder = rodio::Decoder::new(BufReader::new(file)).unwrap();
-    assert!(decoder.any(|x| x != 0.0));
+    assert!(!decoder.all(|x| x.is_zero()));
 
     // 32 bit wav file exported from Audacity (1 channel)
     let file = std::fs::File::open("assets/audacity32bit.wav").unwrap();
     let mut decoder = rodio::Decoder::new(BufReader::new(file)).unwrap();
-    assert!(decoder.any(|x| x != 0.0));
+    assert!(!decoder.all(|x| x.is_zero()));
 
     // 32 bit wav file exported from LMMS (2 channels)
     let file = std::fs::File::open("assets/lmms32bit.wav").unwrap();
     let mut decoder = rodio::Decoder::new(BufReader::new(file)).unwrap();
-    assert!(decoder.any(|x| x != 0.0));
+    assert!(!decoder.all(|x| x.is_zero()));
 
     // 32 bit signed integer wav file exported from Audacity (1 channel).
     let file = std::fs::File::open("assets/audacity32bit_int.wav").unwrap();
     let mut decoder = rodio::Decoder::new(BufReader::new(file)).unwrap();
-    assert!(decoder.any(|x| x != 0.0));
+    assert!(!decoder.all(|x| x.is_zero()));
 }


### PR DESCRIPTION
This PR improves audio quality in two ways:
1. Having decoders output `f32` samples directly instead of converting to `i16`
2. Properly handling high bit-depth FLAC and WAV files (20/24/32-bit) without bit depth reduction

Benefits include:
- Eliminates unnecessary quantization error from `i16` conversion
- Better matches the Rodio pipeline which already uses `f32` internally
- Preserves greater-than-`i16` precision from formats like WAV and FLAC
- More natural for decoders like Vorbis/MP3 that operate in floating point

Breaking changes:
- Decoder output type changes from `i16` to `f32`

Changes:
- Updated decoders to output `f32` samples and preserve full bit depth
- Updated tests and benchmarks to work with `f32` samples
- Simplified benchmark code by removing redundant `.to_f32s()` calls

Testing:
- Verified tests, benchmarks and examples run successfully
- Tested integration with [pleezer](https://github.com/roderickvd/pleezer/)

Fixes RustAudio/rodio#364
