### PR TITLE
[update] update remaining_duration after success try_seek

### DIFF
--- a/src/source/take.rs
+++ b/src/source/take.rs
@@ -176,7 +176,11 @@ where
             // This assumes that the seek implementation of the codec always
             // starts again at the beginning of a span. Which is the case with
             // symphonia.
-            self.remaining_duration = self.total_duration().unwrap_or(self.requested_duration).checked_sub(pos).unwrap_or(Duration::ZERO);
+            self.remaining_duration = self
+                .total_duration()
+                .unwrap_or(self.requested_duration)
+                .checked_sub(pos)
+                .unwrap_or(Duration::ZERO);
             self.current_span_len = self.current_span_len();
         }
         result


### PR DESCRIPTION
I don't really understand the `total_duration` calculation in `TakeDuration`, so there may be something odd in the code.

Fixes #859 