### PR TITLE
Allow accessing chosen OutputStreamConfig from OutputStream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Using `Decoder::TryFrom` for `File` now automatically wraps in `BufReader` and sets `byte_len`.
   `TryFrom<Cursor<T>>` and `TryFrom<BufReader>` are also supported.
 - Added `Source::distortion()` method to control distortion effect by `gain` and `threshold`.
+- Added `OutputStream::config()` method to access an `OutputStream`'s `OutputStreamConfig` once
+  an `OutputStream` has been built.
+- Added `OutputStreamConfig::channel_count()`, `OutputStreamConfig::sample_rate()`,
+  `OutputStreamConfig::buffer_size()` and `OutputStreamConfig::sample_format()` getters to access
+  an `OutputStreamConfig`'s channel count, sample rate, buffer size and sample format values.
 
 ### Changed
 - Breaking: `OutputStreamBuilder` should now be used to initialize an audio output stream.
@@ -40,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Breaking: `ReadSeekSource::new()` now takes `Settings`.
 - Breaking: Sources now use `f32` samples. To convert to and from other types of samples use
             functions from `dasp_sample` crate. For example `DaspSample::from_sample(sample)`.
+- `OutputStreamConfig` is now public.
 
 ### Fixed
 - `ChannelVolume` no longer clips/overflows when converting from many channels to

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -448,7 +448,7 @@ impl OutputStream {
             Ok(Self {
                 _stream: stream,
                 mixer: controller,
-                config: config.clone(),
+                config: *config,
             })
         })
     }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -32,11 +32,13 @@ impl OutputStream {
         &self.mixer
     }
 
+    /// Access the output stream's config.
     pub fn config(&self) -> &OutputStreamConfig {
         &self.config
     }
 }
 
+/// Describes the output stream's configuration
 #[derive(Copy, Clone, Debug)]
 pub struct OutputStreamConfig {
     channel_count: ChannelCount,
@@ -57,18 +59,22 @@ impl Default for OutputStreamConfig {
 }
 
 impl OutputStreamConfig {
+    /// Access the output stream config's channel count.
     pub fn channel_count(&self) -> ChannelCount {
         self.channel_count
     }
 
+    /// Access the output stream config's sample rate.
     pub fn sample_rate(&self) -> SampleRate {
         self.sample_rate
     }
 
+    /// Access the output stream config's buffer size.
     pub fn buffer_size(&self) -> &BufferSize {
         &self.buffer_size
     }
 
+    /// Access the output stream config's sample format.
     pub fn sample_format(&self) -> SampleFormat {
         self.sample_format
     }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -21,6 +21,7 @@ const HZ_44100: SampleRate = 44_100;
 /// Use `mixer()` method to control output.
 /// If this is dropped, playback will end, and the associated output stream will be disposed.
 pub struct OutputStream {
+    config: OutputStreamConfig,
     mixer: Mixer,
     _stream: cpal::Stream,
 }
@@ -30,10 +31,14 @@ impl OutputStream {
     pub fn mixer(&self) -> &Mixer {
         &self.mixer
     }
+
+    pub fn config(&self) -> &OutputStreamConfig {
+        &self.config
+    }
 }
 
 #[derive(Copy, Clone, Debug)]
-struct OutputStreamConfig {
+pub struct OutputStreamConfig {
     channel_count: ChannelCount,
     sample_rate: SampleRate,
     buffer_size: BufferSize,
@@ -48,6 +53,24 @@ impl Default for OutputStreamConfig {
             buffer_size: BufferSize::Default,
             sample_format: SampleFormat::F32,
         }
+    }
+}
+
+impl OutputStreamConfig {
+    pub fn channel_count(&self) -> ChannelCount {
+        self.channel_count
+    }
+
+    pub fn sample_rate(&self) -> SampleRate {
+        self.sample_rate
+    }
+
+    pub fn buffer_size(&self) -> &BufferSize {
+        &self.buffer_size
+    }
+
+    pub fn sample_format(&self) -> SampleFormat {
+        self.sample_format
     }
 }
 
@@ -419,6 +442,7 @@ impl OutputStream {
             Ok(Self {
                 _stream: stream,
                 mixer: controller,
+                config: config.clone(),
             })
         })
     }


### PR DESCRIPTION
When opening an OutputStream there is no way to access the configuration associated with that Stream once it has been created.

The configuration ultimately used by the OutputStream may be different to what has been supplied (in the case when using  `OutputStreamBuilder::open_stream_or_fallback`).

This allows the user to access key configuration attributes that are associated with the OutputStream after build.

We specifically use this for accessing the SampleRate and BufferSize of the OutputStream at runtime.