### PR TITLE
add get_ref to SampleRateConverter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `DitherAlgorithm` enum for algorithm selection
   - `Source::dither()` function for applying dithering
 - Added `64bit` feature to opt-in to 64-bit sample precision (`f64`).
+- Added `SampleRateConverter::inner` to get underlying iterator by ref.
 
 ### Fixed
 - docs.rs will now document all features, including those that are optional.

--- a/src/conversions/sample_rate.rs
+++ b/src/conversions/sample_rate.rs
@@ -101,9 +101,9 @@ where
         &mut self.input
     }
 
-    /// Get a reference to the underlying interator
+    /// Get a reference to the underlying iterator
     #[inline]
-    pub fn get_ref(&self) -> &I {
+    pub fn inner(&self) -> &I {
         &self.input
     }
 


### PR DESCRIPTION
allows inspecting underlying iterator with mutable access