### PR TITLE
fix non-symphonia builds

### DIFF
--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -780,7 +780,6 @@ impl fmt::Display for DecoderError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let text = match self {
             DecoderError::UnrecognizedFormat => "Unrecognized format",
-            #[cfg(feature = "symphonia")]
             DecoderError::IoError(msg) => &msg[..],
             #[cfg(feature = "symphonia")]
             DecoderError::DecodeError(msg) => msg,


### PR DESCRIPTION
Compiling with the following `Cargo.toml` fails:
```toml
rodio = { git = "https://github.com/RustAudio/rodio.git", default-features = false, features = [
  "vorbis",
  "noise",
  "playback",
] }
```

`cargo build` fails without the `"symphonia"` feature flag, because `try_seek` can create a `DecoderError::IoError`.

If different solution is preferred, let me know.