### PR TITLE
Fix assertion

### DIFF
--- a/src/source/signal_generator.rs
+++ b/src/source/signal_generator.rs
@@ -111,7 +111,7 @@ impl SignalGenerator {
         frequency: f32,
         generator_function: GeneratorFunction,
     ) -> Self {
-        assert!(frequency != 0.0, "frequency must be greater than zero");
+        assert!(frequency > 0.0, "frequency must be greater than zero");
         let period = sample_rate.get() as f32 / frequency;
         let phase_step = 1.0f32 / period;
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -445,7 +445,7 @@ pub enum StreamError {
 impl OutputStream {
     fn validate_config(config: &OutputStreamConfig) {
         if let BufferSize::Fixed(sz) = config.buffer_size {
-            assert!(sz > 0, "fixed buffer size is greater than zero");
+            assert!(sz > 0, "fixed buffer size must be greater than zero");
         }
     }
 


### PR DESCRIPTION
In rodio/src/source/signal_generator.rs, frequency should be > 0 according to semantic but code allows it to be negative, so assertion should be changed into `assert!(frequency > 0.0, "frequency must be greater than zero");`
```rust
pub fn with_function(
    sample_rate: SampleRate,
    frequency: f32,
    generator_function: GeneratorFunction,
) -> Self {
    assert!(frequency != 0.0, "frequency must be greater than zero");
    let period = sample_rate as f32 / frequency;
```