### PR TITLE
Fix compiler warnings for unused code when compiling without decoder

### DIFF
--- a/src/decoder/builder.rs
+++ b/src/decoder/builder.rs
@@ -302,7 +302,10 @@ impl<R: Read + Seek + Send + Sync + 'static> DecoderBuilder<R> {
         }
 
         #[cfg(not(feature = "symphonia"))]
-        Err(DecoderError::UnrecognizedFormat)
+        {
+            let _ = data;
+            Err(DecoderError::UnrecognizedFormat)
+        }
     }
 
     /// Creates a new decoder with previously configured settings.

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use crate::{
     buffer::SamplesBuffer,
     common::{assert_error_traits, ChannelCount, SampleRate},
-    math, BitDepth, Float, Sample,
+    math, Float, Sample,
 };
 
 use dasp_sample::FromSample;
@@ -231,7 +231,7 @@ pub trait Source: Iterator<Item = Sample> {
     #[cfg(feature = "dither")]
     #[cfg_attr(docsrs, doc(cfg(feature = "dither")))]
     #[inline]
-    fn dither(self, target_bits: BitDepth, algorithm: DitherAlgorithm) -> Dither<Self>
+    fn dither(self, target_bits: crate::BitDepth, algorithm: DitherAlgorithm) -> Dither<Self>
     where
         Self: Sized,
     {


### PR DESCRIPTION
I use `--no-default-features -F vorbis -F playback` which causes an unused code warning. While fixing this I found more warnings that you get when compiling without any decoder feature enabled. This PR fixes these warnings