### PR TITLE
Only close cpal::Stream once all mixers/sinks drop

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -12,7 +12,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let beep1 = {
         // Play a WAV file.
         let file = std::fs::File::open("assets/beep.wav")?;
-        let sink = rodio::play(mixer, BufReader::new(file))?;
+        let sink = rodio::play(mixer.clone(), BufReader::new(file))?;
         sink.set_volume(0.2);
         sink
     };

--- a/examples/output_ending.rs
+++ b/examples/output_ending.rs
@@ -1,0 +1,21 @@
+use std::error::Error;
+use std::thread::sleep;
+use std::time::Duration;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let stream_handle = rodio::OutputStreamBuilder::open_default_stream()?;
+    let sink = rodio::Sink::connect_new(stream_handle.mixer());
+    drop(stream_handle); // audio output not yet closed since sink is still alive
+
+    let file = std::fs::File::open("assets/music.flac")?;
+    sink.append(rodio::Decoder::try_from(file)?);
+    sleep(Duration::from_secs(2));
+
+    drop(sink);
+    println!(
+        "Audio output was closed because the last \
+        reference to it (Sink) was dropped"
+    );
+    sleep(Duration::from_secs(2));
+    Ok(())
+}

--- a/src/spatial_sink.rs
+++ b/src/spatial_sink.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 
 use dasp_sample::FromSample;
 
-use crate::mixer::Mixer;
 use crate::source::{SeekError, Spatial};
+use crate::stream::OutputMixer;
 use crate::{Sink, Source};
 
 /// A sink that allows changing the position of the source and the listeners
@@ -25,7 +25,7 @@ struct SoundPositions {
 impl SpatialSink {
     /// Builds a new `SpatialSink`.
     pub fn connect_new(
-        mixer: &Mixer,
+        mixer: OutputMixer,
         emitter_position: [f32; 3],
         left_ear: [f32; 3],
         right_ear: [f32; 3],


### PR DESCRIPTION
**This is an alternative to #746**

This resolves a common footgun in rodio, that is: accidentily dropping the stream handle causing all audio to stop. This can be hard to debug.

To solve that we make `cpal::Stream` undroppable by the user. Instead we drop it for the user once all mixers/sinks that are connected to the `cpal::Stream` are dropped. The only way to make `cpal::Stream` undroppable is to hold it in a sleeping thread. This is because `cpal::Stream` is neither send nor sync. If it where we could just store it on the heap in an `Arc` shared by all sinks and streams.

The `cpal::Stream` is now created on a seperate thread. After creation that thread sleeps until the OutputStreamTracker reaches a count of zero. The OutputStreamTracker is shared between all mixers and sinks that are connected to a `cpal::Stream`.

This design is not perfect, its still quite easy to drop the `cpal::Stream`. Simply take a normal mixer (not the `OutputMixer` introduced by this PR) and connect it to an `OutputMixer`. Then use the normal mixer instead of the `OutputMixer` and drop the `OutputMixer`.

An alternative, far simpler solution could be a drop bomb