### PR TITLE
fix: remove decode error retry limit in SymphoniaDecoder

### DIFF
--- a/src/decoder/symphonia.rs
+++ b/src/decoder/symphonia.rs
@@ -20,11 +20,6 @@ use crate::{
     source, Source,
 };
 
-// Decoder errors are not considered fatal.
-// The correct action is to just get a new packet and try again.
-// But a decode error in more than 3 consecutive packets is fatal.
-const MAX_DECODE_RETRIES: usize = 3;
-
 pub(crate) struct SymphoniaDecoder {
     decoder: Box<dyn Decoder>,
     current_span_offset: usize,
@@ -115,7 +110,6 @@ impl SymphoniaDecoder {
             .zip(stream.codec_params.n_frames)
             .map(|(base, spans)| base.calc_time(spans).into());
 
-        let mut decode_errors: usize = 0;
         let decoded = loop {
             let current_span = match probed.format.next_packet() {
                 Ok(packet) => packet,
@@ -131,14 +125,7 @@ impl SymphoniaDecoder {
             match decoder.decode(&current_span) {
                 Ok(decoded) => break decoded,
                 Err(e) => match e {
-                    Error::DecodeError(_) => {
-                        decode_errors += 1;
-                        if decode_errors > MAX_DECODE_RETRIES {
-                            return Err(e);
-                        } else {
-                            continue;
-                        }
-                    }
+                    Error::DecodeError(_) => continue,
                     _ => return Err(e),
                 },
             }
@@ -309,19 +296,12 @@ impl Iterator for SymphoniaDecoder {
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.current_span_offset >= self.buffer.len() {
-            let mut decode_errors = 0;
             let decoded = loop {
                 let packet = self.format.next_packet().ok()?;
                 let decoded = match self.decoder.decode(&packet) {
                     Ok(decoded) => decoded,
-                    Err(_) => {
-                        decode_errors += 1;
-                        if decode_errors > MAX_DECODE_RETRIES {
-                            return None;
-                        } else {
-                            continue;
-                        }
-                    }
+                    Err(Error::DecodeError(_)) => continue,
+                    Err(_) => return None,
                 };
 
                 // Loop until we get a packet with audio frames. This is necessary because some


### PR DESCRIPTION
This PR changes the Symphonia decoder to just keep on decoding a file, no matter the amount of malformed packets. Previously, it would fail after 3 attempts. This could unexpectedly stop playback.

I don't see any particular danger in continuing endlessly, as at some point it will just hit end of file and stop anyway.

Fixes #735