### PR TITLE
Filter out null in sink fallback

### DIFF
--- a/src/microphone.rs
+++ b/src/microphone.rs
@@ -166,13 +166,19 @@ impl fmt::Display for Input {
 }
 
 /// Returns a list of available input devices on the system.
+///
+/// Note: this hides the 'null' device which generates zeros.
 pub fn available_inputs() -> Result<Vec<Input>, ListError> {
-    let host = cpal::default_host();
-    let devices = host
+    Ok(cpal::default_host()
         .input_devices()
         .map_err(ListError)?
-        .map(|dev| Input { inner: dev });
-    Ok(devices.collect())
+        .filter(|dev| {
+            dev.description()
+                .map(|descr| descr.driver().is_none_or(|driver| driver != "null"))
+                .unwrap_or(false)
+        })
+        .map(|dev| Input { inner: dev })
+        .collect::<Vec<_>>())
 }
 
 /// A microphone input stream that can be used as `Source`.

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -234,7 +234,7 @@ impl DeviceSinkBuilder {
         Self::from_default_device()
             .and_then(|x| x.open_stream())
             .or_else(|original_err| {
-                let mut devices = match cpal::default_host().output_devices() {
+                let devices = match cpal::default_host().output_devices() {
                     Ok(devices) => devices,
                     Err(err) => {
                         #[cfg(feature = "tracing")]
@@ -245,6 +245,11 @@ impl DeviceSinkBuilder {
                     }
                 };
                 devices
+                    .filter(|dev| {
+                        dev.description()
+                            .map(|desc| desc.driver().is_some_and(|driver| driver != "null"))
+                            .unwrap_or(false)
+                    })
                     .find_map(|d| {
                         Self::from_device(d)
                             .and_then(|x| x.open_sink_or_fallback())


### PR DESCRIPTION
Cpal has (correctly) started listing the `null` device in 0.17. This messes up our Sink's fallback strategy since it can now land on the null device (which happily eats all samples without producing _any_ sound.) This fixes that by filtering it out. 

Our microphone input has a different API, it does not have fallback. We provide a method to list all input devices which was now including null, a possible footgun if users try to implement fallback themselves. We've taken that out _for now_.

In my opinion automatic fallback at the Rodio layer makes no sense whatsoever. It is therefore excluded from the new output device API (working title speakers).