### PR TITLE
Microphone implements FixedSource

### DIFF
--- a/src/microphone.rs
+++ b/src/microphone.rs
@@ -202,6 +202,21 @@ impl Source for Microphone {
     }
 }
 
+#[cfg(feature = "experimental")]
+impl crate::FixedSource for Microphone {
+    fn channels(&self) -> crate::ChannelCount {
+        self.config.channel_count
+    }
+
+    fn sample_rate(&self) -> crate::SampleRate {
+        self.config.sample_rate
+    }
+
+    fn total_duration(&self) -> Option<std::time::Duration> {
+        None
+    }
+}
+
 impl Iterator for Microphone {
     type Item = Sample;
 


### PR DESCRIPTION
Due to the orphan rule this was hard to do in rodio-experiments. So doing this directly under and experimental flag here.

I plan to gradually move over FixedSource stuff from rodio-experiments over the next month. It will all be under the experimental feature until we're confident we no longer need to release hot-fixes for the current stable.

In my head the timeline is:

1. fix current stable
2. review & merge new Source contract
3. review & merge new Resampler
4. review & merge FixedSource and ConstSource basics from rodio-experiments
5. remove experimental flag for new sources
6. review & merge FixedSource parts in multiple small PR's
7. release next rodio
8. (controversial) deprecate dynamic parts that no longer make sense, backed by performance measurements

Somewhere in between I also hope to add latency & realtime profiling tooling