### PR TITLE
fix: AGC set_enabled to use atomic flag with experimental feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,8 @@ jobs:
         if: matrix.toolchain == 'stable' && matrix.os == 'ubuntu-latest'
 
       - run: cargo test --all-targets
+      - run: cargo test --all-targets --all-features
       - run: cargo test --lib --bins --tests --benches --features=experimental
-      - run: cargo test --all-targets --features=symphonia-all,wav_output
       # `cargo test` does not check benchmarks and `cargo test --all-targets` excludes
       # documentation tests. Therefore, we need an additional docs test command here.
       - run: cargo test --doc

--- a/src/source/agc.rs
+++ b/src/source/agc.rs
@@ -299,14 +299,20 @@ where
         Arc::clone(&self.is_enabled)
     }
 
-    #[cfg(not(feature = "experimental"))]
     /// Enable or disable AGC processing.
     ///
     /// Use this to enable or disable AGC processing.
     /// Useful for comparing processed and unprocessed audio or for disabling/enabling AGC.
     #[inline]
     pub fn set_enabled(&mut self, enabled: bool) {
-        self.is_enabled = enabled;
+        #[cfg(feature = "experimental")]
+        {
+            self.is_enabled.store(enabled, Ordering::Relaxed);
+        }
+        #[cfg(not(feature = "experimental"))]
+        {
+            self.is_enabled = enabled;
+        }
     }
 
     /// Updates the peak level with an adaptive attack coefficient

--- a/src/source/noise.rs
+++ b/src/source/noise.rs
@@ -920,9 +920,9 @@ mod tests {
     fn test_brownian_noise_properties() {
         // Test that brownian noise doesn't accumulate DC indefinitely
         let mut generator = Brownian::new(TEST_SAMPLE_RATE);
-        let samples: Vec<f32> = (0..TEST_SAMPLE_RATE)
+        let samples: Vec<f32> = (0..TEST_SAMPLE_RATE * 10)
             .map(|_| generator.next().unwrap())
-            .collect(); // 1 second
+            .collect(); // 10 seconds
 
         let average = samples.iter().sum::<f32>() / samples.len() as f32;
         // Average should be close to zero due to leak factor


### PR DESCRIPTION
Caught this oversight while running the test suite manually. Updated to CI to prevent regressions.