### PR TITLE
Fix spatial sound inversal

### DIFF
--- a/src/source/channel_volume.rs
+++ b/src/source/channel_volume.rs
@@ -61,7 +61,7 @@ where
     }
 
     /// Gets the volume for a given channel number. Returns `None` if channel number is invalid.
-    pub fn get_volume(&self, channel: usize) -> Option<Float> {
+    pub fn volume(&self, channel: usize) -> Option<Float> {
         self.channel_volumes.get(channel).copied()
     }
 }

--- a/src/source/channel_volume.rs
+++ b/src/source/channel_volume.rs
@@ -59,6 +59,11 @@ where
     pub fn into_inner(self) -> I {
         self.input
     }
+
+    /// Gets the volume for a given channel number. Will panic if channel number is invalid.
+    pub fn get_volume(&self, channel: usize) -> Float {
+        self.channel_volumes[channel]
+    }
 }
 
 impl<I> Iterator for ChannelVolume<I>

--- a/src/source/channel_volume.rs
+++ b/src/source/channel_volume.rs
@@ -60,9 +60,9 @@ where
         self.input
     }
 
-    /// Gets the volume for a given channel number. Will panic if channel number is invalid.
-    pub fn get_volume(&self, channel: usize) -> Float {
-        self.channel_volumes[channel]
+    /// Gets the volume for a given channel number. Returns `None` if channel number is invalid.
+    pub fn get_volume(&self, channel: usize) -> Option<Float> {
+        self.channel_volumes.get(channel).copied()
     }
 }
 

--- a/src/source/channel_volume.rs
+++ b/src/source/channel_volume.rs
@@ -61,8 +61,8 @@ where
     }
 
     /// Gets the volume for a given channel number. Returns `None` if channel number is invalid.
-    pub fn volume(&self, channel: usize) -> Option<Float> {
-        self.channel_volumes.get(channel).copied()
+    pub fn volume(&self, channel: usize) -> Option<&Float> {
+        self.channel_volumes.get(channel)
     }
 }
 

--- a/src/source/spatial.rs
+++ b/src/source/spatial.rs
@@ -135,14 +135,8 @@ mod tests {
             left_ear,
             right_ear,
         );
-        let left = spatial
-            .input
-            .get_volume(0)
-            .expect("left channel should exist");
-        let right = spatial
-            .input
-            .get_volume(1)
-            .expect("right channel should exist");
+        let left = spatial.input.volume(0).expect("left channel should exist");
+        let right = spatial.input.volume(1).expect("right channel should exist");
         assert!(
             (left - right).abs() < EPSILON,
             "Expected equal volume, got left: {left}, right: {right}"
@@ -160,14 +154,8 @@ mod tests {
             left_ear,
             right_ear,
         );
-        let left = spatial
-            .input
-            .get_volume(0)
-            .expect("left channel should exist");
-        let right = spatial
-            .input
-            .get_volume(1)
-            .expect("right channel should exist");
+        let left = spatial.input.volume(0).expect("left channel should exist");
+        let right = spatial.input.volume(1).expect("right channel should exist");
         assert!(
             right > left,
             "Expected right > left, got left: {left}, right: {right}"
@@ -185,14 +173,8 @@ mod tests {
             left_ear,
             right_ear,
         );
-        let left = spatial
-            .input
-            .get_volume(0)
-            .expect("left channel should exist");
-        let right = spatial
-            .input
-            .get_volume(1)
-            .expect("right channel should exist");
+        let left = spatial.input.volume(0).expect("left channel should exist");
+        let right = spatial.input.volume(1).expect("right channel should exist");
         assert!(
             left > right,
             "Expected left > right, got left: {left}, right: {right}"

--- a/src/source/spatial.rs
+++ b/src/source/spatial.rs
@@ -120,18 +120,29 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::source::Spatial;
+    use crate::{source::Spatial, Float};
 
-    const EPSILON: f32 = 0.01;
+    const EPSILON: Float = 0.01;
 
     #[test]
     fn equidistant_emitter_has_equal_volume() {
         let emitter = [0.0, 0.0, 0.0];
         let left_ear = [-1.0, 0.0, 0.0];
         let right_ear = [1.0, 0.0, 0.0];
-        let spatial = Spatial::new(crate::source::SineWave::new(440.0), emitter, left_ear, right_ear);
-        let left = spatial.input.get_volume(0).expect("left channel should exist");
-        let right = spatial.input.get_volume(1).expect("right channel should exist");
+        let spatial = Spatial::new(
+            crate::source::SineWave::new(440.0),
+            emitter,
+            left_ear,
+            right_ear,
+        );
+        let left = spatial
+            .input
+            .get_volume(0)
+            .expect("left channel should exist");
+        let right = spatial
+            .input
+            .get_volume(1)
+            .expect("right channel should exist");
         assert!(
             (left - right).abs() < EPSILON,
             "Expected equal volume, got left: {left}, right: {right}"
@@ -143,9 +154,20 @@ mod tests {
         let emitter = [10.0, 0.0, 0.0];
         let left_ear = [-1.0, 0.0, 0.0];
         let right_ear = [1.0, 0.0, 0.0];
-        let spatial = Spatial::new(crate::source::SineWave::new(440.0), emitter, left_ear, right_ear);
-        let left = spatial.input.get_volume(0).expect("left channel should exist");
-        let right = spatial.input.get_volume(1).expect("right channel should exist");
+        let spatial = Spatial::new(
+            crate::source::SineWave::new(440.0),
+            emitter,
+            left_ear,
+            right_ear,
+        );
+        let left = spatial
+            .input
+            .get_volume(0)
+            .expect("left channel should exist");
+        let right = spatial
+            .input
+            .get_volume(1)
+            .expect("right channel should exist");
         assert!(
             right > left,
             "Expected right > left, got left: {left}, right: {right}"
@@ -157,9 +179,20 @@ mod tests {
         let emitter = [-10.0, 0.0, 0.0];
         let left_ear = [-1.0, 0.0, 0.0];
         let right_ear = [1.0, 0.0, 0.0];
-        let spatial = Spatial::new(crate::source::SineWave::new(440.0), emitter, left_ear, right_ear);
-        let left = spatial.input.get_volume(0).expect("left channel should exist");
-        let right = spatial.input.get_volume(1).expect("right channel should exist");
+        let spatial = Spatial::new(
+            crate::source::SineWave::new(440.0),
+            emitter,
+            left_ear,
+            right_ear,
+        );
+        let left = spatial
+            .input
+            .get_volume(0)
+            .expect("left channel should exist");
+        let right = spatial
+            .input
+            .get_volume(1)
+            .expect("right channel should exist");
         assert!(
             left > right,
             "Expected left > right, got left: {left}, right: {right}"

--- a/src/source/spatial.rs
+++ b/src/source/spatial.rs
@@ -135,8 +135,8 @@ mod tests {
             left_ear,
             right_ear,
         );
-        let left = *spatial.input.volume(0).expect("left channel should exist");
-        let right = *spatial.input.volume(1).expect("right channel should exist");
+        let left = spatial.input.volume(0).expect("left channel should exist");
+        let right = spatial.input.volume(1).expect("right channel should exist");
         assert!(
             (left - right).abs() < EPSILON,
             "Expected equal volume, got left: {left}, right: {right}"
@@ -154,8 +154,8 @@ mod tests {
             left_ear,
             right_ear,
         );
-        let left = *spatial.input.volume(0).expect("left channel should exist");
-        let right = *spatial.input.volume(1).expect("right channel should exist");
+        let left = spatial.input.volume(0).expect("left channel should exist");
+        let right = spatial.input.volume(1).expect("right channel should exist");
         assert!(
             right > left,
             "Expected right > left, got left: {left}, right: {right}"
@@ -173,8 +173,8 @@ mod tests {
             left_ear,
             right_ear,
         );
-        let left = *spatial.input.volume(0).expect("left channel should exist");
-        let right = *spatial.input.volume(1).expect("right channel should exist");
+        let left = spatial.input.volume(0).expect("left channel should exist");
+        let right = spatial.input.volume(1).expect("right channel should exist");
         assert!(
             left > right,
             "Expected left > right, got left: {left}, right: {right}"

--- a/src/source/spatial.rs
+++ b/src/source/spatial.rs
@@ -117,3 +117,84 @@ where
         self.input.try_seek(pos)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{source::Spatial, Source};
+
+    struct TestCase {
+        emitter_pos: [f32; 3],
+        left_ear: [f32; 3],
+        right_ear: [f32; 3],
+        expected: [f32; 2],
+    }
+
+    #[test]
+    fn spatial_table_test() {
+        let test_cases = [
+            TestCase {
+                // left is one unit to the left of the emitter,
+                // right is one unit to the right of the emitter,
+                // so both should be equally loud
+                emitter_pos: [0.0, 0.0, 0.0],
+                left_ear: [-1.0, 0.0, 0.0],
+                right_ear: [1.0, 0.0, 0.0],
+                expected: [0.75, 0.75],
+            },
+            TestCase {
+                // Emitter is 10 units to the RIGHT of center.
+                // Right ear is closer (9 units) vs left ear (11 units).
+                emitter_pos: [10.0, 0.0, 0.0],
+                left_ear: [-1.0, 0.0, 0.0],
+                right_ear: [1.0, 0.0, 0.0],
+                expected: [
+                    1.0 / 121.0, // left: ~0.00826
+                    0.5 / 81.0,  // right: ~0.00617
+                                 // BUG: left channel is FARTHER (11 units), but also LOUDER (0.008264) than right (9 units) (0.006173).
+                ],
+            },
+            TestCase {
+                // Emitter is 10 units to the LEFT of center.
+                // Left ear is closer (9 units) vs right ear (11 units).
+                emitter_pos: [-10.0, 0.0, 0.0],
+                left_ear: [-1.0, 0.0, 0.0],
+                right_ear: [1.0, 0.0, 0.0],
+                expected: [
+                    0.5 / 81.0, // left: ~0.00617
+                    1.0 / 121.0, // right: ~0.00826
+                                // BUG: right channel is FARTHER (11 units), but also LOUDER (0.008264) than left (9 units) (0.006173).
+                ],
+            },
+        ];
+
+        for test_case in test_cases {
+            let spatial = Spatial::new(
+                crate::source::SineWave::new(440.0),
+                test_case.emitter_pos,
+                test_case.left_ear,
+                test_case.right_ear,
+            );
+            assert_eq!(spatial.channels().get(), 2);
+            assert_eq!(
+                spatial.input.get_volume(0),
+                test_case.expected[0],
+                "Failed test case with emitter_pos: {:?}, left_ear: {:?}, right_ear: {:?}, expected at left channel: {:?}, but got: {:?}",
+                test_case.emitter_pos,
+                test_case.left_ear,
+                test_case.right_ear,
+                test_case.expected[0],
+                spatial.input.get_volume(0)
+            );
+            assert_eq!(
+                spatial.input.get_volume(1),
+                test_case.expected[1],
+                "Failed test case with emitter_pos: {:?}, left_ear: {:?}, right_ear: {:?}, expected at right channel: {:?}, but got: {:?}",
+                test_case.emitter_pos,
+                test_case.left_ear,
+                test_case.right_ear,
+                test_case.expected[1],
+                spatial.input.get_volume(1)
+            );
+        }
+    }
+}

--- a/src/source/spatial.rs
+++ b/src/source/spatial.rs
@@ -135,8 +135,8 @@ mod tests {
             left_ear,
             right_ear,
         );
-        let left = spatial.input.volume(0).expect("left channel should exist");
-        let right = spatial.input.volume(1).expect("right channel should exist");
+        let left = *spatial.input.volume(0).expect("left channel should exist");
+        let right = *spatial.input.volume(1).expect("right channel should exist");
         assert!(
             (left - right).abs() < EPSILON,
             "Expected equal volume, got left: {left}, right: {right}"
@@ -154,8 +154,8 @@ mod tests {
             left_ear,
             right_ear,
         );
-        let left = spatial.input.volume(0).expect("left channel should exist");
-        let right = spatial.input.volume(1).expect("right channel should exist");
+        let left = *spatial.input.volume(0).expect("left channel should exist");
+        let right = *spatial.input.volume(1).expect("right channel should exist");
         assert!(
             right > left,
             "Expected right > left, got left: {left}, right: {right}"
@@ -173,8 +173,8 @@ mod tests {
             left_ear,
             right_ear,
         );
-        let left = spatial.input.volume(0).expect("left channel should exist");
-        let right = spatial.input.volume(1).expect("right channel should exist");
+        let left = *spatial.input.volume(0).expect("left channel should exist");
+        let right = *spatial.input.volume(1).expect("right channel should exist");
         assert!(
             left > right,
             "Expected left > right, got left: {left}, right: {right}"

--- a/src/source/spatial.rs
+++ b/src/source/spatial.rs
@@ -120,81 +120,49 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{source::Spatial, Source};
+    use crate::source::Spatial;
 
-    struct TestCase {
-        emitter_pos: [f32; 3],
-        left_ear: [f32; 3],
-        right_ear: [f32; 3],
-        expected: [f32; 2],
+    const EPSILON: f32 = 0.01;
+
+    #[test]
+    fn equidistant_emitter_has_equal_volume() {
+        let emitter = [0.0, 0.0, 0.0];
+        let left_ear = [-1.0, 0.0, 0.0];
+        let right_ear = [1.0, 0.0, 0.0];
+        let spatial = Spatial::new(crate::source::SineWave::new(440.0), emitter, left_ear, right_ear);
+        let left = spatial.input.get_volume(0).expect("left channel should exist");
+        let right = spatial.input.get_volume(1).expect("right channel should exist");
+        assert!(
+            (left - right).abs() < EPSILON,
+            "Expected equal volume, got left: {left}, right: {right}"
+        );
     }
 
     #[test]
-    fn spatial_table_test() {
-        let test_cases = [
-            TestCase {
-                // left is one unit to the left of the emitter,
-                // right is one unit to the right of the emitter,
-                // so both should be equally loud
-                emitter_pos: [0.0, 0.0, 0.0],
-                left_ear: [-1.0, 0.0, 0.0],
-                right_ear: [1.0, 0.0, 0.0],
-                expected: [0.75, 0.75],
-            },
-            TestCase {
-                // Emitter is 10 units to the RIGHT of center.
-                // Right ear is closer (9 units) vs left ear (11 units).
-                emitter_pos: [10.0, 0.0, 0.0],
-                left_ear: [-1.0, 0.0, 0.0],
-                right_ear: [1.0, 0.0, 0.0],
-                expected: [
-                    1.0 / 121.0, // left: ~0.00826
-                    0.5 / 81.0,  // right: ~0.00617
-                                 // BUG: left channel is FARTHER (11 units), but also LOUDER (0.008264) than right (9 units) (0.006173).
-                ],
-            },
-            TestCase {
-                // Emitter is 10 units to the LEFT of center.
-                // Left ear is closer (9 units) vs right ear (11 units).
-                emitter_pos: [-10.0, 0.0, 0.0],
-                left_ear: [-1.0, 0.0, 0.0],
-                right_ear: [1.0, 0.0, 0.0],
-                expected: [
-                    0.5 / 81.0, // left: ~0.00617
-                    1.0 / 121.0, // right: ~0.00826
-                                // BUG: right channel is FARTHER (11 units), but also LOUDER (0.008264) than left (9 units) (0.006173).
-                ],
-            },
-        ];
+    fn emitter_to_the_right_is_louder_in_right_ear() {
+        let emitter = [10.0, 0.0, 0.0];
+        let left_ear = [-1.0, 0.0, 0.0];
+        let right_ear = [1.0, 0.0, 0.0];
+        let spatial = Spatial::new(crate::source::SineWave::new(440.0), emitter, left_ear, right_ear);
+        let left = spatial.input.get_volume(0).expect("left channel should exist");
+        let right = spatial.input.get_volume(1).expect("right channel should exist");
+        assert!(
+            right > left,
+            "Expected right > left, got left: {left}, right: {right}"
+        );
+    }
 
-        for test_case in test_cases {
-            let spatial = Spatial::new(
-                crate::source::SineWave::new(440.0),
-                test_case.emitter_pos,
-                test_case.left_ear,
-                test_case.right_ear,
-            );
-            assert_eq!(spatial.channels().get(), 2);
-            assert_eq!(
-                spatial.input.get_volume(0),
-                test_case.expected[0],
-                "Failed test case with emitter_pos: {:?}, left_ear: {:?}, right_ear: {:?}, expected at left channel: {:?}, but got: {:?}",
-                test_case.emitter_pos,
-                test_case.left_ear,
-                test_case.right_ear,
-                test_case.expected[0],
-                spatial.input.get_volume(0)
-            );
-            assert_eq!(
-                spatial.input.get_volume(1),
-                test_case.expected[1],
-                "Failed test case with emitter_pos: {:?}, left_ear: {:?}, right_ear: {:?}, expected at right channel: {:?}, but got: {:?}",
-                test_case.emitter_pos,
-                test_case.left_ear,
-                test_case.right_ear,
-                test_case.expected[1],
-                spatial.input.get_volume(1)
-            );
-        }
+    #[test]
+    fn emitter_to_the_left_is_louder_in_left_ear() {
+        let emitter = [-10.0, 0.0, 0.0];
+        let left_ear = [-1.0, 0.0, 0.0];
+        let right_ear = [1.0, 0.0, 0.0];
+        let spatial = Spatial::new(crate::source::SineWave::new(440.0), emitter, left_ear, right_ear);
+        let left = spatial.input.get_volume(0).expect("left channel should exist");
+        let right = spatial.input.get_volume(1).expect("right channel should exist");
+        assert!(
+            left > right,
+            "Expected left > right, got left: {left}, right: {right}"
+        );
     }
 }

--- a/src/source/spatial.rs
+++ b/src/source/spatial.rs
@@ -57,9 +57,9 @@ where
         let max_diff = dist_sq(left_ear, right_ear).sqrt();
         let left_dist = left_dist_sq.sqrt();
         let right_dist = right_dist_sq.sqrt();
-        let left_diff_modifier = (((left_dist - right_dist) / max_diff + 1.0) / 4.0 + 0.5).min(1.0);
+        let left_diff_modifier = (((right_dist - left_dist) / max_diff + 1.0) / 4.0 + 0.5).min(1.0);
         let right_diff_modifier =
-            (((right_dist - left_dist) / max_diff + 1.0) / 4.0 + 0.5).min(1.0);
+            (((left_dist - right_dist) / max_diff + 1.0) / 4.0 + 0.5).min(1.0);
         let left_dist_modifier = (1.0 / left_dist_sq).min(1.0);
         let right_dist_modifier = (1.0 / right_dist_sq).min(1.0);
         self.input


### PR DESCRIPTION
Corrects the way sound is produced by Spatial when emitter is located close enough to sources to be noticeably closer to left or right ear.

Previous implementation sounded inversed as demonstrated in tests (right ear would sound louder than left one when emitter is farther from right ear and closer to left ear, and vice versa).

This is a breaking change for anyone relied on old implementation behavior if they decided to switch left and right locations to get correct sounds.

Fixes #884 
