### PR TITLE
Reorganize symphonia's feature flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,7 +1104,9 @@ dependencies = [
  "symphonia-codec-pcm",
  "symphonia-codec-vorbis",
  "symphonia-core",
+ "symphonia-format-caf",
  "symphonia-format-isomp4",
+ "symphonia-format-mkv",
  "symphonia-format-ogg",
  "symphonia-format-riff",
  "symphonia-metadata",
@@ -1200,12 +1202,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "symphonia-format-caf"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e43c99c696a388295a29fe71b133079f5d8b18041cf734c5459c35ad9097af50"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
 name = "symphonia-format-isomp4"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abfdf178d697e50ce1e5d9b982ba1b94c47218e03ec35022d9f0e071a16dc844"
 dependencies = [
  "encoding_rs",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-mkv"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bb43471a100f7882dc9937395bd5ebee8329298e766250b15b3875652fe3d6f"
+dependencies = [
+ "lazy_static",
  "log",
  "symphonia-core",
  "symphonia-metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,18 @@ noise = ["rand"]
 wasm-bindgen = ["cpal/wasm-bindgen"]
 cpal-shared-stdcxx = ["cpal/oboe-shared-stdcxx"]
 
-symphonia-all = ["symphonia/all"]
+symphonia-all = [
+    "symphonia-aiff",
+    "symphonia-caf",
+    "symphonia-isomp4",
+    "symphonia-mkv",
+    "symphonia-ogg",
+    "symphonia-wav",
+    "symphonia-flac",
+    "symphonia-aac",
+    "symphonia-alac",
+    "symphonia-mp3",
+]
 
 symphonia-aiff = ["symphonia/aiff", "symphonia/pcm"]
 symphonia-caf = ["symphonia/caf", "symphonia/pcm", "symphonia/adpcm", "symphonia/mpa", "symphonia/aac", "symphonia/alac"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,24 +42,18 @@ noise = ["rand"]
 wasm-bindgen = ["cpal/wasm-bindgen"]
 cpal-shared-stdcxx = ["cpal/oboe-shared-stdcxx"]
 
-symphonia-aac = ["symphonia/aac"]
-symphonia-all = [
-    "symphonia-aac",
-    "symphonia-flac",
-    "symphonia-isomp4",
-    "symphonia-mp3",
-    "symphonia-ogg",
-    "symphonia-vorbis",
-    "symphonia-wav",
-]
-symphonia-flac = ["symphonia/flac"]
-symphonia-isomp4 = ["symphonia/isomp4"]
-symphonia-mp3 = ["symphonia/mp3"]
-symphonia-ogg = ["symphonia/ogg"]
-symphonia-vorbis = ["symphonia/vorbis"]
-symphonia-wav = ["symphonia/wav", "symphonia/pcm", "symphonia/adpcm"]
-symphonia-alac = ["symphonia/isomp4", "symphonia/alac"]
+symphonia-all = ["symphonia/all"]
+
 symphonia-aiff = ["symphonia/aiff", "symphonia/pcm"]
+symphonia-caf = ["symphonia/caf", "symphonia/pcm", "symphonia/adpcm", "symphonia/mpa", "symphonia/aac", "symphonia/alac"]
+symphonia-isomp4 = ["symphonia/isomp4", "symphonia/mpa", "symphonia/aac", "symphonia/alac"]
+symphonia-mkv = ["symphonia/mkv", "symphonia/aac", "symphonia/mpa", "symphonia/vorbis", "symphonia/pcm", "symphonia/flac", "symphonia/alac"]
+symphonia-ogg = ["symphonia/ogg", "symphonia/vorbis", "symphonia/flac", "symphonia/pcm"]
+symphonia-wav = ["symphonia/wav", "symphonia/pcm", "symphonia/adpcm"]
+symphonia-flac = ["symphonia/flac"]
+symphonia-aac = ["symphonia/aac"]
+symphonia-alac = ["symphonia/isomp4", "symphonia/alac"]
+symphonia-mp3 = ["symphonia/mp3"]
 
 [dev-dependencies]
 quickcheck = "1"
@@ -87,7 +81,7 @@ harness = false
 
 [[example]]
 name = "music_m4a"
-required-features = ["symphonia-isomp4", "symphonia-aac"]
+required-features = ["symphonia-isomp4"]
 
 [[example]]
 name = "noise_generator"

--- a/src/decoder/builder.rs
+++ b/src/decoder/builder.rs
@@ -274,7 +274,7 @@ impl<R: Read + Seek + Send + Sync + 'static> DecoderBuilder<R> {
             Err(data) => data,
         };
 
-        #[cfg(all(feature = "vorbis", not(feature = "symphonia-vorbis")))]
+        #[cfg(all(feature = "vorbis", not(feature = "symphonia-ogg")))]
         let data = match vorbis::VorbisDecoder::new(data) {
             Ok(decoder) => return Ok((DecoderImpl::Vorbis(decoder), self.settings)),
             Err(data) => data,

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -74,7 +74,7 @@ mod read_seek_source;
 #[cfg(feature = "symphonia")]
 /// Symphonia decoders types
 pub mod symphonia;
-#[cfg(all(feature = "vorbis", not(feature = "symphonia-vorbis")))]
+#[cfg(all(feature = "vorbis", not(feature = "symphonia-ogg")))]
 mod vorbis;
 #[cfg(all(feature = "wav", not(feature = "symphonia-wav")))]
 mod wav;
@@ -111,7 +111,7 @@ pub struct LoopedDecoder<R: Read + Seek> {
 enum DecoderImpl<R: Read + Seek> {
     #[cfg(all(feature = "wav", not(feature = "symphonia-wav")))]
     Wav(wav::WavDecoder<R>),
-    #[cfg(all(feature = "vorbis", not(feature = "symphonia-vorbis")))]
+    #[cfg(all(feature = "vorbis", not(feature = "symphonia-ogg")))]
     Vorbis(vorbis::VorbisDecoder<R>),
     #[cfg(all(feature = "flac", not(feature = "symphonia-flac")))]
     Flac(flac::FlacDecoder<R>),
@@ -127,7 +127,7 @@ impl<R: Read + Seek> DecoderImpl<R> {
         match self {
             #[cfg(all(feature = "wav", not(feature = "symphonia-wav")))]
             DecoderImpl::Wav(source) => source.next(),
-            #[cfg(all(feature = "vorbis", not(feature = "symphonia-vorbis")))]
+            #[cfg(all(feature = "vorbis", not(feature = "symphonia-ogg")))]
             DecoderImpl::Vorbis(source) => source.next(),
             #[cfg(all(feature = "flac", not(feature = "symphonia-flac")))]
             DecoderImpl::Flac(source) => source.next(),
@@ -143,7 +143,7 @@ impl<R: Read + Seek> DecoderImpl<R> {
         match self {
             #[cfg(all(feature = "wav", not(feature = "symphonia-wav")))]
             DecoderImpl::Wav(source) => source.size_hint(),
-            #[cfg(all(feature = "vorbis", not(feature = "symphonia-vorbis")))]
+            #[cfg(all(feature = "vorbis", not(feature = "symphonia-ogg")))]
             DecoderImpl::Vorbis(source) => source.size_hint(),
             #[cfg(all(feature = "flac", not(feature = "symphonia-flac")))]
             DecoderImpl::Flac(source) => source.size_hint(),
@@ -159,7 +159,7 @@ impl<R: Read + Seek> DecoderImpl<R> {
         match self {
             #[cfg(all(feature = "wav", not(feature = "symphonia-wav")))]
             DecoderImpl::Wav(source) => source.current_span_len(),
-            #[cfg(all(feature = "vorbis", not(feature = "symphonia-vorbis")))]
+            #[cfg(all(feature = "vorbis", not(feature = "symphonia-ogg")))]
             DecoderImpl::Vorbis(source) => source.current_span_len(),
             #[cfg(all(feature = "flac", not(feature = "symphonia-flac")))]
             DecoderImpl::Flac(source) => source.current_span_len(),
@@ -175,7 +175,7 @@ impl<R: Read + Seek> DecoderImpl<R> {
         match self {
             #[cfg(all(feature = "wav", not(feature = "symphonia-wav")))]
             DecoderImpl::Wav(source) => source.channels(),
-            #[cfg(all(feature = "vorbis", not(feature = "symphonia-vorbis")))]
+            #[cfg(all(feature = "vorbis", not(feature = "symphonia-ogg")))]
             DecoderImpl::Vorbis(source) => source.channels(),
             #[cfg(all(feature = "flac", not(feature = "symphonia-flac")))]
             DecoderImpl::Flac(source) => source.channels(),
@@ -191,7 +191,7 @@ impl<R: Read + Seek> DecoderImpl<R> {
         match self {
             #[cfg(all(feature = "wav", not(feature = "symphonia-wav")))]
             DecoderImpl::Wav(source) => source.sample_rate(),
-            #[cfg(all(feature = "vorbis", not(feature = "symphonia-vorbis")))]
+            #[cfg(all(feature = "vorbis", not(feature = "symphonia-ogg")))]
             DecoderImpl::Vorbis(source) => source.sample_rate(),
             #[cfg(all(feature = "flac", not(feature = "symphonia-flac")))]
             DecoderImpl::Flac(source) => source.sample_rate(),
@@ -213,7 +213,7 @@ impl<R: Read + Seek> DecoderImpl<R> {
         match self {
             #[cfg(all(feature = "wav", not(feature = "symphonia-wav")))]
             DecoderImpl::Wav(source) => source.total_duration(),
-            #[cfg(all(feature = "vorbis", not(feature = "symphonia-vorbis")))]
+            #[cfg(all(feature = "vorbis", not(feature = "symphonia-ogg")))]
             DecoderImpl::Vorbis(source) => source.total_duration(),
             #[cfg(all(feature = "flac", not(feature = "symphonia-flac")))]
             DecoderImpl::Flac(source) => source.total_duration(),
@@ -229,7 +229,7 @@ impl<R: Read + Seek> DecoderImpl<R> {
         match self {
             #[cfg(all(feature = "wav", not(feature = "symphonia-wav")))]
             DecoderImpl::Wav(source) => source.try_seek(pos),
-            #[cfg(all(feature = "vorbis", not(feature = "symphonia-vorbis")))]
+            #[cfg(all(feature = "vorbis", not(feature = "symphonia-ogg")))]
             DecoderImpl::Vorbis(source) => source.try_seek(pos),
             #[cfg(all(feature = "flac", not(feature = "symphonia-flac")))]
             DecoderImpl::Flac(source) => source.try_seek(pos),
@@ -457,7 +457,7 @@ impl<R: Read + Seek + Send + Sync + 'static> Decoder<R> {
     /// let file = File::open("audio.ogg").unwrap();
     /// let decoder = Decoder::new_vorbis(file).unwrap();
     /// ```
-    #[cfg(any(feature = "vorbis", feature = "symphonia-vorbis"))]
+    #[cfg(any(feature = "vorbis", feature = "symphonia-ogg"))]
     pub fn new_vorbis(data: R) -> Result<Self, DecoderError> {
         DecoderBuilder::new()
             .with_data(data)
@@ -618,7 +618,7 @@ where
                     let sample = source.next();
                     (DecoderImpl::Wav(source), sample)
                 }
-                #[cfg(all(feature = "vorbis", not(feature = "symphonia-vorbis")))]
+                #[cfg(all(feature = "vorbis", not(feature = "symphonia-ogg")))]
                 DecoderImpl::Vorbis(source) => {
                     use lewton::inside_ogg::OggStreamReader;
                     let mut reader = source.into_inner().into_inner();

--- a/tests/mp4a_test.rs
+++ b/tests/mp4a_test.rs
@@ -1,4 +1,4 @@
-#![cfg(all(feature = "symphonia-aac", feature = "symphonia-isomp4"))]
+#![cfg(feature = "symphonia-isomp4")]
 
 #[test]
 fn test_mp4a_encodings() {

--- a/tests/seek.rs
+++ b/tests/seek.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 #[template]
 #[rstest]
 #[cfg_attr(
-    all(feature = "symphonia-ogg", feature = "symphonia-vorbis"),
+    all(feature = "symphonia-ogg"),
     case("ogg", true, "symphonia")
 )]
 #[cfg_attr(
@@ -40,7 +40,7 @@ fn all_decoders(
 #[template]
 #[rstest]
 #[cfg_attr(
-    all(feature = "symphonia-ogg", feature = "symphonia-vorbis"),
+    all(feature = "symphonia-ogg"),
     case("ogg", "symphonia")
 )]
 #[cfg_attr(

--- a/tests/total_duration.rs
+++ b/tests/total_duration.rs
@@ -10,7 +10,7 @@ use rstest_reuse::{self, *};
 #[template]
 #[rstest]
 #[cfg_attr(
-    feature = "symphonia-vorbis",
+    feature = "symphonia-ogg",
     case("ogg", Duration::from_secs_f64(69.328979591), "symphonia")
 )]
 #[cfg_attr(


### PR DESCRIPTION
Symphonia's feature flags are separated into format flags and codec flags.
Current symphonia flags wrapped in rodio is a mixture of these two types.

This PR reorganize these flags to format-based (extension-based like).
The flags are separated by format and each flags are contains possible codec flags in the format.

Detail

- symphonia-aac
  not changed
- symphonia-flac
  not changed
- symphonia-isomp4
  mpa(mp3+mp2+mp1), aac, alac flags are added.
- symphonia-mp3
  not changed
- symphonia-ogg
  vorbis, flac, pcm flags are added
- symphonia-vorbis
  deleted
  vorbis flag is codec name in symphonia
  Standalone vorbis format is not general as far as I could find.
- symphonia-wav
  not changed
- symphonia-alac
  not changed
- symphonia-aiff
  not changed

- symphonia-caf
  added
  Core Audio Format support
  With pcm, adpcm, mpa(mp3+mp2+mp1), aac, alac flags
- symphonia-mkv
  added
  mkv (actually mka) and webm support
  With aac, mpa, vorbis, pcm, flac, alac flags



Note:
Currently, symphonia is not support opus codec.
These formats can contain opus format.
isomp4, ogg, caf, mkv(webm)