### PR TITLE
Fix clippy::question_mark on Rust 1.97

### DIFF
--- a/src/source/from_iter.rs
+++ b/src/source/from_iter.rs
@@ -53,11 +53,7 @@ where
                 }
             }
 
-            if let Some(src) = self.iterator.next() {
-                self.current_source = Some(src);
-            } else {
-                return None;
-            }
+            self.current_source = Some(self.iterator.next()?);
         }
     }
 


### PR DESCRIPTION
Rust 1.97, released on July 9, extends `clippy::question_mark` to `if let ... else { return None }`
blocks. CI runs clippy from stable with `-D warnings`, so the check now fails on master:

```
error: this block may be rewritten with the `?` operator
  --> src/source/from_iter.rs:56:13
```

Reproduced with the CI command on rust:1.97, `cargo clippy --all-features -- -D warnings`: it fails
on master and passes with this change, with no other lint behind it. `cargo fmt --all --check` is
clean. `?` on an `Option` inside a function returning `Option` is well below the 1.89 MSRV.
