### PR TITLE
feat: add compressor effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Using `Decoder::TryFrom` for `File` now automatically wraps in `BufReader` and sets `byte_len`.
   `TryFrom<Cursor<T>>` and `TryFrom<BufReader>` are also supported.
 - Added `Source::distortion()` method to control distortion effect by `gain` and `threshold`.
+- Added `Source::compressor()` method for dynamic range compression with threshold, ratio, attack, and release parameters.
 
 ### Changed
 - Breaking: `OutputStreamBuilder` should now be used to initialize an audio output stream.

--- a/examples/compressor.rs
+++ b/examples/compressor.rs
@@ -1,0 +1,25 @@
+use rodio::source::{SineWave, Source};
+use std::error::Error;
+use std::thread;
+use std::time::Duration;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // Open the default output stream and get the mixer
+    let stream_handle = rodio::OutputStreamBuilder::open_default_stream()?;
+    let mixer = stream_handle.mixer();
+
+    // Create a sine wave source and apply compressor
+    let compressed = SineWave::new(440.0)
+        .amplify(0.5)
+        .compressor(0.2, 4.0, 0.01, 0.1)
+        .take_duration(Duration::from_secs(3));
+
+    // Play the compressed sound
+    mixer.add(compressed);
+
+    println!("Playing compressed sine wave for 3 seconds...");
+    thread::sleep(Duration::from_secs(3));
+    println!("Done.");
+
+    Ok(())
+}

--- a/examples/compressor_wav.rs
+++ b/examples/compressor_wav.rs
@@ -1,0 +1,18 @@
+use rodio::Source;
+use std::error::Error;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let stream_handle = rodio::OutputStreamBuilder::open_default_stream()?;
+    let sink = rodio::Sink::connect_new(stream_handle.mixer());
+
+    let file = std::fs::File::open("assets/music.wav")?;
+    let source = rodio::Decoder::try_from(file)?.compressor(0.05, 10.0, 0.001, 0.05);
+
+    sink.append(source);
+
+    println!("Playing music.wav with compressor until finished...");
+    sink.sleep_until_end();
+    println!("Done.");
+
+    Ok(())
+}

--- a/examples/compressor_wav_alternate.rs
+++ b/examples/compressor_wav_alternate.rs
@@ -1,0 +1,56 @@
+use rodio::Source;
+use std::error::Error;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+use std::thread;
+use std::time::Duration;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let stream_handle = rodio::OutputStreamBuilder::open_default_stream()?;
+    let sink = rodio::Sink::connect_new(stream_handle.mixer());
+
+    let file = std::fs::File::open("assets/music.wav")?;
+    let source = rodio::Decoder::try_from(file)?;
+
+    // Shared flag to enable/disable compressor
+    let compressor_enabled = Arc::new(AtomicBool::new(true));
+    let compressor_enabled_clone = compressor_enabled.clone();
+
+    // Apply compressor and alternate the effect during playback
+    let compressed = source.compressor(0.01, 20.0, 0.0005, 0.02).periodic_access(
+        Duration::from_millis(250),
+        move |src| {
+            let enable = compressor_enabled_clone.load(Ordering::Relaxed);
+            if enable {
+                src.set_threshold(0.01);
+                src.set_ratio(20.0);
+                src.set_attack(0.0005);
+                src.set_release(0.02);
+            } else {
+                src.set_threshold(1.0); // effectively disables compression
+                src.set_ratio(1.0);
+                src.set_attack(0.0005);
+                src.set_release(0.02);
+            }
+        },
+    );
+
+    sink.append(compressed);
+
+    println!("Playing music.wav with alternating compressor effect...");
+    // Alternate the compressor effect every two seconds for 10 cycles
+    for _ in 0..10 {
+        thread::sleep(Duration::from_secs(2));
+        let prev = compressor_enabled.load(Ordering::Relaxed);
+        compressor_enabled.store(!prev, Ordering::Relaxed);
+        println!("Compressor {}", if !prev { "ON" } else { "OFF" });
+    }
+
+    // Wait for playback to finish
+    sink.sleep_until_end();
+    println!("Done.");
+
+    Ok(())
+}

--- a/src/source/compressor.rs
+++ b/src/source/compressor.rs
@@ -1,0 +1,153 @@
+use std::time::Duration;
+
+use super::SeekError;
+use crate::common::{ChannelCount, SampleRate};
+use crate::Source;
+
+/// Internal function that builds a `Compressor` object.
+pub(crate) fn compressor<I>(
+    input: I,
+    threshold: f32,
+    ratio: f32,
+    attack: f32,
+    release: f32,
+) -> Compressor<I>
+where
+    I: Source,
+{
+    Compressor {
+        input,
+        threshold,
+        ratio,
+        attack,
+        release,
+        gain: 1.0,
+        envelope: 0.0,
+    }
+}
+
+/// Filter that applies a compressor effect to the source.
+#[derive(Clone, Debug)]
+pub struct Compressor<I> {
+    input: I,
+    threshold: f32,
+    ratio: f32,
+    attack: f32,
+    release: f32,
+    gain: f32,
+    envelope: f32,
+}
+
+impl<I> Compressor<I> {
+    /// Set the compression threshold.
+    #[inline]
+    pub fn set_threshold(&mut self, threshold: f32) {
+        self.threshold = threshold;
+    }
+
+    /// Set the compression ratio.
+    #[inline]
+    pub fn set_ratio(&mut self, ratio: f32) {
+        self.ratio = ratio;
+    }
+
+    /// Set the attack time (seconds).
+    #[inline]
+    pub fn set_attack(&mut self, attack: f32) {
+        self.attack = attack;
+    }
+
+    /// Set the release time (seconds).
+    #[inline]
+    pub fn set_release(&mut self, release: f32) {
+        self.release = release;
+    }
+
+    /// Returns a reference to the inner source.
+    #[inline]
+    pub fn inner(&self) -> &I {
+        &self.input
+    }
+
+    /// Returns a mutable reference to the inner source.
+    #[inline]
+    pub fn inner_mut(&mut self) -> &mut I {
+        &mut self.input
+    }
+
+    /// Returns the inner source.
+    #[inline]
+    pub fn into_inner(self) -> I {
+        self.input
+    }
+}
+
+impl<I> Iterator for Compressor<I>
+where
+    I: Source,
+{
+    type Item = I::Item;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let sample = self.input.next()?;
+        let abs_sample = sample.abs();
+
+        // Envelope follower (simple peak detector)
+        let sr = self.input.sample_rate() as f32;
+        let attack_coeff = f32::exp(-1.0 / (self.attack * sr).max(1.0));
+        let release_coeff = f32::exp(-1.0 / (self.release * sr).max(1.0));
+        if abs_sample > self.envelope {
+            self.envelope = attack_coeff * (self.envelope - abs_sample) + abs_sample;
+        } else {
+            self.envelope = release_coeff * (self.envelope - abs_sample) + abs_sample;
+        }
+
+        // Compute gain reduction
+        let mut gain = 1.0;
+        if self.envelope > self.threshold {
+            let over = self.envelope / self.threshold;
+            gain = (1.0 + (over - 1.0) / self.ratio).recip();
+        }
+        self.gain = gain;
+
+        Some(sample * self.gain)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.input.size_hint()
+    }
+}
+
+impl<I> ExactSizeIterator for Compressor<I> where I: Source + ExactSizeIterator {}
+
+impl<I> Source for Compressor<I>
+where
+    I: Source,
+{
+    #[inline]
+    fn current_span_len(&self) -> Option<usize> {
+        self.input.current_span_len()
+    }
+
+    #[inline]
+    fn channels(&self) -> ChannelCount {
+        self.input.channels()
+    }
+
+    #[inline]
+    fn sample_rate(&self) -> SampleRate {
+        self.input.sample_rate()
+    }
+
+    #[inline]
+    fn total_duration(&self) -> Option<Duration> {
+        self.input.total_duration()
+    }
+
+    #[inline]
+    fn try_seek(&mut self, pos: Duration) -> Result<(), SeekError> {
+        self.input.try_seek(pos)
+    }
+}

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -14,6 +14,7 @@ pub use self::blt::BltFilter;
 pub use self::buffered::Buffered;
 pub use self::channel_volume::ChannelVolume;
 pub use self::chirp::{chirp, Chirp};
+pub use self::compressor::Compressor;
 pub use self::crossfade::Crossfade;
 pub use self::delay::Delay;
 pub use self::distortion::Distortion;
@@ -50,6 +51,7 @@ mod blt;
 mod buffered;
 mod channel_volume;
 mod chirp;
+mod compressor;
 mod crossfade;
 mod delay;
 mod distortion;
@@ -583,6 +585,15 @@ pub trait Source: Iterator<Item = Sample> {
         Self: Sized,
     {
         distortion::distortion(self, gain, threshold)
+    }
+
+    /// Applies a compressor effect to the sound.
+    #[inline]
+    fn compressor(self, threshold: f32, ratio: f32, attack: f32, release: f32) -> Compressor<Self>
+    where
+        Self: Sized,
+    {
+        compressor::compressor(self, threshold, ratio, attack, release)
     }
 
     // There is no `can_seek()` method as it is impossible to use correctly. Between


### PR DESCRIPTION
Fixes #748 

Add a dynamic range compressor. 

Run the examples:

```bash
$ cargo run --example compressor
$ cargo run --example compressor_wav
$ cargo run --example compressor_wav_alternate
```