### PR TITLE
feat: Add optional floor value to AGC and performance optimizations

### DIFF
--- a/benches/effects.rs
+++ b/benches/effects.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use divan::Bencher;
+use rodio::source::AutomaticGainControlSettings;
 use rodio::Source;
 
 mod shared;
@@ -47,12 +48,7 @@ fn amplify(bencher: Bencher) {
 fn agc_enabled(bencher: Bencher) {
     bencher.with_inputs(music_wav).bench_values(|source| {
         source
-            .automatic_gain_control(
-                1.0,   // target_level
-                4.0,   // attack_time (in seconds)
-                0.005, // release_time (in seconds)
-                5.0,   // absolute_max_gain
-            )
+            .automatic_gain_control(AutomaticGainControlSettings::default())
             .for_each(divan::black_box_drop)
     })
 }
@@ -62,12 +58,8 @@ fn agc_enabled(bencher: Bencher) {
 fn agc_disabled(bencher: Bencher) {
     bencher.with_inputs(music_wav).bench_values(|source| {
         // Create the AGC source
-        let amplified_source = source.automatic_gain_control(
-            1.0,   // target_level
-            4.0,   // attack_time (in seconds)
-            0.005, // release_time (in seconds)
-            5.0,   // absolute_max_gain
-        );
+        let amplified_source =
+            source.automatic_gain_control(AutomaticGainControlSettings::default());
 
         // Get the control handle and disable AGC
         let agc_control = amplified_source.get_agc_control();

--- a/benches/pipeline.rs
+++ b/benches/pipeline.rs
@@ -2,6 +2,7 @@ use std::num::NonZero;
 use std::time::Duration;
 
 use divan::Bencher;
+use rodio::source::AutomaticGainControlSettings;
 use rodio::ChannelCount;
 use rodio::{source::UniformSourceIterator, Source};
 
@@ -19,12 +20,7 @@ fn long(bencher: Bencher) {
             .high_pass(300)
             .amplify(1.2)
             .speed(0.9)
-            .automatic_gain_control(
-                1.0,   // target_level
-                4.0,   // attack_time (in seconds)
-                0.005, // release_time (in seconds)
-                5.0,   // absolute_max_gain
-            )
+            .automatic_gain_control(AutomaticGainControlSettings::default())
             .delay(Duration::from_secs_f32(0.5))
             .fade_in(Duration::from_secs_f32(2.0))
             .take_duration(Duration::from_secs(10));

--- a/examples/automatic_gain_control.rs
+++ b/examples/automatic_gain_control.rs
@@ -1,4 +1,4 @@
-use rodio::source::Source;
+use rodio::source::{AutomaticGainControlSettings, Source};
 use rodio::Decoder;
 use std::error::Error;
 use std::fs::File;
@@ -16,7 +16,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let source = Decoder::try_from(file)?;
 
     // Apply automatic gain control to the source
-    let agc_source = source.automatic_gain_control(1.0, 4.0, 0.0, 5.0);
+    let agc_source = source.automatic_gain_control(AutomaticGainControlSettings::default());
 
     // Make it so that the source checks if automatic gain control should be
     // enabled or disabled every 5 milliseconds. We must clone `agc_enabled`,

--- a/examples/into_file.rs
+++ b/examples/into_file.rs
@@ -1,3 +1,4 @@
+use rodio::source::AutomaticGainControlSettings;
 use rodio::{wav_to_file, Source};
 use std::error::Error;
 
@@ -7,7 +8,7 @@ use std::error::Error;
 fn main() -> Result<(), Box<dyn Error>> {
     let file = std::fs::File::open("assets/music.mp3")?;
     let mut audio = rodio::Decoder::try_from(file)?
-        .automatic_gain_control(1.0, 4.0, 0.005, 3.0)
+        .automatic_gain_control(AutomaticGainControlSettings::default())
         .speed(0.8);
 
     let wav_path = "music_mp3_converted.wav";

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,5 +1,8 @@
 //! Math utilities for audio processing.
 
+use crate::common::SampleRate;
+use std::time::Duration;
+
 /// Linear interpolation between two samples.
 ///
 /// The result should be equivalent to
@@ -74,6 +77,28 @@ pub fn db_to_linear(decibels: f32) -> f32 {
 pub fn linear_to_db(linear: f32) -> f32 {
     // Same as `to_linear`: faster than using `20f32.log10() * linear`
     linear.log2() * std::f32::consts::LOG10_2 * 20.0
+}
+
+/// Converts a time duration to a smoothing coefficient for exponential filtering.
+///
+/// Used for both attack and release filtering in the limiter's envelope detector.
+/// Creates a coefficient that determines how quickly the limiter responds to level changes:
+/// * Longer times = higher coefficients (closer to 1.0) = slower, smoother response
+/// * Shorter times = lower coefficients (closer to 0.0) = faster, more immediate response
+///
+/// The coefficient is calculated using the formula: `e^(-1 / (duration_seconds * sample_rate))`
+/// which provides exponential smoothing behavior suitable for audio envelope detection.
+///
+/// # Arguments
+///
+/// * `duration` - Desired response time (attack or release duration)
+/// * `sample_rate` - Audio sample rate in Hz
+///
+/// # Returns
+///
+/// Smoothing coefficient in the range [0.0, 1.0] for use in exponential filters
+pub(crate) fn duration_to_coefficient(duration: Duration, sample_rate: SampleRate) -> f32 {
+    f32::exp(-1.0 / (duration.as_secs_f32() * sample_rate.get() as f32))
 }
 
 /// Utility macro for getting a `NonZero` from a literal. Especially

--- a/src/source/limit.rs
+++ b/src/source/limit.rs
@@ -63,7 +63,8 @@ use std::time::Duration;
 use super::SeekError;
 use crate::{
     common::{ChannelCount, Sample, SampleRate},
-    math, Source,
+    math::{self, duration_to_coefficient},
+    Source,
 };
 
 /// Configuration settings for audio limiting.
@@ -1114,29 +1115,6 @@ where
 
         Ok(())
     }
-}
-
-/// Converts a time duration to a smoothing coefficient for exponential filtering.
-///
-/// Used for both attack and release filtering in the limiter's envelope detector.
-/// Creates a coefficient that determines how quickly the limiter responds to level changes:
-/// * Longer times = higher coefficients (closer to 1.0) = slower, smoother response
-/// * Shorter times = lower coefficients (closer to 0.0) = faster, more immediate response
-///
-/// The coefficient is calculated using the formula: `e^(-1 / (duration_seconds * sample_rate))`
-/// which provides exponential smoothing behavior suitable for audio envelope detection.
-///
-/// # Arguments
-///
-/// * `duration` - Desired response time (attack or release duration)
-/// * `sample_rate` - Audio sample rate in Hz
-///
-/// # Returns
-///
-/// Smoothing coefficient in the range [0.0, 1.0] for use in exponential filters
-#[must_use]
-fn duration_to_coefficient(duration: Duration, sample_rate: SampleRate) -> f32 {
-    f32::exp(-1.0 / (duration.as_secs_f32() * sample_rate.get() as f32))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR introduces an optional floor value for the AGC, enabling users to set a minimum output level that prevents the gain from dropping below a specified threshold.

For example, setting a floor value of `1.0` ensures that the audio output is always at or above the original source level, preventing excessive attenuation.

It also updates the example AGC to use the new defaults, I noticed forgot to do that in #759