### PR TITLE
Better error on `OutputStreamBuilder::open_stream`

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -342,7 +342,7 @@ where
 
     /// Open output stream using parameters configured so far.
     pub fn open_stream(self) -> Result<OutputStream, StreamError> {
-        let device = self.device.as_ref().expect("output device specified");
+        let device = self.device.as_ref().expect("No output device specified");
 
         OutputStream::open(device, &self.config, self.error_callback)
     }
@@ -355,7 +355,7 @@ where
     where
         E: Clone,
     {
-        let device = self.device.as_ref().expect("output device specified");
+        let device = self.device.as_ref().expect("No output device specified");
         let error_callback = &self.error_callback;
 
         OutputStream::open(device, &self.config, error_callback.clone()).or_else(|err| {


### PR DESCRIPTION
I'd think the panic will make much more sense if there's the word `No` in front of it :D