### PR TITLE
Draft of an optimized pausing architecture

### DIFF
--- a/src/mixer.rs
+++ b/src/mixer.rs
@@ -140,6 +140,14 @@ impl Source for MixerSource {
         //     Ok(())
         // }
     }
+
+    fn set_pause_handle(&mut self, pause_handle: crate::source::PauseHandle) {
+        // TODO create MixerController in pausable. It will only set paused on this
+        // pause handle when all sources in the mixer have been paused
+        // Create one here, then call set_pause_handle on all sources in this 
+        // mixer with that mixercontroller.
+        todo!()
+    }
 }
 
 impl Iterator for MixerSource {

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -92,6 +92,8 @@ pub mod noise;
 #[cfg_attr(docsrs, doc(cfg(feature = "noise")))]
 pub use self::noise::{Pink, WhiteUniform};
 
+pub(crate) mod pausing;
+pub(crate) use pausing::{PauseControl, PauseHandle};
 /// A source of samples.
 ///
 /// # A quick lesson about sounds
@@ -180,6 +182,15 @@ pub trait Source: Iterator<Item = Sample> {
     ///
     /// `None` indicates at the same time "infinite" or "unknown".
     fn total_duration(&self) -> Option<Duration>;
+
+    #[expect(unused_variables)]
+    fn set_pause_handle(&mut self, pause_handle: PauseHandle) {
+        todo!()
+    }
+
+    fn is_paused(&self) -> bool {
+        todo!()
+    }
 
     /// Stores the source in a buffer in addition to returning it. This iterator can be cloned.
     #[inline]

--- a/src/source/pausable.rs
+++ b/src/source/pausable.rs
@@ -2,6 +2,8 @@ use std::time::Duration;
 
 use super::SeekError;
 use crate::common::{ChannelCount, SampleRate};
+use crate::source::pausing;
+use crate::source::PauseHandle;
 use crate::Source;
 
 /// Builds a `Pausable` object.
@@ -18,6 +20,7 @@ where
         input: source,
         paused_channels,
         remaining_paused_samples: 0,
+        pause_handle: None,
     }
 }
 
@@ -32,6 +35,7 @@ pub struct Pausable<I> {
     input: I,
     paused_channels: Option<ChannelCount>,
     remaining_paused_samples: u16,
+    pause_handle: Option<pausing::PauseHandle>,
 }
 
 impl<I> Pausable<I>
@@ -129,5 +133,13 @@ where
     #[inline]
     fn try_seek(&mut self, pos: Duration) -> Result<(), SeekError> {
         self.input.try_seek(pos)
+    }
+
+    fn set_pause_handle(&mut self, pause_handle: PauseHandle) {
+        self.pause_handle = Some(pause_handle)
+    }
+
+    fn is_paused(&self) -> bool {
+        self.paused_channels.is_some()
     }
 }

--- a/src/source/pausing.rs
+++ b/src/source/pausing.rs
@@ -1,0 +1,72 @@
+use cpal::traits::StreamTrait;
+use std::sync::{Arc, Mutex, Weak};
+
+// TODO add more such as one for sources passed to a mixer (should only call
+// pause on the downstream PauseHandle when all stream in the mixer have been
+// baused
+#[derive(Debug, Clone)]
+pub(crate) enum PauseControl {
+    StreamMixer(StreamMixerControl),
+}
+
+impl PauseControl {
+    fn pause(&self) {
+        match self {
+            PauseControl::StreamMixer(stream_mixer_control) => stream_mixer_control.pause(),
+        }
+    }
+    fn unpause(&self) {
+        match self {
+            PauseControl::StreamMixer(stream_mixer_control) => stream_mixer_control.unpause(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct StreamMixerControl {
+    pub(crate) stream: Arc<Mutex<Option<Weak<cpal::Stream>>>>,
+}
+
+impl StreamMixerControl {
+    fn pause(&self) {
+        let stream = self.stream.lock().expect("audio thread should not panic");
+        let stream = stream.as_ref().expect("should be set just after creation");
+        let Some(stream) = stream.upgrade() else {
+            return; // stream has been dropped
+        };
+        stream.pause().unwrap(); // TODO (defer till design done and working) errors
+    }
+    fn unpause(&self) {
+        let stream = self.stream.lock().expect("audio thread should not panic");
+        let stream = stream.as_ref().expect("should be set just after creation");
+        let Some(stream) = stream.upgrade() else {
+            return; // stream has been dropped
+        };
+        stream.play().unwrap(); // TODO (defer till design done and working) errors
+    }
+}
+
+impl StreamMixerControl {
+    pub(crate) fn set_stream(&self, stream: std::sync::Weak<cpal::Stream>) {
+        *self.stream.lock().expect("audio thread should not panic") = Some(stream);
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PauseHandle {
+    pub(crate) control: Arc<PauseControl>,
+}
+
+impl PauseHandle {
+    pub(crate) fn pause(&self) {
+        self.control.pause();
+    }
+
+    pub(crate) fn unpause(&self) {
+        self.control.unpause();
+    }
+
+    pub(crate) fn new(control: PauseControl) -> Self {
+        Self { control: Arc::new(control) }
+    }
+}


### PR DESCRIPTION
`Source`s in rodio get queried by the `OutputStream`. That means that the stream calls the next method on a `Source`. Only then can the `Source` do something, like call next on a `Source` it wraps.

For pausing we want to turn this flow around, we want to affect the `OutputStream` from a `Source` (possibly wrapped by many others).

To do so we need to get access to the `OutputStream` in a `Source`. We do so by making the `OutputStream` call `set_pause_handle(<some handle>)` on each `Source` added to it. During that call of `set_pause_handle` each of those sources calls `set_pause_handle` on which ever source the wrap. This goes on all through the `Source`s tree.

A `Pausable` source keeps a copy of the pause handle passed to it when `set_pause_handle` got called on it. When it needs to pause the stream it can simply call `pause()` on its stored pause handle.

There will be multiple types of pause handles:
- One which simply (un)pauses the `cpal::Stream`. It is passed to all the sources through `set_pause_handle` on `OutputStream` creation.
- One made for `Mixer`. It is passed to all streams added to the `Mixer`. This wraps whichever pause handle was set on the mixer. It only calls pause on that handle when all streams in the mixer have called pause on it.
- Maybe more I did not think off?