### PR TITLE
feat: support I24 output sample format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds a new method on source: record which collects all samples into a
   SamplesBuffer.
 - Adds `wav_to_writer` which writes a `Source` to a writer.
+- Added supported for `I24` output (24-bit samples on 4 bytes storage).
 
 ### Fixed
 - docs.rs will now document all features, including those that are optional.

--- a/src/math.rs
+++ b/src/math.rs
@@ -139,7 +139,7 @@ mod test {
     /// - Practical audio range (-60dB to +40dB): max errors ~1x ε
     /// - Extended range (-100dB to +100dB): max errors ~2.3x ε
     /// - Extreme edge cases beyond ±100dB have larger errors but are rarely used
-
+    ///
     /// Based on [Wikipedia's Decibel article].
     ///
     /// [Wikipedia's Decibel article]: https://web.archive.org/web/20230810185300/https://en.wikipedia.org/wiki/Decibel

--- a/src/microphone.rs
+++ b/src/microphone.rs
@@ -111,6 +111,7 @@ mod builder;
 mod config;
 pub use builder::MicrophoneBuilder;
 pub use config::InputConfig;
+use cpal::I24;
 use cpal::{
     traits::{DeviceTrait, HostTrait, StreamTrait},
     Device,
@@ -265,10 +266,13 @@ impl Microphone {
             F64, f64;
             I8, i8;
             I16, i16;
+            I24, I24;
             I32, i32;
             I64, i64;
             U8, u8;
             U16, u16;
+            // TODO: uncomment when https://github.com/RustAudio/cpal/pull/1011 is merged
+            // U24, cpal::U24;
             U32, u32;
             U64, u64
         )

--- a/src/mixer.rs
+++ b/src/mixer.rs
@@ -177,7 +177,9 @@ impl MixerSource {
         let mut pending = self.input.0.pending_sources.lock().unwrap(); // TODO: relax ordering?
 
         for source in pending.drain(..) {
-            let in_step = self.sample_count % source.channels().get() as usize == 0;
+            let in_step = self
+                .sample_count
+                .is_multiple_of(source.channels().get() as usize);
 
             if in_step {
                 self.current_sources.push(source);

--- a/src/source/linear_ramp.rs
+++ b/src/source/linear_ramp.rs
@@ -88,7 +88,7 @@ where
             factor = self.start_gain * (1.0f32 - p) + self.end_gain * p;
         }
 
-        if self.sample_idx % (self.channels().get() as u64) == 0 {
+        if self.sample_idx.is_multiple_of(self.channels().get() as u64) {
             self.elapsed_ns += 1000000000.0 / (self.input.sample_rate().get() as f32);
         }
 


### PR DESCRIPTION
I24 (or: S24) output is for 24-bit samples on 4 bytes of storage. This is a common format for I2S devices.

Refactored while there:
- made `init_stream` generic for any `Source` - in today's code it only takes a `MixerSource` but it could be anything
- moved repetitive stream callback and sample conversion code into helper function