### PR TITLE
docs: document optional features on docs.rs with doc(cfg) attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Migration guides for incompatible versions can be found in `UPGRADE.md` file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- docs.rs will now document all features, including those that are optional.
+
 ## Version [0.21.1] (2025-07-14)
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ lewton = ["dep:lewton"]         # Ogg Vorbis
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 cpal = { version = "0.16", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,6 +174,7 @@ mod spatial_sink;
 #[cfg(feature = "playback")]
 pub mod stream;
 #[cfg(feature = "wav_output")]
+#[cfg_attr(docsrs, doc(cfg(feature = "wav_output")))]
 mod wav_output;
 
 pub mod buffer;
@@ -193,4 +194,5 @@ pub use crate::spatial_sink::SpatialSink;
 #[cfg(feature = "playback")]
 pub use crate::stream::{play, OutputStream, OutputStreamBuilder, PlayError, StreamError};
 #[cfg(feature = "wav_output")]
+#[cfg_attr(docsrs, doc(cfg(feature = "wav_output")))]
 pub use crate::wav_output::output_to_wav;

--- a/src/source/agc.rs
+++ b/src/source/agc.rs
@@ -245,6 +245,7 @@ where
     }
 
     #[cfg(feature = "experimental")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     /// Access the target output level for real-time adjustment.
     ///
     /// Use this to dynamically modify the AGC's target level while audio is processing.
@@ -255,6 +256,7 @@ where
     }
 
     #[cfg(feature = "experimental")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     /// Access the maximum gain limit for real-time adjustment.
     ///
     /// Use this to dynamically modify the AGC's maximum allowable gain during runtime.
@@ -265,6 +267,7 @@ where
     }
 
     #[cfg(feature = "experimental")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     /// Access the attack coefficient for real-time adjustment.
     ///
     /// Use this to dynamically modify how quickly the AGC responds to level increases.
@@ -276,6 +279,7 @@ where
     }
 
     #[cfg(feature = "experimental")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     /// Access the release coefficient for real-time adjustment.
     ///
     /// Use this to dynamically modify how quickly the AGC responds to level decreases.
@@ -287,6 +291,7 @@ where
     }
 
     #[cfg(feature = "experimental")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     /// Access the AGC on/off control.
     /// Use this to dynamically enable or disable AGC processing during runtime.
     ///

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -85,8 +85,10 @@ mod uniform;
 mod zero;
 
 #[cfg(feature = "noise")]
+#[cfg_attr(docsrs, doc(cfg(feature = "noise")))]
 pub mod noise;
 #[cfg(feature = "noise")]
+#[cfg_attr(docsrs, doc(cfg(feature = "noise")))]
 pub use self::noise::{Pink, WhiteUniform};
 
 /// A source of samples.
@@ -687,6 +689,7 @@ pub enum SeekError {
     /// The symphonia decoder ran into an issue
     SymphoniaDecoder(crate::decoder::symphonia::SeekError),
     #[cfg(feature = "hound")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "hound")))]
     /// The hound (wav) decoder ran into an issue
     HoundDecoder(std::io::Error),
     // Prefer adding an enum variant to using this. It's meant for end users their
@@ -694,6 +697,7 @@ pub enum SeekError {
     /// Any other error probably in a custom Source
     Other(Box<dyn std::error::Error + Send>),
 }
+
 impl fmt::Display for SeekError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {


### PR DESCRIPTION
Optional features still are not documented on docs.rs. Even though we had done:

```toml
[package.metadata.docs.rs]
all-features = true
```

It also required:

```toml
rustdoc-args = ["--cfg", "docsrs"]
```

And then `cfg_attr` stuff like:

```rust
#[cfg(feature = "experimental")]
#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
/// Access the target output level for real-time adjustment.
```

If all is well, this will now work on docs.rs (which builds with nightly) as well as local builds (typically with stable).