### PR TITLE
Revert to default buffer size

### DIFF
--- a/benches/effects.rs
+++ b/benches/effects.rs
@@ -12,7 +12,7 @@ fn main() {
 
 #[divan::bench]
 fn reverb(bencher: Bencher) {
-    bencher.with_inputs(|| music_wav()).bench_values(|source| {
+    bencher.with_inputs(music_wav).bench_values(|source| {
         source
             .buffered()
             .reverb(Duration::from_secs_f32(0.05), 0.3)
@@ -23,13 +23,13 @@ fn reverb(bencher: Bencher) {
 #[divan::bench]
 fn high_pass(bencher: Bencher) {
     bencher
-        .with_inputs(|| music_wav())
+        .with_inputs(music_wav)
         .bench_values(|source| source.high_pass(200).for_each(divan::black_box_drop))
 }
 
 #[divan::bench]
 fn fade_out(bencher: Bencher) {
-    bencher.with_inputs(|| music_wav()).bench_values(|source| {
+    bencher.with_inputs(music_wav).bench_values(|source| {
         source
             .fade_out(Duration::from_secs(5))
             .for_each(divan::black_box_drop)
@@ -39,13 +39,13 @@ fn fade_out(bencher: Bencher) {
 #[divan::bench]
 fn amplify(bencher: Bencher) {
     bencher
-        .with_inputs(|| music_wav())
+        .with_inputs(music_wav)
         .bench_values(|source| source.amplify(0.8).for_each(divan::black_box_drop))
 }
 
 #[divan::bench]
 fn agc_enabled(bencher: Bencher) {
-    bencher.with_inputs(|| music_wav()).bench_values(|source| {
+    bencher.with_inputs(music_wav).bench_values(|source| {
         source
             .automatic_gain_control(
                 1.0,   // target_level

--- a/benches/pipeline.rs
+++ b/benches/pipeline.rs
@@ -12,7 +12,7 @@ fn main() {
 
 #[divan::bench]
 fn long(bencher: Bencher) {
-    bencher.with_inputs(|| music_wav()).bench_values(|source| {
+    bencher.with_inputs(music_wav).bench_values(|source| {
         let mut take_dur = source
             .high_pass(300)
             .amplify(1.2)
@@ -38,7 +38,7 @@ fn long(bencher: Bencher) {
 
 #[divan::bench]
 fn short(bencher: Bencher) {
-    bencher.with_inputs(|| music_wav()).bench_values(|source| {
+    bencher.with_inputs(music_wav).bench_values(|source| {
         source
             .amplify(1.2)
             .low_pass(200)

--- a/examples/automatic_gain_control.rs
+++ b/examples/automatic_gain_control.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let stream_handle = rodio::OutputStreamBuilder::open_default_stream()?;
-    let sink = rodio::Sink::connect_new(&stream_handle.mixer());
+    let sink = rodio::Sink::connect_new(stream_handle.mixer());
 
     // Decode the sound file into a source
     let file = File::open("assets/music.flac")?;

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -12,7 +12,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let beep1 = {
         // Play a WAV file.
         let file = std::fs::File::open("assets/beep.wav")?;
-        let sink = rodio::play(&mixer, BufReader::new(file))?;
+        let sink = rodio::play(mixer, BufReader::new(file))?;
         sink.set_volume(0.2);
         sink
     };
@@ -32,7 +32,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let beep3 = {
         // Play an OGG file.
         let file = std::fs::File::open("assets/beep3.ogg")?;
-        let sink = rodio::play(&mixer, BufReader::new(file))?;
+        let sink = rodio::play(mixer, BufReader::new(file))?;
         sink.set_volume(0.2);
         sink
     };

--- a/examples/callback_on_end.rs
+++ b/examples/callback_on_end.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let stream_handle = rodio::OutputStreamBuilder::open_default_stream()?;
-    let sink = rodio::Sink::connect_new(&stream_handle.mixer());
+    let sink = rodio::Sink::connect_new(stream_handle.mixer());
 
     let file = std::fs::File::open("assets/music.wav")?;
     sink.append(rodio::Decoder::try_from(file)?);

--- a/examples/low_pass.rs
+++ b/examples/low_pass.rs
@@ -5,7 +5,7 @@ use rodio::Source;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let stream_handle = rodio::OutputStreamBuilder::open_default_stream()?;
-    let sink = rodio::Sink::connect_new(&stream_handle.mixer());
+    let sink = rodio::Sink::connect_new(stream_handle.mixer());
 
     let file = std::fs::File::open("assets/music.wav")?;
     let decoder = rodio::Decoder::new(BufReader::new(file))?;

--- a/examples/mix_multiple_sources.rs
+++ b/examples/mix_multiple_sources.rs
@@ -7,7 +7,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Construct a dynamic controller and mixer, stream_handle, and sink.
     let (controller, mixer) = mixer::mixer(2, 44_100);
     let stream_handle = rodio::OutputStreamBuilder::open_default_stream()?;
-    let sink = rodio::Sink::connect_new(&stream_handle.mixer());
+    let sink = rodio::Sink::connect_new(stream_handle.mixer());
 
     // Create four unique sources. The frequencies used here correspond
     // notes in the key of C and in octave 4: C4, or middle C on a piano,

--- a/examples/music_flac.rs
+++ b/examples/music_flac.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let stream_handle = rodio::OutputStreamBuilder::open_default_stream()?;
-    let sink = rodio::Sink::connect_new(&stream_handle.mixer());
+    let sink = rodio::Sink::connect_new(stream_handle.mixer());
 
     let file = std::fs::File::open("assets/music.flac")?;
     sink.append(rodio::Decoder::try_from(file)?);

--- a/examples/music_mp3.rs
+++ b/examples/music_mp3.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let stream_handle = rodio::OutputStreamBuilder::open_default_stream()?;
-    let sink = rodio::Sink::connect_new(&stream_handle.mixer());
+    let sink = rodio::Sink::connect_new(stream_handle.mixer());
 
     let file = std::fs::File::open("assets/music.mp3")?;
     sink.append(rodio::Decoder::try_from(file)?);

--- a/examples/music_ogg.rs
+++ b/examples/music_ogg.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let stream_handle = rodio::OutputStreamBuilder::open_default_stream()?;
-    let sink = rodio::Sink::connect_new(&stream_handle.mixer());
+    let sink = rodio::Sink::connect_new(stream_handle.mixer());
 
     let file = std::fs::File::open("assets/music.ogg")?;
     sink.append(rodio::Decoder::try_from(file)?);

--- a/examples/music_wav.rs
+++ b/examples/music_wav.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let stream_handle = rodio::OutputStreamBuilder::open_default_stream()?;
-    let sink = rodio::Sink::connect_new(&stream_handle.mixer());
+    let sink = rodio::Sink::connect_new(stream_handle.mixer());
 
     let file = std::fs::File::open("assets/music.wav")?;
     sink.append(rodio::Decoder::try_from(file)?);

--- a/examples/reverb.rs
+++ b/examples/reverb.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let stream_handle = rodio::OutputStreamBuilder::open_default_stream()?;
-    let sink = rodio::Sink::connect_new(&stream_handle.mixer());
+    let sink = rodio::Sink::connect_new(stream_handle.mixer());
 
     let file = std::fs::File::open("assets/music.ogg")?;
     let source = rodio::Decoder::try_from(file)?;

--- a/examples/seek_mp3.rs
+++ b/examples/seek_mp3.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let stream_handle = rodio::OutputStreamBuilder::open_default_stream()?;
-    let sink = rodio::Sink::connect_new(&stream_handle.mixer());
+    let sink = rodio::Sink::connect_new(stream_handle.mixer());
 
     let file = std::fs::File::open("assets/music.mp3")?;
     sink.append(rodio::Decoder::try_from(file)?);

--- a/examples/spatial.rs
+++ b/examples/spatial.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let mut positions = ([0., 0., 0.], [-1., 0., 0.], [1., 0., 0.]);
     let sink = rodio::SpatialSink::connect_new(
-        &stream_handle.mixer(),
+        stream_handle.mixer(),
         positions.0,
         positions.1,
         positions.2,

--- a/examples/stereo.rs
+++ b/examples/stereo.rs
@@ -5,7 +5,7 @@ use std::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let stream_handle = rodio::OutputStreamBuilder::open_default_stream()?;
-    let sink = rodio::Sink::connect_new(&stream_handle.mixer());
+    let sink = rodio::Sink::connect_new(stream_handle.mixer());
 
     let file = std::fs::File::open("assets/RL.ogg")?;
     sink.append(rodio::Decoder::try_from(file)?.amplify(0.2));

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -177,7 +177,6 @@ mod tests {
                 CHANNELS,
                 SAMPLE_RATE,
                 (0..2000i16)
-                    .into_iter()
                     .map(|s| s as Sample)
                     .collect::<Vec<_>>(),
             );

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -176,9 +176,7 @@ mod tests {
             let mut buf = SamplesBuffer::new(
                 CHANNELS,
                 SAMPLE_RATE,
-                (0..2000i16)
-                    .map(|s| s as Sample)
-                    .collect::<Vec<_>>(),
+                (0..2000i16).map(|s| s as Sample).collect::<Vec<_>>(),
             );
             buf.try_seek(Duration::from_secs(5)).unwrap();
             assert_eq!(buf.next(), Some(5.0 * SAMPLE_RATE as f32 * CHANNELS as f32));

--- a/src/math.rs
+++ b/src/math.rs
@@ -26,7 +26,7 @@ mod test {
             let a = first as f64;
             let b = second as f64;
             let c = numerator as f64 / denominator as f64;
-            if c < 0.0 || c > 1.0 { return TestResult::discard(); };
+            if !(0.0..=1.0).contains(&c) { return TestResult::discard(); };
 
             let reference = a * (1.0 - c) + b * c;
             let x = lerp(&(first as f32), &(second as f32), numerator as u32, denominator as u32) as f64;

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -219,7 +219,7 @@ impl SourcesQueueOutput {
         let (next, signal_after_end) = {
             let mut next = self.input.next_sounds.lock().unwrap();
 
-            if next.len() == 0 {
+            if next.is_empty() {
                 let silence = Box::new(Zero::new_samples(1, 44100, THRESHOLD)) as Box<_>;
                 if self.input.keep_alive_if_empty.load(Ordering::Acquire) {
                     // Play a short silence in order to avoid spinlocking.

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -401,7 +401,7 @@ mod tests {
 
         assert_eq!(source.next(), Some(0.0));
 
-        assert_eq!(sink.empty(), true);
+        assert!(sink.empty());
     }
 
     #[test]

--- a/src/source/position.rs
+++ b/src/source/position.rs
@@ -174,7 +174,7 @@ mod tests {
         source.next();
         assert_eq!(source.get_pos().as_secs_f32(), 2.0);
 
-        assert_eq!(source.try_seek(Duration::new(1, 0)).is_ok(), true);
+        assert!(source.try_seek(Duration::new(1, 0)).is_ok());
         assert_eq!(source.get_pos().as_secs_f32(), 1.0);
     }
 
@@ -190,7 +190,7 @@ mod tests {
         source.next();
         assert_eq!(source.get_pos().as_secs_f32(), 1.0);
 
-        assert_eq!(source.try_seek(Duration::new(1, 0)).is_ok(), true);
+        assert!(source.try_seek(Duration::new(1, 0)).is_ok());
         assert_eq!(source.get_pos().as_secs_f32(), 1.0);
     }
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -3,7 +3,7 @@ use crate::decoder;
 use crate::mixer::{mixer, Mixer, MixerSource};
 use crate::sink::Sink;
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use cpal::{BufferSize, FrameCount, Sample, SampleFormat, StreamConfig, SupportedBufferSize};
+use cpal::{BufferSize, Sample, SampleFormat, StreamConfig};
 use std::io::{Read, Seek};
 use std::marker::Sync;
 use std::{error, fmt};
@@ -185,9 +185,8 @@ where
         self.config = OutputStreamConfig {
             channel_count: config.channels() as ChannelCount,
             sample_rate: config.sample_rate().0 as SampleRate,
-            // In case of supported range limit buffer size to avoid unexpectedly long playback delays.
-            buffer_size: clamp_supported_buffer_size(config.buffer_size(), 1024),
             sample_format: config.sample_format(),
+            ..Default::default()
         };
         self
     }
@@ -246,20 +245,6 @@ where
             }
             Err(err)
         })
-    }
-}
-
-fn clamp_supported_buffer_size(
-    buffer_size: &SupportedBufferSize,
-    preferred_size: FrameCount,
-) -> BufferSize {
-    match buffer_size {
-        SupportedBufferSize::Range { min, max } => {
-            let size = preferred_size.clamp(*min, *max);
-            assert!(size > 0, "selected buffer size is greater than zero");
-            BufferSize::Fixed(size)
-        }
-        SupportedBufferSize::Unknown => BufferSize::Default,
     }
 }
 

--- a/tests/seek.rs
+++ b/tests/seek.rs
@@ -156,7 +156,7 @@ fn seek_does_not_break_channel_order(
 
         source.try_seek(beep_start + offset).unwrap();
         let samples: Vec<_> = source.by_ref().take(100).collect();
-        let channel0 = 0 + channel_offset;
+        let channel0 = channel_offset;
         assert!(
             is_silent(&samples, source.channels(), channel0),
             "channel0 should be silent,


### PR DESCRIPTION
Current v0.20.1 uses the backend's default buffer size. `master` has changed this to prefer a period size of 1024. This cannot be expected to always work correctly, even if it's within the minimum / maximum reported supported frame count.

This reverts that back to the default, while still allowing the `with_buffer_size` builder method to override it.

Also includes some clippy fixes now that Rust 1.86 is out in a separate commit.

Fixes #724 