### PR TITLE
Improve ChannelVolume's Mono conversion algorithm to use the average of samples

### DIFF
--- a/src/source/channel_volume.rs
+++ b/src/source/channel_volume.rs
@@ -34,12 +34,14 @@ where
         I::Item: Sample,
     {
         let mut sample = None;
-        for _ in 0..input.channels() {
+        let num_channels = input.channels();
+
+        for _ in 0..num_channels {
             if let Some(s) = input.next() {
                 sample = Some(
                     sample
                         .get_or_insert_with(I::Item::zero_value)
-                        .saturating_add(s),
+                        .saturating_add(s.amplify(1.0 / num_channels as f32)),
                 );
             }
         }
@@ -92,12 +94,15 @@ where
         if self.current_channel >= self.channel_volumes.len() {
             self.current_channel = 0;
             self.current_sample = None;
-            for _ in 0..self.input.channels() {
+
+            let num_channels = self.input.channels();
+
+            for _ in 0..num_channels {
                 if let Some(s) = self.input.next() {
                     self.current_sample = Some(
                         self.current_sample
                             .get_or_insert_with(I::Item::zero_value)
-                            .saturating_add(s),
+                            .saturating_add(s.amplify(1.0 / num_channels as f32)),
                     );
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/RustAudio/rodio/issues/680

This avoids any potential clipping/overflow.

As ChannelVolume deals with Samples in the same format they come in as (e.g. i16), previously just using `.saturating_add()` to sum all the samples would mean that the sum would be clipped/overflow if the signals were large enough. By averaging the Samples we avoid this overflow.