### PR TITLE
Adds split_once to Source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `Source::amplify_normalized()` method to perceptually modify volume.
 - Adds a function to write a `Source` to a `wav` file, see `output_to_wav`.
 - Output audio stream buffer size can now be adjusted.
+- Adds a method to split sources in two: `Source::split_once`
 - Sources for directly generating square waves, triangle waves, square waves, and
   sawtooths have been added.
 - An interface for defining `SignalGenerator` patterns with an `fn`, see

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,3 +183,7 @@ required-features = ["playback", "vorbis"]
 [[example]]
 name = "stereo"
 required-features = ["playback", "vorbis"]
+
+[[example]]
+name = "fadeout_end"
+required-features = ["playback", "vorbis"]

--- a/examples/fadeout_end.rs
+++ b/examples/fadeout_end.rs
@@ -1,0 +1,25 @@
+use std::error::Error;
+use std::io::BufReader;
+use std::time::Duration;
+
+use rodio::Source;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let stream_handle = rodio::OutputStreamBuilder::open_default_stream()?;
+    let sink = rodio::Sink::connect_new(&stream_handle.mixer());
+
+    let file = std::fs::File::open("assets/music.wav")?;
+    let music = rodio::Decoder::new(BufReader::new(file))?;
+    let [start, end] = music.split_once(Duration::from_secs(3));
+    let end_duration = end
+        .total_duration()
+        .expect("can only fade out at the end if we know the total duration");
+    let end = end.fade_out(end_duration);
+
+    sink.append(start);
+    sink.append(end);
+
+    sink.sleep_until_end();
+
+    Ok(())
+}

--- a/examples/fadeout_end.rs
+++ b/examples/fadeout_end.rs
@@ -1,16 +1,16 @@
 use std::error::Error;
-use std::io::BufReader;
 use std::time::Duration;
 
 use rodio::Source;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let stream_handle = rodio::OutputStreamBuilder::open_default_stream()?;
-    let sink = rodio::Sink::connect_new(&stream_handle.mixer());
-
+    let sink = rodio::Sink::connect_new(stream_handle.mixer());
+    //
     let file = std::fs::File::open("assets/music.wav")?;
-    let music = rodio::Decoder::new(BufReader::new(file))?;
-    let [start, end] = music.split_once(Duration::from_secs(3));
+    let source = rodio::Decoder::try_from(file)?;
+
+    let [start, end] = source.split_once(Duration::from_secs(3));
     let end_duration = end
         .total_duration()
         .expect("can only fade out at the end if we know the total duration");

--- a/src/source/blt.rs
+++ b/src/source/blt.rs
@@ -123,6 +123,7 @@ where
         }
 
         let sample = self.input.next()?;
+
         let result = self
             .applier
             .as_ref()

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -520,8 +520,15 @@ pub trait Source: Iterator<Item = Sample> {
         skippable::skippable(self)
     }
 
-    /// returns two sources, the second source is inactive and will return
-    /// `None` until the first has passed the split_point.
+    /// returns two new sources that are continues segments of `self`.
+    /// The second segment is inactive and will return None until the
+    /// first segment has passed the provided split_point.
+    ///
+    /// # Seeking
+    /// If you seek outside the range of a segment the segment will
+    /// deactivate itself such that the other segment can play. This
+    /// works well when searching forward. Seeking back can require you
+    /// to play the previous segment again.
     fn split_once(self, at: Duration) -> [SplitAt<Self>; 2]
     where
         Self: Sized,

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -654,7 +654,7 @@ pub enum SeekError {
     /// Any other error probably in a custom Source
     Other(Box<dyn std::error::Error + Send>),
     /// Can not seek, this part of the split is not active
-    SegmentNotActive,
+    SegementNotActive,
 }
 impl fmt::Display for SeekError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -671,7 +671,7 @@ impl fmt::Display for SeekError {
             #[cfg(feature = "wav")]
             SeekError::HoundDecoder(err) => write!(f, "Error seeking in wav source: {}", err),
             SeekError::Other(_) => write!(f, "An error occurred"),
-            SeekError::SegmentNotActive => {
+            SeekError::SegementNotActive => {
                 write!(f, "Can not seek, this segement is still active")
             }
         }
@@ -686,7 +686,7 @@ impl std::error::Error for SeekError {
             #[cfg(feature = "wav")]
             SeekError::HoundDecoder(err) => Some(err),
             SeekError::Other(err) => Some(err.as_ref()),
-            SeekError::SegmentNotActive => None,
+            SeekError::SegementNotActive => None,
         }
     }
 }
@@ -709,7 +709,7 @@ impl SeekError {
             #[cfg(feature = "wav")]
             SeekError::HoundDecoder(_) => false,
             SeekError::Other(_) => false,
-            SeekError::SegmentNotActive => true,
+            SeekError::SegementNotActive => true,
         }
     }
 }

--- a/src/source/sine.rs
+++ b/src/source/sine.rs
@@ -1,4 +1,4 @@
-use crate::common::{ChannelCount, SampleRate};
+use crate::common::{ChannelCount, Sample, SampleRate};
 use crate::source::{Function, SignalGenerator};
 use crate::Source;
 use std::time::Duration;
@@ -29,7 +29,7 @@ impl SineWave {
 }
 
 impl Iterator for SineWave {
-    type Item = f32;
+    type Item = Sample;
 
     #[inline]
     fn next(&mut self) -> Option<f32> {

--- a/src/source/split_at.rs
+++ b/src/source/split_at.rs
@@ -1,0 +1,123 @@
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use crate::ChannelCount;
+use crate::SampleRate;
+
+use super::Source;
+use super::TrackPosition;
+
+pub struct SplitAt<S> {
+    shared_source: Arc<Mutex<Option<TrackPosition<S>>>>,
+    active: Option<TrackPosition<S>>,
+    split_duration: Option<Duration>,
+    split_point: Duration,
+    first_span_sample_rate: SampleRate,
+    first_span_channel_count: ChannelCount,
+}
+
+impl<S> SplitAt<S>
+where
+    S: Source,
+    <S as Iterator>::Item: crate::Sample,
+{
+    /// returns two sources, the second is inactive and will return
+    /// none until the first has passed the split_point.
+    pub(crate) fn new(input: S, split_point: Duration) -> [Self; 2] {
+        let shared_source = Arc::new(Mutex::new(None));
+        let first_span_sample_rate = input.sample_rate();
+        let first_span_channel_count = input.channels();
+        let total_duration = input.total_duration();
+        [
+            Self {
+                shared_source: shared_source.clone(),
+                active: Some(input.track_position()),
+                split_duration: Some(split_point),
+                split_point,
+                first_span_sample_rate,
+                first_span_channel_count,
+            },
+            Self {
+                shared_source,
+                active: None,
+                split_duration: total_duration.map(|d| d.saturating_sub(split_point)),
+                split_point: Duration::MAX,
+                first_span_sample_rate,
+                first_span_channel_count,
+            },
+        ]
+    }
+}
+
+impl<S> Iterator for SplitAt<S>
+where
+    S: Source,
+    S::Item: crate::Sample,
+{
+    type Item = <S as Iterator>::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let input = if let Some(active) = self.active.as_mut() {
+            active
+        } else {
+            // did they other stop?
+            let shared = self
+                .shared_source
+                .lock()
+                .expect("audio thread should not panic")
+                .take();
+            self.active = shared;
+            self.active.as_mut()?
+        };
+
+        // There is some optimization potential here we are not using currently.
+        // Calling get_pos once per span should be enough
+        if input.get_pos() < self.split_point {
+            input.next()
+        } else {
+            let source = self.active.take();
+            *self
+                .shared_source
+                .lock()
+                .expect("audio thread should not panic") = source;
+            None
+        }
+    }
+}
+
+impl<S> Source for SplitAt<S>
+where
+    S: Source,
+    S::Item: crate::Sample,
+{
+    fn current_span_len(&self) -> Option<usize> {
+        self.active.as_ref()?.current_span_len()
+    }
+
+    fn channels(&self) -> ChannelCount {
+        self.active
+            .as_ref()
+            .map(Source::channels)
+            .unwrap_or(self.first_span_channel_count)
+    }
+
+    fn sample_rate(&self) -> SampleRate {
+        self.active
+            .as_ref()
+            .map(Source::sample_rate)
+            .unwrap_or(self.first_span_sample_rate)
+    }
+
+    fn total_duration(&self) -> Option<Duration> {
+        self.split_duration
+    }
+
+    fn try_seek(&mut self, pos: Duration) -> Result<(), super::SeekError> {
+        if let Some(active) = self.active.as_mut() {
+            active.try_seek(pos)
+        } else {
+            Err(super::SeekError::SplitNotActive)
+        }
+    }
+}

--- a/src/source/split_at.rs
+++ b/src/source/split_at.rs
@@ -9,14 +9,14 @@ use crate::SampleRate;
 use super::Source;
 use super::TrackPosition;
 
-pub struct SplitAt<S> {
+pub struct Segment<S> {
     shared_source: Arc<Mutex<Option<TrackPosition<S>>>>,
     active: Option<TrackPosition<S>>,
     segment_range: Range<Duration>,
     split_duration: Option<Duration>,
 }
 
-impl<S> SplitAt<S>
+impl<S> Segment<S>
 where
     S: Source,
     <S as Iterator>::Item: crate::Sample,
@@ -53,7 +53,7 @@ where
     }
 }
 
-impl<S> Iterator for SplitAt<S>
+impl<S> Iterator for Segment<S>
 where
     S: Source,
     S::Item: crate::Sample,
@@ -89,7 +89,7 @@ where
     }
 }
 
-impl<S> Source for SplitAt<S>
+impl<S> Source for Segment<S>
 where
     S: Source,
     S::Item: crate::Sample,
@@ -131,7 +131,7 @@ where
             }
             Ok(())
         } else {
-            Err(super::SeekError::SplitNotActive)
+            Err(super::SeekError::SegmentNotActive)
         }
     }
 }

--- a/src/source/split_at.rs
+++ b/src/source/split_at.rs
@@ -94,10 +94,7 @@ impl<S: Source> Source for Segment<S> {
     }
 
     fn channels(&self) -> ChannelCount {
-        self.active
-            .as_ref()
-            .map(Source::channels)
-            .unwrap_or(2)
+        self.active.as_ref().map(Source::channels).unwrap_or(2)
     }
 
     fn sample_rate(&self) -> SampleRate {

--- a/tests/split.rs
+++ b/tests/split.rs
@@ -1,78 +1,10 @@
-use rodio::Source;
+use rodio::{buffer::SamplesBuffer, Source};
 use std::time::Duration;
-
-struct TestSource {
-    samples: Vec<f32>,
-    pos: usize,
-    channels: rodio::ChannelCount,
-    sample_rate: rodio::SampleRate,
-    total_duration: Option<Duration>,
-}
-
-impl TestSource {
-    fn new<'a>(samples: impl IntoIterator<Item = &'a f32>) -> Self {
-        Self {
-            samples: samples.into_iter().copied().collect::<Vec<f32>>(),
-            pos: 0,
-            channels: 1,
-            sample_rate: 1,
-            total_duration: None,
-        }
-    }
-
-    fn with_sample_rate(mut self, rate: rodio::SampleRate) -> Self {
-        self.sample_rate = rate;
-        self
-    }
-    fn with_channels(mut self, count: rodio::ChannelCount) -> Self {
-        self.channels = count;
-        self
-    }
-    fn with_total_duration(mut self, duration: Duration) -> Self {
-        self.total_duration = Some(duration);
-        self
-    }
-}
-
-impl Iterator for TestSource {
-    type Item = f32;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let res = self.samples.get(self.pos).copied();
-        self.pos += 1;
-        res
-    }
-}
-
-impl rodio::Source for TestSource {
-    fn current_span_len(&self) -> Option<usize> {
-        None // must be None or seek will not work
-    }
-    fn channels(&self) -> rodio::ChannelCount {
-        self.channels
-    }
-    fn sample_rate(&self) -> rodio::SampleRate {
-        self.sample_rate
-    }
-    fn total_duration(&self) -> Option<Duration> {
-        self.total_duration
-    }
-    fn try_seek(&mut self, pos: Duration) -> Result<(), rodio::source::SeekError> {
-        let duration_per_sample = Duration::from_secs(1) / self.sample_rate;
-        let offset = pos.div_duration_f64(duration_per_sample).floor() as usize;
-        self.pos = offset;
-
-        Ok(())
-    }
-}
 
 #[test]
 fn split_contains_all_samples() {
     let input = [0, 1, 2, 3, 4].map(|s| s as f32);
-    let source = TestSource::new(&input)
-        .with_channels(1)
-        .with_sample_rate(1)
-        .with_total_duration(Duration::from_secs(5));
+    let source = SamplesBuffer::new(1, 1, input);
 
     let [start, end] = source.split_once(Duration::from_secs(3));
 
@@ -83,10 +15,7 @@ fn split_contains_all_samples() {
 #[test]
 fn seek_over_segment_boundry() {
     let input = [0, 1, 2, 3, 4, 5, 6, 7].map(|s| s as f32);
-    let source = TestSource::new(&input)
-        .with_channels(1)
-        .with_sample_rate(1)
-        .with_total_duration(Duration::from_secs(5));
+    let source = SamplesBuffer::new(1, 1, input);
 
     let [mut start, mut end] = source.split_once(Duration::from_secs(3));
     assert_eq!(start.next(), Some(0.0));

--- a/tests/split.rs
+++ b/tests/split.rs
@@ -1,0 +1,96 @@
+use rodio::Source;
+use std::time::Duration;
+
+struct TestSource {
+    samples: Vec<f32>,
+    pos: usize,
+    channels: rodio::ChannelCount,
+    sample_rate: rodio::SampleRate,
+    total_duration: Option<Duration>,
+}
+
+impl TestSource {
+    fn new<'a>(samples: impl IntoIterator<Item = &'a f32>) -> Self {
+        Self {
+            samples: samples.into_iter().copied().collect::<Vec<f32>>(),
+            pos: 0,
+            channels: 1,
+            sample_rate: 1,
+            total_duration: None,
+        }
+    }
+
+    fn with_sample_rate(mut self, rate: rodio::SampleRate) -> Self {
+        self.sample_rate = rate;
+        self
+    }
+    fn with_channels(mut self, count: rodio::ChannelCount) -> Self {
+        self.channels = count;
+        self
+    }
+    fn with_total_duration(mut self, duration: Duration) -> Self {
+        self.total_duration = Some(duration);
+        self
+    }
+}
+
+impl Iterator for TestSource {
+    type Item = f32;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let res = self.samples.get(self.pos).copied();
+        self.pos += 1;
+        res
+    }
+}
+
+impl rodio::Source for TestSource {
+    fn current_span_len(&self) -> Option<usize> {
+        None // must be None or seek will not work
+    }
+    fn channels(&self) -> rodio::ChannelCount {
+        self.channels
+    }
+    fn sample_rate(&self) -> rodio::SampleRate {
+        self.sample_rate
+    }
+    fn total_duration(&self) -> Option<Duration> {
+        self.total_duration
+    }
+    fn try_seek(&mut self, pos: Duration) -> Result<(), rodio::source::SeekError> {
+        let duration_per_sample = Duration::from_secs(1) / self.sample_rate;
+        let offset = pos.div_duration_f64(duration_per_sample).floor() as usize;
+        self.pos = offset;
+
+        Ok(())
+    }
+}
+
+#[test]
+fn split_contains_all_samples() {
+    let input = [0, 1, 2, 3, 4].map(|s| s as f32);
+    let source = TestSource::new(&input)
+        .with_channels(1)
+        .with_sample_rate(1)
+        .with_total_duration(Duration::from_secs(5));
+
+    let [start, end] = source.split_once(Duration::from_secs(3));
+
+    let played: Vec<_> = start.chain(end).collect();
+    assert_eq!(input.as_slice(), played.as_slice());
+}
+
+#[test]
+fn seek_over_segment_boundry() {
+    let input = [0, 1, 2, 3, 4, 5, 6, 7].map(|s| s as f32);
+    let source = TestSource::new(&input)
+        .with_channels(1)
+        .with_sample_rate(1)
+        .with_total_duration(Duration::from_secs(5));
+
+    let [mut start, mut end] = source.split_once(Duration::from_secs(3));
+    assert_eq!(start.next(), Some(0.0));
+    start.try_seek(Duration::from_secs(6)).unwrap();
+    assert_eq!(end.next(), Some(6.0));
+    assert_eq!(end.next(), Some(7.0));
+}

--- a/tests/split.rs
+++ b/tests/split.rs
@@ -13,7 +13,7 @@ fn split_contains_all_samples() {
 }
 
 #[test]
-fn seek_over_segment_boundry() {
+fn seek_over_segment_boundary() {
     let input = [0, 1, 2, 3, 4, 5, 6, 7].map(|s| s as f32);
     let source = SamplesBuffer::new(1, 1, input);
 


### PR DESCRIPTION
split_once can be used chop a source into two sources without duplicating the first. Those sources can then not be played simultaneously. This is usefull for adding a fadeout at the end of a song for example. Though we could later specialize fadeout at end.

The implementation uses a `SplitAt` struct, `split_once` returns an array of two of those. In the future we can introduce methods like `split` that return a vec of SplitAt's allowing users to chop a source into multiple sections