### PR TITLE
Fix Speed::try_seek to handle seek position independently of speed factor (#876)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed sources to correctly handle sample rate and channel count changes at span boundaries.
 - Fixed sources to detect parameter updates after mid-span seeks.
 - Fixed `Stoppable` and `Skippable` not signaling exhaustion.
+- Fixed `Speed::try_seek` to pass seek position directly to inner source without accounting for speed factor (#876).
 
 ## Version [0.22.2] (2026-02-22)
 

--- a/src/source/speed.rs
+++ b/src/source/speed.rs
@@ -6,7 +6,7 @@
 //! In order to speed up a sink, the speed struct:
 //! - Increases the current sample rate by the given factor.
 //! - Updates the total duration function to cover for the new factor by dividing by the factor.
-//! - Updates the try_seek function by multiplying the audio position by the factor.
+//! - Passes the seek position directly to the inner source (independent of speed factor).
 //!
 //! To speed up a source from sink all you need to do is call the   `set_speed(factor: f32)` function
 //! For example, here is how you speed up your sound by using sink or playing raw:
@@ -139,7 +139,6 @@ where
 
     #[inline]
     fn try_seek(&mut self, pos: Duration) -> Result<(), SeekError> {
-        let pos_accounting_for_speedup = pos.mul_f32(self.factor);
-        self.input.try_seek(pos_accounting_for_speedup)
+        self.input.try_seek(pos)
     }
 }


### PR DESCRIPTION
Closes #876

As discussed in the issue, seeking while at non-1x speed was incorrectly scaling the seek duration. This PR ensures the seek position is passed directly to the inner source.