### PR TITLE
Filter out zero duration

### DIFF
--- a/src/decoder/symphonia.rs
+++ b/src/decoder/symphonia.rs
@@ -104,11 +104,12 @@ impl SymphoniaDecoder {
 
         let mut decoder = symphonia::default::get_codecs()
             .make(&track.codec_params, &DecoderOptions::default())?;
-        let total_duration = stream
+        let total_duration: Option<Duration> = track
             .codec_params
             .time_base
             .zip(stream.codec_params.n_frames)
-            .map(|(base, spans)| base.calc_time(spans).into());
+            .map(|(base, spans)| base.calc_time(spans).into())
+            .filter(|d: &Duration| !d.is_zero());
 
         let decoded = loop {
             let current_span = match probed.format.next_packet() {


### PR DESCRIPTION
This adjusts the symphonia integration to filter out erroneous total lengths if the duration is set to zero when probing.

I found that with a few audio tracks I wanted to play they don't set the track duration in the metadata very well for some reason & so I have to rely on reading the track to get out the total duration.

Unfortunately this breaks the `seek` behaviour of the rodio sink, since that will clamp to the total duration.