### PR TITLE
refactor: add DEFAULT_SAMPLE_RATE and default to 48 kHz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - All sources now implement `ExactSizeIterator` when their inner source does.
 - All sources now implement `Iterator::size_hint()`.
 - `Chirp` now implements `try_seek`.
+- Added `DEFAULT_SAMPLE_RATE` set to match `cpal::SAMPLE_RATE_48K`.
 
 ### Changed
 
@@ -25,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensured decoders to always return complete frames, as well as `TakeDuration` when expired.
 - Breaking: `Zero::new_samples()` now returns `Result<Self, ZeroError>` requiring a frame-aligned number of samples.
 - Improved queue, buffer, mixer and sample rate conversion performance.
+- Default sample rate changed from 44.1 kHz to 48 kHz consistently.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Breaking: `Zero::new_samples()` now returns `Result<Self, ZeroError>` requiring a frame-aligned number of samples.
 - Improved queue, buffer, mixer and sample rate conversion performance.
 - Default sample rate changed from 44.1 kHz to 48 kHz consistently.
+- `open_sink_or_fallback` now tries 48 kHz and 44.1 kHz before the device's maximum sample rate.
+
+### Removed
+
+- Breaking: Removed `stream::supported_output_configs`. Use `cpal::Device::supported_output_configs`.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,7 +235,7 @@ dependencies = [
 [[package]]
 name = "cpal"
 version = "0.18.0"
-source = "git+https://github.com/RustAudio/cpal#39b543e3d1f644869d1e9cd1f99322146503ce19"
+source = "git+https://github.com/RustAudio/cpal#f938e338c9811fbe4d428517acf1d15cc6d694d4"
 dependencies = [
  "alsa",
  "block2",

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,6 +6,9 @@ The list below only contains required code changes. For a complete list of
 changes and new features, see [CHANGELOG.md](CHANGELOG.md).
 
 # rodio 0.22 to current github version
+- `stream::supported_output_configs` is removed. To pick a non-default device config,
+  call `device.supported_output_configs()` directly and pass your chosen
+  `SupportedStreamConfig` to `DeviceSinkBuilder::with_supported_config`.
 - `Done` now calls a callback instead of decrementing an `Arc<AtomicUsize>`.
   - To retain old behavior replace the `Arc<AtomicUsize>` argument in `Done::new` with
     `move |_| { number.fetch_sub(1, std::sync::atomic::Ordering::Relaxed) }`.

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,8 +1,13 @@
 use std::fmt::{Debug, Display};
 use std::num::NonZero;
 
+use crate::math::nz;
+
 /// Sample rate (a frame rate or samples per second per channel).
 pub type SampleRate = NonZero<u32>;
+
+/// The default sample rate used by rodio for generators and device sinks.
+pub const DEFAULT_SAMPLE_RATE: SampleRate = nz!(48_000);
 
 /// Number of channels in a stream. Can never be Zero
 pub type ChannelCount = NonZero<u16>;

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -734,7 +734,7 @@ where
     fn sample_rate(&self) -> SampleRate {
         self.inner
             .as_ref()
-            .map_or(nz!(44100), |inner| inner.sample_rate())
+            .map_or(crate::DEFAULT_SAMPLE_RATE, |inner| inner.sample_rate())
     }
 
     /// Returns the total duration of this audio source.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,7 +215,7 @@ pub mod queue;
 pub mod source;
 pub mod static_buffer;
 
-pub use crate::common::{BitDepth, ChannelCount, Float, Sample, SampleRate};
+pub use crate::common::{BitDepth, ChannelCount, Float, Sample, SampleRate, DEFAULT_SAMPLE_RATE};
 pub use crate::decoder::Decoder;
 #[cfg(feature = "experimental")]
 pub use crate::fixed_source::FixedSource;

--- a/src/microphone/config.rs
+++ b/src/microphone/config.rs
@@ -74,7 +74,7 @@ impl Default for InputConfig {
     fn default() -> Self {
         Self {
             channel_count: nz!(1),
-            sample_rate: nz!(44_100),
+            sample_rate: crate::DEFAULT_SAMPLE_RATE,
             buffer_size: cpal::BufferSize::Default,
             sample_format: cpal::SampleFormat::F32,
         }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -419,8 +419,8 @@ mod tests {
             );
             assert_eq!(
                 rx.sample_rate(),
-                nz!(48000),
-                "Initial sample rate should be 48000 (keep_alive={keep_alive})"
+                crate::DEFAULT_SAMPLE_RATE,
+                "Initial sample rate should be DEFAULT_SAMPLE_RATE (keep_alive={keep_alive})"
             );
 
             tx.append(SamplesBuffer::new(

--- a/src/source/empty.rs
+++ b/src/source/empty.rs
@@ -47,7 +47,7 @@ impl Source for Empty {
 
     #[inline]
     fn sample_rate(&self) -> SampleRate {
-        nz!(48000)
+        crate::DEFAULT_SAMPLE_RATE
     }
 
     #[inline]

--- a/src/source/empty_callback.rs
+++ b/src/source/empty_callback.rs
@@ -51,7 +51,7 @@ impl Source for EmptyCallback {
 
     #[inline]
     fn sample_rate(&self) -> SampleRate {
-        nz!(48000)
+        crate::DEFAULT_SAMPLE_RATE
     }
 
     #[inline]

--- a/src/source/from_iter.rs
+++ b/src/source/from_iter.rs
@@ -103,7 +103,7 @@ where
             src.sample_rate()
         } else {
             // Dummy value that only happens if the iterator was empty.
-            nz!(44100)
+            crate::DEFAULT_SAMPLE_RATE
         }
     }
 

--- a/src/source/sawtooth.rs
+++ b/src/source/sawtooth.rs
@@ -18,13 +18,11 @@ pub struct SawtoothWave {
 }
 
 impl SawtoothWave {
-    const SAMPLE_RATE: SampleRate = nz!(48000);
-
     /// The frequency of the sine.
     #[inline]
     pub fn new(freq: f32) -> SawtoothWave {
         SawtoothWave {
-            test_saw: SignalGenerator::new(Self::SAMPLE_RATE, freq, Function::Sawtooth),
+            test_saw: SignalGenerator::new(crate::DEFAULT_SAMPLE_RATE, freq, Function::Sawtooth),
         }
     }
 }
@@ -56,7 +54,7 @@ impl Source for SawtoothWave {
 
     #[inline]
     fn sample_rate(&self) -> SampleRate {
-        Self::SAMPLE_RATE
+        crate::DEFAULT_SAMPLE_RATE
     }
 
     #[inline]

--- a/src/source/sine.rs
+++ b/src/source/sine.rs
@@ -18,13 +18,11 @@ pub struct SineWave {
 }
 
 impl SineWave {
-    const SAMPLE_RATE: SampleRate = nz!(48000);
-
     /// The frequency of the sine.
     #[inline]
     pub fn new(freq: f32) -> SineWave {
         SineWave {
-            test_sine: SignalGenerator::new(Self::SAMPLE_RATE, freq, Function::Sine),
+            test_sine: SignalGenerator::new(crate::DEFAULT_SAMPLE_RATE, freq, Function::Sine),
         }
     }
 }
@@ -56,7 +54,7 @@ impl Source for SineWave {
 
     #[inline]
     fn sample_rate(&self) -> SampleRate {
-        Self::SAMPLE_RATE
+        crate::DEFAULT_SAMPLE_RATE
     }
 
     #[inline]

--- a/src/source/square.rs
+++ b/src/source/square.rs
@@ -18,13 +18,11 @@ pub struct SquareWave {
 }
 
 impl SquareWave {
-    const SAMPLE_RATE: SampleRate = nz!(48000);
-
     /// The frequency of the sine.
     #[inline]
     pub fn new(freq: f32) -> SquareWave {
         SquareWave {
-            test_square: SignalGenerator::new(Self::SAMPLE_RATE, freq, Function::Square),
+            test_square: SignalGenerator::new(crate::DEFAULT_SAMPLE_RATE, freq, Function::Square),
         }
     }
 }
@@ -56,7 +54,7 @@ impl Source for SquareWave {
 
     #[inline]
     fn sample_rate(&self) -> SampleRate {
-        Self::SAMPLE_RATE
+        crate::DEFAULT_SAMPLE_RATE
     }
 
     #[inline]

--- a/src/source/triangle.rs
+++ b/src/source/triangle.rs
@@ -18,13 +18,11 @@ pub struct TriangleWave {
 }
 
 impl TriangleWave {
-    const SAMPLE_RATE: SampleRate = nz!(48000);
-
     /// The frequency of the sine.
     #[inline]
     pub fn new(freq: f32) -> TriangleWave {
         TriangleWave {
-            test_tri: SignalGenerator::new(Self::SAMPLE_RATE, freq, Function::Triangle),
+            test_tri: SignalGenerator::new(crate::DEFAULT_SAMPLE_RATE, freq, Function::Triangle),
         }
     }
 }
@@ -56,7 +54,7 @@ impl Source for TriangleWave {
 
     #[inline]
     fn sample_rate(&self) -> SampleRate {
-        Self::SAMPLE_RATE
+        crate::DEFAULT_SAMPLE_RATE
     }
 
     #[inline]

--- a/src/speakers/config.rs
+++ b/src/speakers/config.rs
@@ -108,7 +108,7 @@ impl Default for OutputConfig {
     fn default() -> Self {
         Self {
             channel_count: nz!(1),
-            sample_rate: nz!(44_100),
+            sample_rate: crate::DEFAULT_SAMPLE_RATE,
             buffer_size: BufferSize::default(),
             sample_format: cpal::SampleFormat::F32,
         }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -30,7 +30,6 @@ use std::io::{Read, Seek};
 use std::marker::Sync;
 use std::num::NonZero;
 
-
 /// `cpal::Stream` container. Use `mixer()` method to control output.
 ///
 /// <div class="warning">When dropped playback will end, and the associated
@@ -349,8 +348,8 @@ where
         self
     }
 
-    /// Set available parameters from a CPAL supported config. You can get a list of
-    /// such configurations for an output device using [crate::stream::supported_output_configs()]
+    /// Set available parameters from a CPAL supported config. To enumerate what a device supports,
+    /// use [`cpal::Device::supported_output_configs`].
     pub fn with_supported_config(
         mut self,
         config: &cpal::SupportedStreamConfig,
@@ -572,8 +571,11 @@ impl MixerDeviceSink {
     }
 }
 
-/// Return all formats supported by the device.
-pub fn supported_output_configs(
+/// Returns candidate output configurations for the device in preference order.
+///
+/// For each supported format, yields 48 kHz and 44.1 kHz (where the device supports them),
+/// followed by the device's maximum sample rate.
+fn supported_output_configs(
     device: &cpal::Device,
 ) -> Result<impl Iterator<Item = cpal::SupportedStreamConfig>, DeviceSinkError> {
     let mut supported: Vec<_> = device
@@ -585,12 +587,15 @@ pub fn supported_output_configs(
     Ok(supported.into_iter().flat_map(|sf| {
         let max_rate = sf.max_sample_rate();
         let min_rate = sf.min_sample_rate();
-        let mut formats = vec![sf.with_max_sample_rate()];
-        let preferred_rate = crate::DEFAULT_SAMPLE_RATE.get();
-        if preferred_rate < max_rate && preferred_rate > min_rate {
-            formats.push(sf.with_sample_rate(preferred_rate))
+        let mut formats = Vec::new();
+        for rate in [cpal::SAMPLE_RATE_48K, cpal::SAMPLE_RATE_CD] {
+            if rate >= min_rate && rate <= max_rate {
+                formats.push(sf.with_sample_rate(rate));
+            }
         }
-        formats.push(sf.with_sample_rate(min_rate));
+        if !formats.iter().any(|f| f.sample_rate() == max_rate) {
+            formats.push(sf.with_max_sample_rate());
+        }
         formats
     }))
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -30,7 +30,6 @@ use std::io::{Read, Seek};
 use std::marker::Sync;
 use std::num::NonZero;
 
-const HZ_44100: SampleRate = nz!(44_100);
 
 /// `cpal::Stream` container. Use `mixer()` method to control output.
 ///
@@ -128,7 +127,7 @@ impl Default for DeviceSinkConfig {
     fn default() -> Self {
         Self {
             channel_count: nz!(2),
-            sample_rate: HZ_44100,
+            sample_rate: crate::DEFAULT_SAMPLE_RATE,
             buffer_size: BufferSize::Default,
             sample_format: SampleFormat::F32,
         }
@@ -587,7 +586,7 @@ pub fn supported_output_configs(
         let max_rate = sf.max_sample_rate();
         let min_rate = sf.min_sample_rate();
         let mut formats = vec![sf.with_max_sample_rate()];
-        let preferred_rate = HZ_44100.get();
+        let preferred_rate = crate::DEFAULT_SAMPLE_RATE.get();
         if preferred_rate < max_rate && preferred_rate > min_rate {
             formats.push(sf.with_sample_rate(preferred_rate))
         }


### PR DESCRIPTION
In cpal I've changed the default sample rate to 48 kHz for devices that support it, falling back to 44.1 kHz, then to the device's maximum support sample rate.

In Rodio we used 44.1 and 48 kHz inconsistently, so I think it's good to follow cpal here.

Second, I changed `stream::supported_output_configs` which had several smells:

- Somewhere in the transition from `SampleRate` becoming `NonZero` this function became public. I'm not sure if that was intentional or smart, because it's conflating `cpal::supported_output_configs`. I reverted it to be private now, and updated the Rustdoc of `with_supported_config` to use the cpal version instead.

- The `supported_output_configs` Rustdoc was imprecise: it did not yield _all_ supported formats, only `[max, 44_100, min]` (in that order). If `min` or `max` happened to also be `44_100`, it had duplicate values. I changed it to yield `[48_000, 44_100, max]` without duplicates.