### PR TITLE
docs: fix information about default decoder features

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,16 +111,27 @@
 //! let source = source.take_duration(Duration::from_secs(5)).repeat_infinite();
 //! ```
 //!
-//! ## Alternative Decoder Backends
+//! ## Decoder Backends
 //!
-//! [Symphonia](https://github.com/pdeljanov/Symphonia) is an alternative decoder library that can be used in place
-//! of many of the default backends.
-//! Currently, the main benefit is that Symphonia is the only backend that supports M4A and AAC,
-//! but it may be used to implement additional optional functionality in the future.
+//! [Symphonia](https://github.com/pdeljanov/Symphonia) is the default decoder library.
+//! Rodio supports enabling all of Symphonia's codecs using the `symphonia-all` feature
+//! or enabling specific codecs using one of the `symphonia-{codec name}` features.
+//! By default, decoders for the most common file types (flac, mp3, mp4, vorbis, wav) are enabled.
 //!
-//! To use, enable either the `symphonia-all` feature to enable all Symphonia codecs
-//! or enable specific codecs using one of the `symphonia-{codec name}` features.
-//! If you enable one or more of the Symphonia codecs, you may want to set `default-features = false` in order
+//! ### Alternative Decoders
+//!
+//! Alternative decoder libraries are available for some filetypes:
+//!
+//! - claxon (flac)
+//! - hound (wav)
+//! - lewton (vorbis)
+//! - minimp3 (mp3)
+//!
+//! Symphonia is recommended for most usage. However, the alternative decoders are all licensed
+//! under either MIT or Apache 2.0 while Symphonia is licensed under MPL-2.0, so
+//! this may be a factor if you have strict licensing requirements.
+//!
+//! If you enable one of these, you may want to set `default-features = false`
 //! to avoid adding extra crates to your binary.
 //! See the [available feature flags](https://docs.rs/crate/rodio/latest/features) for all options.
 //!


### PR DESCRIPTION
Fixes the docs to reflect the current state after the default decoder was switched to Symphonia in #753. I've also added a bit more info about licensing since that's the main reason people would likely opt for the alternative decoders. 