### PR TITLE
docs: fix build with unstable features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ lewton = ["dep:lewton"]         # Ogg Vorbis
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+cargo-args = ["-Zunstable-options"]
 
 [dependencies]
 cpal = { version = "0.17", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,6 +180,7 @@
     allow(unused_variables),
     allow(unreachable_code)
 )]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "playback")]
 pub use cpal::{
@@ -195,7 +196,6 @@ pub mod speakers;
 #[cfg(feature = "playback")]
 pub mod stream;
 #[cfg(feature = "wav_output")]
-#[cfg_attr(docsrs, doc(cfg(feature = "wav_output")))]
 mod wav_output;
 
 pub mod buffer;
@@ -222,8 +222,6 @@ pub use crate::spatial_player::SpatialPlayer;
 #[cfg(feature = "playback")]
 pub use crate::stream::{play, DeviceSinkBuilder, DeviceSinkError, MixerDeviceSink, PlayError};
 #[cfg(feature = "wav_output")]
-#[cfg_attr(docsrs, doc(cfg(feature = "wav_output")))]
 pub use crate::wav_output::wav_to_file;
 #[cfg(feature = "wav_output")]
-#[cfg_attr(docsrs, doc(cfg(feature = "wav_output")))]
 pub use crate::wav_output::wav_to_writer;

--- a/src/source/agc.rs
+++ b/src/source/agc.rs
@@ -284,7 +284,6 @@ where
     }
 
     #[cfg(feature = "experimental")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     /// Access the target output level for real-time adjustment.
     ///
     /// Use this to dynamically modify the AGC's target level while audio is processing.
@@ -295,7 +294,6 @@ where
     }
 
     #[cfg(feature = "experimental")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     /// Access the maximum gain limit for real-time adjustment.
     ///
     /// Use this to dynamically modify the AGC's maximum allowable gain during runtime.
@@ -306,7 +304,6 @@ where
     }
 
     #[cfg(feature = "experimental")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     /// Access the attack coefficient for real-time adjustment.
     ///
     /// Use this to dynamically modify how quickly the AGC responds to level increases.
@@ -318,7 +315,6 @@ where
     }
 
     #[cfg(feature = "experimental")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     /// Access the release coefficient for real-time adjustment.
     ///
     /// Use this to dynamically modify how quickly the AGC responds to level decreases.
@@ -330,7 +326,6 @@ where
     }
 
     #[cfg(feature = "experimental")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     /// Access the AGC on/off control.
     /// Use this to dynamically enable or disable AGC processing during runtime.
     ///

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -86,17 +86,13 @@ mod uniform;
 mod zero;
 
 #[cfg(feature = "dither")]
-#[cfg_attr(docsrs, doc(cfg(feature = "dither")))]
 pub mod dither;
 #[cfg(feature = "dither")]
-#[cfg_attr(docsrs, doc(cfg(feature = "dither")))]
 pub use self::dither::{Algorithm as DitherAlgorithm, Dither};
 
 #[cfg(feature = "noise")]
-#[cfg_attr(docsrs, doc(cfg(feature = "noise")))]
 pub mod noise;
 #[cfg(feature = "noise")]
-#[cfg_attr(docsrs, doc(cfg(feature = "noise")))]
 pub use self::noise::{Pink, WhiteUniform};
 
 /// A source of samples.
@@ -229,7 +225,6 @@ pub trait Source: Iterator<Item = Sample> {
     ///     .dither(BitDepth::new(16).unwrap(), DitherAlgorithm::default());
     /// ```
     #[cfg(feature = "dither")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "dither")))]
     #[inline]
     fn dither(self, target_bits: BitDepth, algorithm: DitherAlgorithm) -> Dither<Self>
     where
@@ -764,7 +759,6 @@ pub enum SeekError {
     #[error("Symphonia decoder returned an error")]
     SymphoniaDecoder(#[source] crate::decoder::symphonia::SeekError),
     #[cfg(feature = "hound")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "hound")))]
     /// The hound (wav) decoder ran into an issue
     #[error("Hound decoder returned an error")]
     HoundDecoder(#[source] Arc<std::io::Error>),


### PR DESCRIPTION
The [docs failed to build for 0.22.0](https://docs.rs/crate/rodio/0.22.0) because `#[doc(cfg)]` is experimental (see build logs [here](https://docs.rs/crate/rodio/0.22.0/builds/2911025)).

```
[INFO] [stderr] error[E0658]: `#[doc(cfg)]` is experimental
[INFO] [stderr]    --> src/lib.rs:187:20
[INFO] [stderr]     |
[INFO] [stderr] 187 | #[cfg_attr(docsrs, doc(cfg(feature = "wav_output")))]
```

We can fix this by passing `cargo-args = ["-Zunstable-options"]`

Additionally, we can use [`#![cfg_attr(docsrs, feature(doc_cfg))]`](https://doc.rust-lang.org/unstable-book/language-features/doc-cfg.html) to automatically document features without having to add `#[cfg_attr(docsrs, doc(cfg(feature = "feature_name")))]` everywhere.

We can verify this works by running `RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc -Zunstable-options --all-features --no-deps --open` and checking the output:

<img width="568" height="293" alt="image" src="https://github.com/user-attachments/assets/d4d6752a-d8b2-43c5-b578-9275eaa61874" />
