### PR TITLE
ci: verify docs build and resolve warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,8 @@ jobs:
       # Check examples compile in both modes
       - run: cargo check --examples
       - run: cargo check --examples --features 64bit
+      
+      # Verify docs
+      - run: cargo +nightly doc -Zunstable-options --no-deps --all-features
+        env:
+          RUSTDOCFLAGS: --cfg docsrs -D warnings

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,10 +4,10 @@
 //! represents a sound (streaming or not). In order to play a sound, there are three steps:
 //!
 //! - Get an OS-Sink handle to a physical device. For example, get a sink to the system's
-//!   default sound device with [`DeviceSinkBuilder::open_default_stream()`].
+//!   default sound device with [`DeviceSinkBuilder::open_default_sink()`].
 //! - Create an object that represents the streaming sound. It can be a sine wave, a buffer, a
 //!   [`decoder`], etc. or even your own type that implements the [`Source`] trait.
-//! - Add the source to the OS-Sink using [`DeviceSink::mixer()`](OutputStream::mixer)
+//! - Add the source to the OS-Sink using [`MixerDeviceSink::mixer()`]
 //!   on the OS-Sink handle.
 //!
 //! Here is a complete example of how you would play an audio file:

--- a/src/speakers.rs
+++ b/src/speakers.rs
@@ -1,6 +1,6 @@
 //! A speakers sink
 //!
-//! An audio *stream* originates at a [Source] and flows to a player. This is a
+//! An audio *stream* originates at a [`Source`](crate::Source) and flows to a player. This is a
 //! Sink that plays audio over the systems speakers or headphones through an
 //! audio output device;
 //!

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -27,7 +27,7 @@ const HZ_44100: SampleRate = nz!(44_100);
 /// # Note
 /// On drop this will print a message to stderr or emit a log msg when tracing is
 /// enabled. Though we recommend you do not you can disable that print/log with:
-/// [`DeviceSink::log_on_drop(false)`](DeviceSink::log_on_drop).
+/// [`MixerDeviceSink::log_on_drop(false)`](MixerDeviceSink::log_on_drop).
 /// If the `DeviceSink` is dropped because the program is panicking we do not print
 /// or log anything.
 ///
@@ -60,7 +60,7 @@ impl MixerDeviceSink {
         &self.config
     }
 
-    /// When [`OS-Sink`] is dropped a message is logged to stderr or
+    /// When [`MixerDeviceSink`] is dropped a message is logged to stderr or
     /// emitted through tracing if the tracing feature is enabled.
     pub fn log_on_drop(&mut self, enabled: bool) {
         self.log_on_drop = enabled;


### PR DESCRIPTION
Adds a step to CI to verify docs build correctly and resolves existing warnings related to invalid links (required so that we can include `-D warnings` in CI).