### PR TITLE
Trigger GitHub release/publish explicitly, scripts cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,14 +28,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: install linux deps
-        run: |
-          sudo apt update
-          sudo apt install -y --no-install-recommends libasound2-dev pkg-config
+      - name: Install linux build requirements
+        run: sudo apt install --yes --no-install-recommends libasound2-dev pkg-config
         if: contains(matrix.os, 'ubuntu')
 
       - name: install ${{ matrix.toolchain }} toolchain
-        id: install_toolchain
         run: rustup toolchain install ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
 
       - run: cargo clippy -- -D warnings
@@ -55,33 +52,3 @@ jobs:
       # Check minimal build. `tests/seek.rs` fails if there are no decoders at all,
       # adding one to make the tests check pass.
       - run: cargo check --tests --lib --no-default-features --features mp3
-
-  create-git-tag:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout the code.
-        uses: actions/checkout@v4
-
-      - name: Fetch tags.
-        #### FIXME Test this (it should fetch all tags without getting the history).
-        run: git fetch --prune --unshallow --tags
-
-      - name: Create a tag for current version if it does not exist yet.
-        id: create_version_tag
-        run: |
-          echo "Current git commit is $(git rev-list -n 1 HEAD)."
-          VERSION="$(yq '.package.version' Cargo.toml)"
-          echo "Project version from Cargo.toml: $VERSION"
-          VERSION_TAG="v$VERSION"
-          if git tag | grep "$VERSION_TAG"; then
-            echo "Tag $VERSION_TAG already exists at $(git rev-list -n 1 $VERSION_TAG), leaving it unchanged."
-          else
-            echo "Creating new tag $VERSION_TAG ..."
-            ###### FIXME Review this using https://github.com/actions/checkout
-            ######        User name and email may need to be updated.
-            git config user.name 'github-actions'
-            git config user.email 'github-actions@github.com'
-            git tag --annotate "$VERSION_TAG" --message "Release version $VERSION_TAG"
-            git push origin "$VERSION_TAG"
-          endif

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [main, master]
+    branches: [ main, master ]
 
 env:
   RUSTFLAGS: "-C debuginfo=0 -D warnings"
@@ -18,8 +18,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
-        toolchain: [stable, beta, nightly]
+        os: [ macos-latest, windows-latest, ubuntu-latest ]
+        toolchain: [ stable, beta, nightly ]
         include:
           - os: macos-latest
             MACOS: true
@@ -52,72 +52,36 @@ jobs:
       # `cargo test` does not check benchmarks and `cargo test --all-targets` excludes
       # documentation tests. Therefore, we need an additional docs test command here.
       - run: cargo test --doc
-  cargo-publish:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-    env:
-      CRATESIO_TOKEN: ${{ secrets.CRATESIO_TOKEN }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Update apt
-        run: sudo apt update
-      - name: Install alsa
-        run: sudo apt install -y --no-install-recommends libasound2-dev pkg-config
-      - name: Run cargo publish for rodio
-        continue-on-error: true
-        run: |
-          RODIO_TMP=$(mktemp /tmp/rodioXXX.txt) || echo "::error::mktemp error"
-          echo "RODIO_TMP=$RODIO_TMP" >> $GITHUB_ENV
-          cargo publish --token $CRATESIO_TOKEN 2> $RODIO_TMP
-      - name: Check if rodio is already published
-        run: |
-          empty=0
-          RODIO_TMP="${{ env.RODIO_TMP }}"
-          grep -q '[^[:space:]]' < $RODIO_TMP || empty=1
-          [ $empty -eq 0 ] && cat $RODIO_TMP
-          [ $empty -eq 1 ] || grep -q "is already uploaded" < $RODIO_TMP
+      # Check minimal build. `tests/seek.rs` fails if there are no decoders at all,
+      # adding one to make the tests check pass.
+      - run: cargo check --tests --lib --no-default-features --features mp3
 
   create-git-tag:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
-    - name: Check if WORKFLOW_TOKEN is set
-      run: |
-        if [ -z "${{ secrets.WORKFLOW_TOKEN }}" ]; then
-          echo "Personal access token WORKFLOW_TOKEN is not set"
-          exit 1
-        else
-          echo "Checked `WORKFLOW_TOKEN` is set"
-        fi
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0  # Fetch all history to list all existing tags
-        token: ${{ secrets.WORKFLOW_TOKEN }}
-    - name: Extract version from Cargo.toml
-      id: extract_version
-      run: |
-        version=$(awk '/\[package\]/,/^version/ { if ($1 == "version") { gsub(/"/, "", $3); print $3 } }' Cargo.toml)
-        echo "Version value found: $version"
-        echo "version=$version" >> $GITHUB_OUTPUT
-    - name: Check if tag exists
-      id: check_tag
-      run: |
-        version=${{ steps.extract_version.outputs.version }}
-        version_name="v$version"
-        if git rev-parse "refs/tags/$version_name" >/dev/null 2>&1; then
-          echo "Tag $version_name already exists"
-          echo "tag_exists=true" >> $GITHUB_OUTPUT
-        else
-          echo "Tag $version_name does not exist"
-          echo "tag_exists=false" >> $GITHUB_OUTPUT
-        fi
-    - name: Create and push tag
-      if: steps.check_tag.outputs.tag_exists == 'false'
-      run: |
-        version=${{ steps.extract_version.outputs.version }}
-        git config --global user.name 'github-actions'
-        git config --global user.email 'github-actions@github.com'
-        version_name="v$version"
-        git tag -a "$version_name" -m "Release for $version_name"
-        git push origin $version_name
+      - name: Checkout the code.
+        uses: actions/checkout@v4
+
+      - name: Fetch tags.
+        #### FIXME Test this (it should fetch all tags without getting the history).
+        run: git fetch --prune --unshallow --tags
+
+      - name: Create a tag for current version if it does not exist yet.
+        id: create_version_tag
+        run: |
+          echo "Current git commit is $(git rev-list -n 1 HEAD)."
+          VERSION="$(yq '.package.version' Cargo.toml)"
+          echo "Project version from Cargo.toml: $VERSION"
+          VERSION_TAG="v$VERSION"
+          if git tag | grep "$VERSION_TAG"; then
+            echo "Tag $VERSION_TAG already exists at $(git rev-list -n 1 $VERSION_TAG), leaving it unchanged."
+          else
+            echo "Creating new tag $VERSION_TAG ..."
+            ###### FIXME Review this using https://github.com/actions/checkout
+            ######        User name and email may need to be updated.
+            git config user.name 'github-actions'
+            git config user.email 'github-actions@github.com'
+            git tag --annotate "$VERSION_TAG" --message "Release version $VERSION_TAG"
+            git push origin "$VERSION_TAG"
+          endif

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,28 @@
+name: Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_tag:
+        description: 'Rodio version git tag to publish.'
+        required: true
+
+jobs:
+  cargo-publish:
+    env:
+      CRATESIO_TOKEN: ${{ secrets.CRATESIO_TOKEN }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if the git reference looks like a version tag.
+        run: |
+          echo "${{ inputs.version_tag }}" \
+          | grep --quiet "^v[0-9]\{1,2\}\.[0-9]\{1,3\}\(\.[0-9]\{1,3\}\)\?$"
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.version_tag }}
+      - name: Update list of apt packages.
+        run: sudo apt update
+      - name: Install alsa.
+        run: sudo apt install --yes --no-install-recommends libasound2-dev pkg-config
+      - name: Publish rodio to crates.io.
+        run: cargo publish --token "$CRATESIO_TOKEN"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,10 +20,15 @@ jobs:
       - name: Publish and tag
         run: |
           echo "Current git commit is $(git rev-list -n 1 HEAD)."
+
           VERSION="$(yq '.package.version' Cargo.toml)"
           echo "Project version from Cargo.toml is $VERSION"
-          VERSION_TAG="v$VERSION"
+          if ! (echo "$VERSION" | grep --quiet "^[0-9]\{1,2\}\.[0-9]\{1,3\}\(\.[0-9]\{1,3\}\)\?$"); then
+            echo "The version format does not look like a release version, not publishing the crate."
+            exit 1
+          fi
 
+          VERSION_TAG="v$VERSION"
           if git tag | grep --quiet "^$VERSION_TAG$"; then
             echo "Tag $VERSION_TAG already exists at $(git rev-list -n 1 $VERSION_TAG), not publishing the crate."
             exit 1

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,28 +1,40 @@
 name: Publish
 
-on:
-  workflow_dispatch:
-    inputs:
-      version_tag:
-        description: 'Rodio version git tag to publish.'
-        required: true
+on: workflow_dispatch
 
 jobs:
   cargo-publish:
-    env:
-      CRATESIO_TOKEN: ${{ secrets.CRATESIO_TOKEN }}
     runs-on: ubuntu-latest
     steps:
-      - name: Check if the git reference looks like a version tag.
-        run: |
-          echo "${{ inputs.version_tag }}" \
-          | grep --quiet "^v[0-9]\{1,2\}\.[0-9]\{1,3\}\(\.[0-9]\{1,3\}\)\?$"
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.version_tag }}
-      - name: Update list of apt packages.
-        run: sudo apt update
-      - name: Install alsa.
+
+      - name: Fetch tags
+        run: git fetch --prune --unshallow --tags
+
+      - name: Install linux build requirements
         run: sudo apt install --yes --no-install-recommends libasound2-dev pkg-config
-      - name: Publish rodio to crates.io.
-        run: cargo publish --token "$CRATESIO_TOKEN"
+
+      - name: Publish and tag
+        run: |
+          echo "Current git commit is $(git rev-list -n 1 HEAD)."
+          VERSION="$(yq '.package.version' Cargo.toml)"
+          echo "Project version from Cargo.toml is $VERSION"
+          VERSION_TAG="v$VERSION"
+
+          if git tag | grep --quiet "^$VERSION_TAG$"; then
+            echo "Tag $VERSION_TAG already exists at $(git rev-list -n 1 $VERSION_TAG), not publishing the crate."
+            exit 1
+          fi
+
+          cargo publish --token "${{ secrets.CRATESIO_TOKEN }}"
+
+          echo "Tagging current version with $VERSION_TAG ..."
+          # The bot name and email is taken from here https://github.com/actions/checkout/pull/1707
+          # see also https://api.github.com/users/github-actions%5Bbot%5D
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag --annotate "$VERSION_TAG" --message "Release version $VERSION_TAG"
+          git push origin "$VERSION_TAG"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,3 +139,17 @@ We understand that every situation is unique and encourage contributors
 to use their best judgment. If you have any doubts or questions about
 how to approach a particular task or contribution, don't hesitate to
 reach out to the maintainers for guidance.
+
+## Guidelines for Maintainers
+
+### Release Procedure
+
+The project is built automatically by a GitHub action when a new revision is pushed to the master branch.
+The crate is published by triggering `.github/workflows/manual.yml` GitHub action.
+After the crate is successfully published a new git tag is created in the repository.
+
+So to publish a new version
+1. Update `project.version` field in `Cargo.toml`.
+2. Push the changes to the `master` branch.
+3. Wait until GitHub build job completes successfully.
+4. [On the Actions page](https://github.com/RustAudio/rodio/actions) start `.github/workflows/manual.yml`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,11 +154,11 @@ For example spelling/grammar or fixing up a PR by someone else.
 ## Release Procedure
 
 The project is built automatically by a GitHub action when a new revision is pushed to the master branch.
-The crate is published by triggering `.github/workflows/manual.yml` GitHub action.
-After the crate is successfully published a new git tag is created in the repository.
+The crate is published by triggering `.github/workflows/publish.yml` GitHub action.
+After the crate is successfully published a new version's git tag is created in the repository.
 
 So to publish a new version
 1. Update `project.version` field in `Cargo.toml`.
 2. Push the changes to the `master` branch.
 3. Wait until GitHub build job completes successfully.
-4. [On the Actions page](https://github.com/RustAudio/rodio/actions) start `.github/workflows/manual.yml`.
+4. [On the Actions page](https://github.com/RustAudio/rodio/actions) start `.github/workflows/publish.yml`.


### PR DESCRIPTION
This avoid irrelevant errors during build as release/publish is now triggered manually.  This helps to make it intentional, now it is not obvious that change in Cargo.toml may trigger publication, so some versions may end up on Crates.io accidentally and then be depended upon.
The tag is created only after successful publication, so we know which version was released.
Also some scripts were unnecessarily complex, I tried to streamline that.

One drawback is that one have to wait for tests on master to complete successfully. It is possible to invoke the tests from the release workflow. This is more reliable, but will do some work twice.