### PR TITLE
fix: minimal build with no default features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [ main, master ]
+    branches: [main, master]
 
 env:
   RUSTFLAGS: "-C debuginfo=0 -D warnings"
@@ -18,8 +18,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-latest, windows-latest, ubuntu-latest ]
-        toolchain: [ stable, beta, nightly ]
+        os: [macos-latest, windows-latest, ubuntu-latest]
+        toolchain: [stable, beta, nightly]
         include:
           - os: macos-latest
             MACOS: true
@@ -49,6 +49,5 @@ jobs:
       # `cargo test` does not check benchmarks and `cargo test --all-targets` excludes
       # documentation tests. Therefore, we need an additional docs test command here.
       - run: cargo test --doc
-      # Check minimal build. `tests/seek.rs` fails if there are no decoders at all,
-      # adding one to make the tests check pass.
-      - run: cargo check --tests --lib --no-default-features --features mp3
+      # Check minimal build.
+      - run: cargo check --no-default-features

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -780,7 +780,6 @@ impl fmt::Display for DecoderError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let text = match self {
             DecoderError::UnrecognizedFormat => "Unrecognized format",
-            #[cfg(feature = "symphonia")]
             DecoderError::IoError(msg) => &msg[..],
             #[cfg(feature = "symphonia")]
             DecoderError::DecodeError(msg) => msg,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,6 +165,13 @@ mod wav_output;
 
 pub mod buffer;
 pub mod conversions;
+#[cfg(any(
+    feature = "flac",
+    feature = "mp3",
+    feature = "symphonia",
+    feature = "vorbis",
+    feature = "wav",
+))]
 pub mod decoder;
 pub mod mixer;
 pub mod queue;
@@ -172,6 +179,13 @@ pub mod source;
 pub mod static_buffer;
 
 pub use crate::common::{ChannelCount, Sample, SampleRate};
+#[cfg(any(
+    feature = "flac",
+    feature = "mp3",
+    feature = "symphonia",
+    feature = "vorbis",
+    feature = "wav",
+))]
 pub use crate::decoder::Decoder;
 pub use crate::sink::Sink;
 pub use crate::source::Source;


### PR DESCRIPTION
This commit makes the decoder module and its exports conditional on the having at least one decoder format enabled. Also changes the CI to prevent regression.

Fixes #730 