### PR TITLE
expose pause/play in MixerDeviceSink

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -54,13 +54,19 @@ impl MixerDeviceSink {
     pub fn mixer(&self) -> &Mixer {
         &self.mixer
     }
-    /// pause underlaying audio stream
+    /// pause underlaying audio stream reducing cpu usage
     ///
-    /// this will prevent audio from playing until play() is called
+    /// will silenty fail to play audio until play() is called
+    ///
+    /// This is an experimental API it is likely to removed once a better solution is found without notice or a change log entry
+    #[cfg(feature = "experimental")]
     pub fn pause(&self) {
         let _ = self._stream.pause();
     }
-    /// resumes underlaying audio stream
+    /// resume underlaying audio stream
+    ///
+    /// This is an experimental API it is likely to removed once a better solution is found without notice or a change log entry
+    #[cfg(feature = "experimental")]
     pub fn play(&self) {
         let _ = self._stream.play();
     }


### PR DESCRIPTION
this PR partially addresses long standing issue of the background cpu usage even when nothing is playing
https://github.com/RustAudio/rodio/issues/299
https://github.com/RustAudio/rodio/issues/782

while there was an attempt to make a proper *fix* https://github.com/RustAudio/rodio/pull/791 it looks like the author gave up after a day