### PR TITLE
Fixed volume span len calculation (Issue #880)

### DIFF
--- a/src/source/channel_volume.rs
+++ b/src/source/channel_volume.rs
@@ -106,9 +106,9 @@ where
 {
     #[inline]
     fn current_span_len(&self) -> Option<usize> {
-        self.input.current_span_len().map(|len| {
-            len / self.input.channels().get() as usize * self.channel_volumes.len()
-        })
+        self.input
+            .current_span_len()
+            .map(|len| len / self.input.channels().get() as usize * self.channel_volumes.len())
     }
 
     #[inline]

--- a/src/source/channel_volume.rs
+++ b/src/source/channel_volume.rs
@@ -106,7 +106,9 @@ where
 {
     #[inline]
     fn current_span_len(&self) -> Option<usize> {
-        self.input.current_span_len()
+        self.input.current_span_len().map(|len| {
+            len / self.input.channels().get() as usize * self.channel_volumes.len()
+        })
     }
 
     #[inline]


### PR DESCRIPTION
This change fixes a bug where `ChannelVolume::current_span_len()` returns the wrong units.