### PR TITLE
a stream is now seekable if bytes_len is known

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ hound = { version = "3.3.1", optional = true }
 lewton = { version = "0.10", optional = true }
 minimp3_fixed = { version = "0.5.4", optional = true }
 symphonia = { version = "0.5.4", optional = true, default-features = false }
+# symphonia = { git = "https://github.com/roderickvd/Symphonia", branch = "perf/faster-seeking", optional = true }
 crossbeam-channel = { version = "0.5.15", optional = true }
 
 rand = { version = "0.9.0", features = ["small_rng", "os_rng"], optional = true }

--- a/src/decoder/builder.rs
+++ b/src/decoder/builder.rs
@@ -74,9 +74,6 @@ pub struct Settings {
     /// An MIME type hint for the decoder about the format of the stream.
     /// When known, this can help the decoder to select the correct demuxer.
     pub(crate) mime_type: Option<String>,
-
-    /// Whether the decoder should report as seekable.
-    pub(crate) is_seekable: bool,
 }
 
 impl Default for Settings {
@@ -87,7 +84,6 @@ impl Default for Settings {
             gapless: true,
             hint: None,
             mime_type: None,
-            is_seekable: false,
         }
     }
 }
@@ -225,37 +221,6 @@ impl<R: Read + Seek + Send + Sync + 'static> DecoderBuilder<R> {
     /// Common values are "audio/mpeg", "audio/vnd.wav", "audio/flac", "audio/ogg", etc.
     pub fn with_mime_type(mut self, mime_type: &str) -> Self {
         self.settings.mime_type = Some(mime_type.to_string());
-        self
-    }
-
-    /// Configure whether the decoder should report as seekable.
-    ///
-    /// For reliable seeking behavior, `byte_len` should be set either from file metadata
-    /// or by seeking to the end of the stream. While seeking may work without `byte_len`
-    /// for some formats, it is not guaranteed.
-    ///
-    /// # Examples
-    /// ```no_run
-    /// use std::fs::File;
-    /// use rodio::Decoder;
-    ///
-    /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let file = File::open("audio.mp3")?;
-    ///     let len = file.metadata()?.len();
-    ///
-    ///     // Recommended: Set both byte_len and seekable
-    ///     let decoder = Decoder::builder()
-    ///         .with_data(file)
-    ///         .with_byte_len(len)
-    ///         .with_seekable(true)
-    ///         .build()?;
-    ///
-    ///     // Use the decoder...
-    ///     Ok(())
-    /// }
-    /// ```
-    pub fn with_seekable(mut self, is_seekable: bool) -> Self {
-        self.settings.is_seekable = is_seekable;
         self
     }
 

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -25,7 +25,6 @@
 //! let decoder = Decoder::builder()
 //!     .with_data(file)
 //!     .with_byte_len(len)      // Enable seeking and duration calculation
-//!     .with_seekable(true)     // Enable seeking operations
 //!     .with_hint("mp3")        // Optional format hint
 //!     .with_gapless(true)      // Enable gapless playback
 //!     .build()
@@ -276,7 +275,6 @@ impl TryFrom<std::fs::File> for Decoder<BufReader<std::fs::File>> {
         Self::builder()
             .with_data(BufReader::new(file))
             .with_byte_len(len)
-            .with_seekable(true)
             .build()
     }
 }

--- a/src/decoder/read_seek_source.rs
+++ b/src/decoder/read_seek_source.rs
@@ -14,8 +14,6 @@ pub struct ReadSeekSource<T: Read + Seek + Send + Sync> {
     /// Optional length of the media source in bytes.
     /// When known, this can help with seeking and duration calculations.
     byte_len: Option<u64>,
-    /// Whether this media source reports as seekable.
-    is_seekable: bool,
 }
 
 impl<T: Read + Seek + Send + Sync> ReadSeekSource<T> {
@@ -29,16 +27,15 @@ impl<T: Read + Seek + Send + Sync> ReadSeekSource<T> {
         ReadSeekSource {
             inner,
             byte_len: settings.byte_len,
-            is_seekable: settings.is_seekable,
         }
     }
 }
 
 impl<T: Read + Seek + Send + Sync> MediaSource for ReadSeekSource<T> {
-    /// Returns whether this media source reports as seekable.
+    /// symphonia sources are only seekable if `byte_len.is_some()`
     #[inline]
     fn is_seekable(&self) -> bool {
-        self.is_seekable
+        self.byte_len.is_some()
     }
 
     /// Returns the total length of the media source in bytes, if known.

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -614,6 +614,8 @@ pub enum SeekError {
         /// The source that did not support seek
         underlying_source: &'static str,
     },
+    /// The decoder needs to know the length of the underlying byte stream
+    NeedsBytesLen,
     #[cfg(feature = "symphonia")]
     /// The symphonia decoder ran into an issue
     SymphoniaDecoder(crate::decoder::symphonia::SeekError),
@@ -640,6 +642,7 @@ impl fmt::Display for SeekError {
             #[cfg(feature = "wav")]
             SeekError::HoundDecoder(err) => write!(f, "Error seeking in wav source: {}", err),
             SeekError::Other(_) => write!(f, "An error occurred"),
+            SeekError::NeedsBytesLen => write!(f, "The decoder needs to know the length of the file/byte stream to be able to seek. You can set that by using the `DecoderBuilder` or creating a decoder using `Decoder::try_from(some_file)`"),
         }
     }
 }
@@ -651,6 +654,7 @@ impl std::error::Error for SeekError {
             SeekError::SymphoniaDecoder(err) => Some(err),
             #[cfg(feature = "wav")]
             SeekError::HoundDecoder(err) => Some(err),
+            SeekError::NeedsBytesLen => None,
             SeekError::Other(err) => Some(err.as_ref()),
         }
     }
@@ -669,6 +673,7 @@ impl SeekError {
     pub fn source_intact(&self) -> bool {
         match self {
             SeekError::NotSupported { .. } => true,
+            SeekError::NeedsBytesLen => true,
             #[cfg(feature = "symphonia")]
             SeekError::SymphoniaDecoder(_) => false,
             #[cfg(feature = "wav")]

--- a/tests/total_duration.rs
+++ b/tests/total_duration.rs
@@ -55,7 +55,6 @@ fn get_music(format: &str) -> Decoder<impl Read + Seek> {
     rodio::Decoder::builder()
         .with_data(file)
         .with_byte_len(len)
-        .with_seekable(true)
         .with_gapless(false)
         .build()
         .unwrap()


### PR DESCRIPTION
Unfortunatly this reviels a bug(?) in symphonia regarding format recognition. M4a is no longer openable with symphonia. To resolve that we can set `seekable` to true without having `bytes_len` even though that is breaking an invarint. (seekable can not be true if bytes_len is unknown).