### PR TITLE
Improve seeking behavior and error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,22 @@ name = "custom_config"
 required-features = ["playback", "wav"]
 
 [[example]]
+name = "distortion"
+required-features = ["playback"]
+
+[[example]]
+name = "distortion_mp3"
+required-features = ["playback", "mp3"]
+
+[[example]]
+name = "distortion_wav"
+required-features = ["playback", "wav"]
+
+[[example]]
+name = "distortion_wav_alternate"
+required-features = ["playback", "wav"]
+
+[[example]]
 name = "error_callback"
 required-features = ["playback"]
 
@@ -123,6 +139,10 @@ required-features = ["playback", "wav"]
 [[example]]
 name = "mix_multiple_sources"
 required-features = ["playback"]
+
+[[example]]
+name = "music_flac"
+required-features = ["playback", "flac"]
 
 [[example]]
 name = "music_m4a"

--- a/src/decoder/builder.rs
+++ b/src/decoder/builder.rs
@@ -165,6 +165,8 @@ impl<R: Read + Seek + Send + Sync + 'static> DecoderBuilder<R> {
     /// - Reliable seeking operations
     /// - Duration calculations in formats that lack timing information (e.g. MP3, Vorbis)
     ///
+    /// Note that this also sets `is_seekable` to `true`.
+    ///
     /// The byte length should typically be obtained from file metadata:
     /// ```no_run
     /// use std::fs::File;
@@ -189,10 +191,11 @@ impl<R: Read + Seek + Send + Sync + 'static> DecoderBuilder<R> {
     /// incorrect duration calculations and seeking errors.
     pub fn with_byte_len(mut self, byte_len: u64) -> Self {
         self.settings.byte_len = Some(byte_len);
+        self.settings.is_seekable = true;
         self
     }
 
-    /// Enables or disables coarse seeking.
+    /// Enables or disables coarse seeking. This is disabled by default.
     ///
     /// This needs `byte_len` to be set. Coarse seeking is faster but less accurate:
     /// it may seek to a position slightly before or after the requested one,
@@ -202,7 +205,7 @@ impl<R: Read + Seek + Send + Sync + 'static> DecoderBuilder<R> {
         self
     }
 
-    /// Enables or disables gapless playback.
+    /// Enables or disables gapless playback. This is enabled by default.
     ///
     /// When enabled, removes silence between tracks for formats that support it.
     pub fn with_gapless(mut self, gapless: bool) -> Self {
@@ -228,7 +231,8 @@ impl<R: Read + Seek + Send + Sync + 'static> DecoderBuilder<R> {
         self
     }
 
-    /// Configure whether the decoder should report as seekable.
+    /// Configure whether the data supports random access seeking. Without this,
+    /// only forward seeking may work.
     ///
     /// For reliable seeking behavior, `byte_len` should be set either from file metadata
     /// or by seeking to the end of the stream. While seeking may work without `byte_len`

--- a/tests/mp4a_test.rs
+++ b/tests/mp4a_test.rs
@@ -8,6 +8,7 @@ fn test_mp4a_encodings() {
     // Licensed under Creative Commons: By Attribution 3.0
     // http://creativecommons.org/licenses/by/3.0/
     let file = std::fs::File::open("assets/monkeys.mp4a").unwrap();
-    let mut decoder = rodio::Decoder::try_from(file).unwrap();
+    // Open with `new` instead of `try_from` to ensure it works even without is_seekable
+    let mut decoder = rodio::Decoder::new(file).unwrap();
     assert!(decoder.any(|x| x != 0.0)); // Assert not all zeros
 }

--- a/tests/seek.rs
+++ b/tests/seek.rs
@@ -1,6 +1,8 @@
 #![allow(dead_code)]
 #![allow(unused_imports)]
 
+#[cfg(feature = "symphonia-mp3")]
+use rodio::{decoder::symphonia, source::SeekError};
 use rodio::{ChannelCount, Decoder, Source};
 use rstest::rstest;
 use rstest_reuse::{self, *};
@@ -239,6 +241,7 @@ fn seek_does_not_break_channel_order(
     }
 }
 
+#[cfg(feature = "symphonia-mp3")]
 #[test]
 fn random_access_seeks() {
     // Decoder::new::<File> does *not* set byte_len and is_seekable
@@ -249,7 +252,12 @@ fn random_access_seeks() {
         "forward seek should work without byte_len"
     );
     assert!(
-        decoder.try_seek(Duration::from_secs(1)).is_err(),
+        matches!(
+            decoder.try_seek(Duration::from_secs(1)),
+            Err(SeekError::SymphoniaDecoder(
+                symphonia::SeekError::RandomAccessNotSupported,
+            ))
+        ),
         "backward seek should fail without byte_len"
     );
 

--- a/tests/seek.rs
+++ b/tests/seek.rs
@@ -273,10 +273,7 @@ fn random_access_seeks() {
     );
 }
 
-fn second_channel_beep_range<R: rodio::Source>(source: &mut R) -> std::ops::Range<usize>
-where
-    R: Iterator<Item = f32>,
-{
+fn second_channel_beep_range<R: rodio::Source>(source: &mut R) -> std::ops::Range<usize> {
     let channels = source.channels() as usize;
     let samples: Vec<f32> = source.by_ref().collect();
 


### PR DESCRIPTION
I think I've found the compromise I like best:

- Automatically enable `is_seekable` when `byte_len` is set
- Add helpful error message for random access seeking without `byte_len`
- Clarify documentation for builder methods with default states
- Test forward-only vs. random access seeking scenarios
- Ensure MP4s open without depending on `is_seekable`

I also tried setting `is_seekable` to `true` by default, but that only increases random access seeking weirdness without `byte_len` set. Which is why I think this is the sweet spot of compromises.

Mostly fixes #740
Supersedes #744

I say "mostly" fixes because `symphonia-isomp4` can still report it's successfully seeked backwards, when in fact it hasn't without `byte_len` set. In Symphonia v0.5 the MP4 support is working, but with a number of bugs that are targeted for some v0.6 release. In the meantime, I propose we regard MP4 as a "second tier" target and we don't go too far out of a way to fix upstream issues here.