### PR TITLE
Phase1a of audio engine rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 [![Crates.io Downloads](https://img.shields.io/crates/d/rodio.svg)](https://crates.io/crates/rodio)
 [![Build Status](https://github.com/RustAudio/rodio/workflows/CI/badge.svg)](https://github.com/RustAudio/rodio/actions)
 
+> [!WARNING]
+> We are currently rewriting Rodio's core audio engine. The current state should
+> be working but under documented. This is expected to take at least a month. 
+> For the latest unreleased work pre engine rewrite see [this checkout](https://github.com/RustAudio/rodio/tree/c5f1e94290922fe4ee963ce6f85754ea6ba36243)
+
 Rust playback library.
 
 Playback is handled by [cpal](https://github.com/RustAudio/cpal). Format decoding is handled by [Symphonia](https://github.com/pdeljanov/Symphonia) by default, or by optional format-specific decoders:

--- a/README.md
+++ b/README.md
@@ -6,8 +6,11 @@
 
 > [!WARNING]
 > We are currently rewriting Rodio's core audio engine. The current state should
-> be working but under documented. This is expected to take at least a month. 
-> For the latest unreleased work pre engine rewrite see [this checkout](https://github.com/RustAudio/rodio/tree/c5f1e94290922fe4ee963ce6f85754ea6ba36243)
+> be working but under documented. This is expected to take at least a month.
+> For the latest unreleased work pre engine rewrite see [this
+> checkout](https://github.com/RustAudio/rodio/tree/c5f1e94290922fe4ee963ce6f85754ea6ba36243).
+> To follow our progress see the [tracking
+> issue](https://github.com/RustAudio/rodio/issues/901)
 
 Rust playback library.
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -12,9 +12,8 @@
 //!
 
 use crate::common::{ChannelCount, SampleRate};
-use crate::math::{duration_to_float, NANOS_PER_SEC};
 use crate::source::{SeekError, UniformSourceIterator};
-use crate::{Float, Sample, Source};
+use crate::{Sample, Source};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -25,37 +24,19 @@ pub struct SamplesBuffer {
     pos: usize,
     channels: ChannelCount,
     sample_rate: SampleRate,
-    duration: Duration,
 }
 
 impl SamplesBuffer {
     /// Builds a new `SamplesBuffer`.
-    ///
-    /// # Panics
-    ///
-    /// - Panics if the samples rate is zero.
-    /// - Panics if the length of the buffer is larger than approximately 16 billion elements.
-    ///   This is because the calculation of the duration would overflow.
-    ///
     pub fn new<D>(channels: ChannelCount, sample_rate: SampleRate, data: D) -> Self
     where
         D: Into<Vec<Sample>>,
     {
-        let data: Arc<[Sample]> = data.into().into();
-        let duration_ns = NANOS_PER_SEC.checked_mul(data.len() as u64).unwrap()
-            / sample_rate.get() as u64
-            / channels.get() as u64;
-        let duration = Duration::new(
-            duration_ns / NANOS_PER_SEC,
-            (duration_ns % NANOS_PER_SEC) as u32,
-        );
-
         Self {
-            data,
+            data: data.into().into(),
             pos: 0,
             channels,
             sample_rate,
-            duration,
         }
     }
 
@@ -91,50 +72,11 @@ impl Source for SamplesBuffer {
         self.sample_rate
     }
 
-    #[inline]
-    fn total_duration(&self) -> Option<Duration> {
-        Some(self.duration)
-    }
-
-    /// This jumps in memory till the sample for `pos`.
-    #[inline]
-    fn try_seek(&mut self, pos: Duration) -> Result<(), SeekError> {
-        // This is fast because all the samples are in memory already
-        // and due to the constant sample_rate we can jump to the right
-        // sample directly.
-
-        let curr_channel = self.pos % self.channels().get() as usize;
-        let new_pos = duration_to_float(pos)
-            * self.sample_rate().get() as Float
-            * self.channels().get() as Float;
-        // saturate pos at the end of the source
-        let new_pos = new_pos as usize;
-        let new_pos = new_pos.min(self.data.len());
-
-        // make sure the next sample is for the right channel
-        let new_pos = new_pos.next_multiple_of(self.channels().get() as usize);
-        let new_pos = new_pos - curr_channel;
-
-        self.pos = new_pos;
-        Ok(())
-    }
+    crate::common::source::buffer::source_impl! {}
 }
 
 impl Iterator for SamplesBuffer {
-    type Item = Sample;
-
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        let sample = self.data.get(self.pos)?;
-        self.pos += 1;
-        Some(*sample)
-    }
-
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let remaining = self.data.len() - self.pos;
-        (remaining, Some(remaining))
-    }
+    crate::common::source::buffer::iter_impl! {}
 }
 
 impl ExactSizeIterator for SamplesBuffer {}

--- a/src/common.rs
+++ b/src/common.rs
@@ -3,6 +3,8 @@ use std::num::NonZero;
 
 use crate::math::nz;
 
+pub(crate) mod source;
+
 /// Sample rate (a frame rate or samples per second per channel).
 pub type SampleRate = NonZero<u32>;
 

--- a/src/common/source.rs
+++ b/src/common/source.rs
@@ -1,0 +1,20 @@
+//! Code shared between source types.
+//!
+//! Since we have three source types there is a lot of code duplication. We
+//! combat that by placing whatever can be shared here.
+//!
+//! This can be:
+//! - shared types like error enums
+//! - shared free functions
+//! - shared members / impl blocks through macro_rules
+//!
+//! # Note
+//! Effects are defined through a macro and do not need this kind of
+//! deduplication
+//!
+//! This modules structure mirrors that of what it deduplicates. For example
+//! the code shared between [fixed_source::chain] and [const_source::chain] is in
+//! common/source/chain.rs
+
+pub(crate) mod buffer;
+pub(crate) mod chain;

--- a/src/common/source/buffer.rs
+++ b/src/common/source/buffer.rs
@@ -37,7 +37,7 @@ macro_rules! source_impl {
 
             // make sure the next sample is for the right channel
             let new_pos = new_pos.next_multiple_of(self.channels().get() as usize);
-            let new_pos = new_pos - curr_channel;
+            let new_pos = new_pos + curr_channel;
 
             self.pos = new_pos;
             Ok(())
@@ -56,7 +56,7 @@ macro_rules! iter_impl {
         }
         #[inline]
         fn size_hint(&self) -> (usize, Option<usize>) {
-            let remaining = self.data.len() - self.pos;
+            let remaining = self.data.len().saturating_sub(self.pos);
             (remaining, Some(remaining))
         }
     };

--- a/src/common/source/buffer.rs
+++ b/src/common/source/buffer.rs
@@ -1,0 +1,66 @@
+macro_rules! source_impl {
+    () => {
+        /// # Panics
+        /// If the length of the buffer is larger than approximately 16 billion elements.
+        /// This is because the calculation of the duration would overflow.
+        #[inline]
+        fn total_duration(&self) -> Option<Duration> {
+            use crate::math::NANOS_PER_SEC;
+
+            let duration_ns = NANOS_PER_SEC
+                .checked_mul(self.data.len() as u64)
+                .expect("slices longer then 16 billion elements are not supported")
+                / self.sample_rate().get() as u64
+                / self.channels().get() as u64;
+            let duration = Duration::new(
+                duration_ns / NANOS_PER_SEC,
+                (duration_ns % NANOS_PER_SEC) as u32,
+            );
+
+            Some(duration)
+        }
+
+        /// This jumps in memory to the sample corresponding to `pos`.
+        #[inline]
+        fn try_seek(&mut self, pos: Duration) -> Result<(), SeekError> {
+            // This is fast because all the samples are in memory already
+            // and due to the constant sample_rate we can jump to the right
+            // sample directly.
+
+            let curr_channel = self.pos % self.channels().get() as usize;
+            let new_pos = crate::math::duration_to_float(pos)
+                * self.sample_rate().get() as crate::Float
+                * self.channels().get() as crate::Float;
+            // saturate pos at the end of the source
+            let new_pos = new_pos as usize;
+            let new_pos = new_pos.min(self.data.len());
+
+            // make sure the next sample is for the right channel
+            let new_pos = new_pos.next_multiple_of(self.channels().get() as usize);
+            let new_pos = new_pos - curr_channel;
+
+            self.pos = new_pos;
+            Ok(())
+        }
+    };
+}
+
+macro_rules! iter_impl {
+    () => {
+        type Item = Sample;
+        #[inline]
+        fn next(&mut self) -> Option<Self::Item> {
+            let sample = self.data.get(self.pos)?;
+            self.pos += 1;
+            Some(*sample)
+        }
+        #[inline]
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            let remaining = self.data.len() - self.pos;
+            (remaining, Some(remaining))
+        }
+    };
+}
+
+pub(crate) use iter_impl;
+pub(crate) use source_impl;

--- a/src/common/source/chain.rs
+++ b/src/common/source/chain.rs
@@ -2,15 +2,21 @@ use crate::source::SeekError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ChainSeekError {
-    #[error("Could not get duration of first source ({ty}")]
+    #[error("Could not get duration of first source ({ty})")]
     NoTotalDurationForFirst { ty: &'static str },
-    #[error("Could not seek in first source")]
+    #[error("Could not seek in first source ({ty})")]
     FailedToSeekInFirst {
         ty: &'static str,
         #[source]
         error: SeekError,
     },
-    #[error("Could not seek in second source")]
+    #[error("Could not reset first source ({ty}) to start")]
+    FailedToResetFirst {
+        ty: &'static str,
+        #[source]
+        error: SeekError,
+    },
+    #[error("Could not seek in second source ({ty})")]
     FailedToSeekInSecond {
         ty: &'static str,
         #[source]
@@ -48,6 +54,23 @@ macro_rules! source_impl {
             };
 
             if pos < first {
+                // Reset first source to prevent a jump to the current position
+                // after the first source completes again.
+                if !self.playing_first {
+                    // FIXME(yara): implement Seekable trait for all sources and extract
+                    // this to a function. (all sources are required to impl Seekable).
+                    // Might wanna do a similar thing for other shared functionality
+                    // like total duration
+                    self.second
+                        .try_seek(std::time::Duration::ZERO)
+                        .map_err(|error| ChainSeekError::FailedToResetFirst {
+                            ty: type_name_of_val(&self.first),
+                            error,
+                        })
+                        .map_err(Arc::new)
+                        .map_err(|e| SeekError::Other(e))?;
+                }
+
                 self.first
                     .try_seek(pos)
                     .map_err(|error| ChainSeekError::FailedToSeekInFirst {
@@ -55,16 +78,20 @@ macro_rules! source_impl {
                         error,
                     })
                     .map_err(Arc::new)
-                    .map_err(|e| SeekError::Other(e))
+                    .map_err(|e| SeekError::Other(e))?;
+                self.playing_first = true;
+                Ok(())
             } else {
                 self.second
-                    .try_seek(pos)
+                    .try_seek(pos - first)
                     .map_err(|error| ChainSeekError::FailedToSeekInSecond {
                         ty: type_name_of_val(&self.second),
                         error,
                     })
                     .map_err(Arc::new)
-                    .map_err(|e| SeekError::Other(e))
+                    .map_err(|e| SeekError::Other(e))?;
+                self.playing_first = false;
+                Ok(())
             }
         }
     };
@@ -75,17 +102,27 @@ macro_rules! iter_impl {
         type Item = Sample;
 
         fn next(&mut self) -> Option<Self::Item> {
-            if self.playing_inner {
+            if self.playing_first {
                 match self.first.next() {
                     Some(sample) => Some(sample),
                     None => {
-                        self.playing_inner = false;
+                        self.playing_first = false;
                         self.second.next()
                     }
                 }
             } else {
                 self.second.next()
             }
+        }
+
+        #[inline]
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            let (lower_bound_a, upper_bound_a) = self.first.size_hint();
+            let (lower_bound_b, upper_bound_b) = self.second.size_hint();
+
+            let lower_bound = lower_bound_a + lower_bound_b;
+            let upper_bound = upper_bound_a.zip(upper_bound_b).map(|(a, b)| a + b);
+            (lower_bound, upper_bound)
         }
     };
 }

--- a/src/common/source/chain.rs
+++ b/src/common/source/chain.rs
@@ -1,0 +1,94 @@
+use crate::source::SeekError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ChainSeekError {
+    #[error("Could not get duration of first source ({ty}")]
+    NoTotalDurationForFirst { ty: &'static str },
+    #[error("Could not seek in first source")]
+    FailedToSeekInFirst {
+        ty: &'static str,
+        #[source]
+        error: SeekError,
+    },
+    #[error("Could not seek in second source")]
+    FailedToSeekInSecond {
+        ty: &'static str,
+        #[source]
+        error: SeekError,
+    },
+}
+
+macro_rules! source_impl {
+    () => {
+        fn channels(&self) -> crate::ChannelCount {
+            self.first.channels()
+        }
+
+        fn sample_rate(&self) -> crate::SampleRate {
+            self.first.sample_rate()
+        }
+
+        fn total_duration(&self) -> Option<std::time::Duration> {
+            self.first
+                .total_duration()
+                .and_then(|d| self.second.total_duration().map(|d2| d2 + d))
+        }
+
+        fn try_seek(&mut self, pos: std::time::Duration) -> Result<(), crate::source::SeekError> {
+            use crate::source::SeekError;
+            use std::any::type_name_of_val;
+            use std::sync::Arc;
+
+            let Some(first) = self.first.total_duration() else {
+                return Err(ChainSeekError::NoTotalDurationForFirst {
+                    ty: type_name_of_val(&self.first),
+                })
+                .map_err(Arc::new)
+                .map_err(|e| SeekError::Other(e));
+            };
+
+            if pos < first {
+                self.first
+                    .try_seek(pos)
+                    .map_err(|error| ChainSeekError::FailedToSeekInFirst {
+                        ty: type_name_of_val(&self.first),
+                        error,
+                    })
+                    .map_err(Arc::new)
+                    .map_err(|e| SeekError::Other(e))
+            } else {
+                self.second
+                    .try_seek(pos)
+                    .map_err(|error| ChainSeekError::FailedToSeekInSecond {
+                        ty: type_name_of_val(&self.second),
+                        error,
+                    })
+                    .map_err(Arc::new)
+                    .map_err(|e| SeekError::Other(e))
+            }
+        }
+    };
+}
+
+macro_rules! iter_impl {
+    () => {
+        type Item = Sample;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            if self.playing_inner {
+                match self.first.next() {
+                    Some(sample) => Some(sample),
+                    None => {
+                        self.playing_inner = false;
+                        self.second.next()
+                    }
+                }
+            } else {
+                self.second.next()
+            }
+        }
+    };
+}
+
+pub(crate) use iter_impl;
+pub(crate) use source_impl;

--- a/src/const_source.rs
+++ b/src/const_source.rs
@@ -58,6 +58,14 @@ pub trait ConstSource<const SR: u32, const CH: u16>: Iterator<Item = Sample> {
         IntoDynamicSource { inner: self }
     }
 
+    #[doc = include_str!("docs/collect_into_buffer.md")]
+    fn collect_into_buffer(self) -> SamplesBuffer<SR, CH>
+    where
+        Self: Sized,
+    {
+        SamplesBuffer::new(self.collect::<Vec<_>>())
+    }
+
     /// Add another source to play directly after this one.
     ///
     /// # Example

--- a/src/const_source.rs
+++ b/src/const_source.rs
@@ -1,4 +1,4 @@
-//! A sound source that has it's sample rate and number of channels fixed at compile time. 
+//! A sound source that has it's sample rate and number of channels fixed at compile time.
 //! Some practical examples:
 //! - An effect performed by a neural network trained on a specific channel
 //!   count and sample rate
@@ -13,16 +13,17 @@ use std::num::NonZeroU16;
 use std::num::NonZeroU32;
 use std::time::Duration;
 
+use crate::source::SeekError;
 use crate::ChannelCount;
 use crate::Sample;
 use crate::SampleRate;
-use crate::Source as DynamicSource; // will be renamed to this upstream
+use crate::Source as DynamicSource; // Source will (probably) be renamed to this later
 
-mod chain;
 mod buffer;
+mod chain;
 
-pub use chain::SourceChain;
 pub use buffer::SamplesBuffer;
+pub use chain::SourceChain;
 
 /// A source which sample rate and channel count are fixed at compile time.
 pub trait ConstSource<const SR: u32, const CH: u16>: Iterator<Item = Sample> {
@@ -37,6 +38,14 @@ pub trait ConstSource<const SR: u32, const CH: u16>: Iterator<Item = Sample> {
 
     #[doc = include_str!("docs/total_duration.md")]
     fn total_duration(&self) -> Option<Duration>;
+
+    #[allow(unused_variables)]
+    #[doc = include_str!("docs/try_seek.md")]
+    fn try_seek(&mut self, pos: Duration) -> Result<(), SeekError> {
+        Err(SeekError::NotSupported {
+            underlying_source: std::any::type_name::<Self>(),
+        })
+    }
 
     /// Use this const source as if it's a dynamic source. You generally do not
     /// want to do this since there are less effects for dynamic sources and

--- a/src/const_source.rs
+++ b/src/const_source.rs
@@ -1,0 +1,132 @@
+//! A sound source that has it's sample rate and number of channels fixed at compile time. 
+//! Some practical examples:
+//! - An effect performed by a neural network trained on a specific channel
+//!   count and sample rate
+//! - A custom audio source streaming in at a pre-determined fixed sample rate.
+//!   We use this in our VoIP example.
+//!
+//! A const pipeline _may_ also be optimized more by the compiler as many
+//! branches are known at compile time, like when converting from one channel
+//! count to another.
+use std::marker::PhantomData;
+use std::num::NonZeroU16;
+use std::num::NonZeroU32;
+use std::time::Duration;
+
+use crate::ChannelCount;
+use crate::Sample;
+use crate::SampleRate;
+use crate::Source as DynamicSource; // will be renamed to this upstream
+
+mod chain;
+mod buffer;
+
+pub use chain::SourceChain;
+pub use buffer::SamplesBuffer;
+
+/// A source which sample rate and channel count are fixed at compile time.
+pub trait ConstSource<const SR: u32, const CH: u16>: Iterator<Item = Sample> {
+    /// Returns the sample rate which is the first generic (SR) of a ConstSource
+    fn sample_rate(&self) -> SampleRate {
+        const { NonZeroU32::new(SR).expect("SampleRate must be > 0") }
+    }
+    /// Returns the channel count which is the second generic (CH) of a ConstSource
+    fn channels(&self) -> ChannelCount {
+        const { NonZeroU16::new(CH).expect("Channel count must be > 0") }
+    }
+
+    #[doc = include_str!("docs/total_duration.md")]
+    fn total_duration(&self) -> Option<Duration>;
+
+    /// Use this const source as if it's a dynamic source. You generally do not
+    /// want to do this since there are less effects for dynamic sources and
+    /// those that are available can not be implemented as efficient. This is
+    /// therefore purely provided for backwards compatibility.
+    fn into_dynamic_source(self) -> IntoDynamicSource<SR, CH, Self>
+    where
+        Self: Sized,
+    {
+        IntoDynamicSource { inner: self }
+    }
+
+    /// Add another source to play directly after this one.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use rodio::const_source::ConstSource;
+    /// # use rodio::const_source::SamplesBuffer;
+    /// let preamble = SamplesBuffer::<44100, 1>::new([1.0, 1.0]);
+    /// let signal = SamplesBuffer::<44100, 1>::new([2.0, 2.0]);
+    ///
+    /// let mixed = preamble.chain_source(signal);
+    /// assert_eq!(mixed.collect::<Vec<_>>(), vec![1.0,1.0,2.0,2.0])
+    /// ```
+    fn chain_source<S>(self, next: S) -> SourceChain<SR, CH, Self, S>
+    where
+        Self: Sized,
+        S: ConstSource<SR, CH>,
+    {
+        SourceChain::new(self, next)
+    }
+
+    // placeholder until effects land (need this for some examples)
+    #[allow(missing_docs)]
+    fn take_duration(self, _duration: Duration) -> Placeholder<SR, CH, Self>
+    where
+        Self: Sized,
+    {
+        todo!()
+    }
+}
+
+// placeholder until effects land (need this for some examples)
+#[allow(missing_docs)]
+pub struct Placeholder<const SR: u32, const CH: u16, S>
+where
+    S: ConstSource<SR, CH>,
+{
+    inner: PhantomData<S>,
+}
+
+/// A `DynamicSource` converted from a `ConstSource`. Useful for passing to old
+/// APIs that do not accept a `ConstSource` nor `FixedSource`.
+#[derive(Clone)]
+pub struct IntoDynamicSource<const SR: u32, const CH: u16, S>
+where
+    S: ConstSource<SR, CH>,
+{
+    inner: S,
+}
+
+impl<const SR: u32, const CH: u16, S> Iterator for IntoDynamicSource<SR, CH, S>
+where
+    S: ConstSource<SR, CH>,
+{
+    type Item = Sample;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+}
+
+impl<const SR: u32, const CH: u16, S> DynamicSource for IntoDynamicSource<SR, CH, S>
+where
+    S: ConstSource<SR, CH>,
+{
+    fn current_span_len(&self) -> Option<usize> {
+        None
+    }
+
+    fn channels(&self) -> ChannelCount {
+        const { NonZeroU16::new(CH).expect("channel count must be larger then zero") }
+    }
+
+    fn sample_rate(&self) -> SampleRate {
+        const { NonZeroU32::new(SR).expect("sample rate must be larger then zero") }
+    }
+
+    fn total_duration(&self) -> Option<std::time::Duration> {
+        self.inner.total_duration()
+    }
+}

--- a/src/const_source/buffer.rs
+++ b/src/const_source/buffer.rs
@@ -1,0 +1,80 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::Sample;
+use crate::ConstSource;
+
+/// A buffer of samples treated as a source.
+#[derive(Debug, Clone)]
+pub struct SamplesBuffer<const SR: u32, const CH: u16> {
+    data: Arc<[Sample]>,
+    pos: usize,
+}
+
+impl<const SR: u32, const CH: u16> SamplesBuffer<SR, CH> {
+    /// Builds a new `SamplesBuffer`.
+    ///
+    /// Note any call to total_duration will panic if the buffer is larger then
+    /// 16 billion elements.
+    pub fn new<D>(data: D) -> SamplesBuffer<SR, CH>
+    where
+        D: Into<Vec<Sample>>,
+    {
+        const { assert!(SR > 0) };
+        const { assert!(CH > 0) };
+
+        SamplesBuffer {
+            data: data.into().into(),
+            pos: 0,
+        }
+    }
+}
+
+impl<const SR: u32, const CH: u16> ConstSource<SR, CH> for SamplesBuffer<SR, CH> {
+    /// # Panics
+    /// If the length of the buffer is larger than approximately 16 billion elements.
+    /// This is because the calculation of the duration would overflow.
+    #[inline]
+    fn total_duration(&self) -> Option<Duration> {
+        let duration_ns = 1_000_000_000u64
+            .checked_mul(self.data.len() as u64)
+            .unwrap()
+            / SR as u64
+            / CH as u64;
+        Some(Duration::new(
+            duration_ns / 1_000_000_000,
+            (duration_ns % 1_000_000_000) as u32,
+        ))
+    }
+    // /// This jumps in memory till the sample for `pos`.
+    // #[inline]
+    // fn try_seek(&mut self, pos: Duration) -> Result<(), SeekError> {
+    //     // This is fast because all the samples are in memory already
+    //     // and due to the constant sample_rate we can jump to the right
+    //     // sample directly.
+    //     let curr_channel = self.pos % self.channels() as usize;
+    //     let new_pos = pos.as_secs_f32() * self.sample_rate() as f32 * self.channels() as f32;
+    //     // saturate pos at the end of the source
+    //     let new_pos = new_pos as usize;
+    //     let new_pos = new_pos.min(self.data.len());
+    //     // make sure the next sample is for the right channel
+    //     let new_pos = new_pos.next_multiple_of(self.channels() as usize);
+    //     let new_pos = new_pos - curr_channel;
+    //     self.pos = new_pos;
+    //     Ok(())
+    // }
+}
+
+impl<const SR: u32, const CH: u16> Iterator for SamplesBuffer<SR, CH> {
+    type Item = Sample;
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let sample = self.data.get(self.pos)?;
+        self.pos += 1;
+        Some(*sample)
+    }
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.data.len(), Some(self.data.len()))
+    }
+}

--- a/src/const_source/buffer.rs
+++ b/src/const_source/buffer.rs
@@ -32,51 +32,9 @@ impl<const SR: u32, const CH: u16> SamplesBuffer<SR, CH> {
 }
 
 impl<const SR: u32, const CH: u16> ConstSource<SR, CH> for SamplesBuffer<SR, CH> {
-    /// # Panics
-    /// If the length of the buffer is larger than approximately 16 billion elements.
-    /// This is because the calculation of the duration would overflow.
-    #[inline]
-    fn total_duration(&self) -> Option<Duration> {
-        let duration_ns = 1_000_000_000u64
-            .checked_mul(self.data.len() as u64)
-            .unwrap()
-            / SR as u64
-            / CH as u64;
-        Some(Duration::new(
-            duration_ns / 1_000_000_000,
-            (duration_ns % 1_000_000_000) as u32,
-        ))
-    }
-    /// This jumps in memory till the sample for `pos`.
-    #[inline]
-    fn try_seek(&mut self, pos: Duration) -> Result<(), SeekError> {
-        // This is fast because all the samples are in memory already
-        // and due to the constant sample_rate we can jump to the right
-        // sample directly.
-        let curr_channel = self.pos % self.channels().get() as usize;
-        let new_pos =
-            pos.as_secs_f32() * self.sample_rate().get() as f32 * self.channels().get() as f32;
-        // saturate pos at the end of the source
-        let new_pos = new_pos as usize;
-        let new_pos = new_pos.min(self.data.len());
-        // make sure the next sample is for the right channel
-        let new_pos = new_pos.next_multiple_of(self.channels().get() as usize);
-        let new_pos = new_pos - curr_channel;
-        self.pos = new_pos;
-        Ok(())
-    }
+    crate::common::source::buffer::source_impl! {}
 }
 
 impl<const SR: u32, const CH: u16> Iterator for SamplesBuffer<SR, CH> {
-    type Item = Sample;
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        let sample = self.data.get(self.pos)?;
-        self.pos += 1;
-        Some(*sample)
-    }
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.data.len(), Some(self.data.len()))
-    }
+    crate::common::source::buffer::iter_impl! {}
 }

--- a/src/const_source/buffer.rs
+++ b/src/const_source/buffer.rs
@@ -14,9 +14,6 @@ pub struct SamplesBuffer<const SR: u32, const CH: u16> {
 
 impl<const SR: u32, const CH: u16> SamplesBuffer<SR, CH> {
     /// Builds a new `SamplesBuffer`.
-    ///
-    /// Note any call to total_duration will panic if the buffer is larger then
-    /// 16 billion elements.
     pub fn new<D>(data: D) -> SamplesBuffer<SR, CH>
     where
         D: Into<Vec<Sample>>,

--- a/src/const_source/buffer.rs
+++ b/src/const_source/buffer.rs
@@ -1,8 +1,9 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::Sample;
+use crate::source::SeekError;
 use crate::ConstSource;
+use crate::Sample;
 
 /// A buffer of samples treated as a source.
 #[derive(Debug, Clone)]
@@ -46,23 +47,24 @@ impl<const SR: u32, const CH: u16> ConstSource<SR, CH> for SamplesBuffer<SR, CH>
             (duration_ns % 1_000_000_000) as u32,
         ))
     }
-    // /// This jumps in memory till the sample for `pos`.
-    // #[inline]
-    // fn try_seek(&mut self, pos: Duration) -> Result<(), SeekError> {
-    //     // This is fast because all the samples are in memory already
-    //     // and due to the constant sample_rate we can jump to the right
-    //     // sample directly.
-    //     let curr_channel = self.pos % self.channels() as usize;
-    //     let new_pos = pos.as_secs_f32() * self.sample_rate() as f32 * self.channels() as f32;
-    //     // saturate pos at the end of the source
-    //     let new_pos = new_pos as usize;
-    //     let new_pos = new_pos.min(self.data.len());
-    //     // make sure the next sample is for the right channel
-    //     let new_pos = new_pos.next_multiple_of(self.channels() as usize);
-    //     let new_pos = new_pos - curr_channel;
-    //     self.pos = new_pos;
-    //     Ok(())
-    // }
+    /// This jumps in memory till the sample for `pos`.
+    #[inline]
+    fn try_seek(&mut self, pos: Duration) -> Result<(), SeekError> {
+        // This is fast because all the samples are in memory already
+        // and due to the constant sample_rate we can jump to the right
+        // sample directly.
+        let curr_channel = self.pos % self.channels().get() as usize;
+        let new_pos =
+            pos.as_secs_f32() * self.sample_rate().get() as f32 * self.channels().get() as f32;
+        // saturate pos at the end of the source
+        let new_pos = new_pos as usize;
+        let new_pos = new_pos.min(self.data.len());
+        // make sure the next sample is for the right channel
+        let new_pos = new_pos.next_multiple_of(self.channels().get() as usize);
+        let new_pos = new_pos - curr_channel;
+        self.pos = new_pos;
+        Ok(())
+    }
 }
 
 impl<const SR: u32, const CH: u16> Iterator for SamplesBuffer<SR, CH> {

--- a/src/const_source/chain.rs
+++ b/src/const_source/chain.rs
@@ -1,7 +1,3 @@
-use std::any::type_name_of_val;
-use std::sync::Arc;
-
-use crate::source::SeekError;
 use crate::ConstSource;
 use crate::Sample;
 
@@ -23,82 +19,17 @@ impl<const SR: u32, const CH: u16, S1: ConstSource<SR, CH>, S2: ConstSource<SR, 
             playing_inner: true,
         }
     }
-
-    fn try_seek_inner(&mut self, pos: std::time::Duration) -> Result<(), ChainSeekError> {
-        let Some(first) = self.first.total_duration() else {
-            return Err(ChainSeekError::NoTotalDurationForFirst {
-                ty: type_name_of_val(&self.first),
-            });
-        };
-
-        if pos < first {
-            self.first
-                .try_seek(pos)
-                .map_err(|error| ChainSeekError::FailedToSeekInFirst {
-                    ty: type_name_of_val(&self.first),
-                    error,
-                })
-        } else {
-            self.second
-                .try_seek(pos)
-                .map_err(|error| ChainSeekError::FailedToSeekInSecond {
-                    ty: type_name_of_val(&self.second),
-                    error,
-                })
-        }
-    }
 }
 
-#[derive(Debug, thiserror::Error)]
-pub enum ChainSeekError {
-    #[error("Could not get duration of first source ({ty}")]
-    NoTotalDurationForFirst { ty: &'static str },
-    #[error("Could not seek in first source")]
-    FailedToSeekInFirst {
-        ty: &'static str,
-        #[source]
-        error: SeekError,
-    },
-    #[error("Could not seek in second source")]
-    FailedToSeekInSecond {
-        ty: &'static str,
-        #[source]
-        error: SeekError,
-    },
-}
-
+pub use crate::common::source::chain::ChainSeekError;
 impl<const SR: u32, const CH: u16, S1: ConstSource<SR, CH>, S2: ConstSource<SR, CH>>
     ConstSource<SR, CH> for SourceChain<SR, CH, S1, S2>
 {
-    fn total_duration(&self) -> Option<std::time::Duration> {
-        self.first
-            .total_duration()
-            .and_then(|d| self.second.total_duration().map(|d2| d2 + d))
-    }
-
-    fn try_seek(&mut self, pos: std::time::Duration) -> Result<(), SeekError> {
-        self.try_seek_inner(pos)
-            .map_err(Arc::new)
-            .map_err(|e| SeekError::Other(e))
-    }
+    crate::common::source::chain::source_impl! {}
 }
 
 impl<const SR: u32, const CH: u16, S1: ConstSource<SR, CH>, S2: ConstSource<SR, CH>> Iterator
     for SourceChain<SR, CH, S1, S2>
 {
-    type Item = Sample;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.playing_inner {
-            match self.first.next() {
-                Some(sample) => Some(sample),
-                None => {
-                    self.playing_inner = false;
-                    self.second.next()
-                }
-            }
-        } else {
-            self.second.next()
-        }
-    }
+    crate::common::source::chain::iter_impl! {}
 }

--- a/src/const_source/chain.rs
+++ b/src/const_source/chain.rs
@@ -6,7 +6,7 @@ use crate::Sample;
 pub struct SourceChain<const SR: u32, const CH: u16, S1, S2> {
     first: S1,
     second: S2,
-    playing_inner: bool,
+    playing_first: bool,
 }
 
 impl<const SR: u32, const CH: u16, S1: ConstSource<SR, CH>, S2: ConstSource<SR, CH>>
@@ -16,11 +16,12 @@ impl<const SR: u32, const CH: u16, S1: ConstSource<SR, CH>, S2: ConstSource<SR, 
         SourceChain {
             first: s1,
             second: s2,
-            playing_inner: true,
+            playing_first: true,
         }
     }
 }
 
+// FIXME(yara) extract all this into yet another macro? macro's all the way down time :3
 pub use crate::common::source::chain::ChainSeekError;
 impl<const SR: u32, const CH: u16, S1: ConstSource<SR, CH>, S2: ConstSource<SR, CH>>
     ConstSource<SR, CH> for SourceChain<SR, CH, S1, S2>
@@ -32,4 +33,9 @@ impl<const SR: u32, const CH: u16, S1: ConstSource<SR, CH>, S2: ConstSource<SR, 
     for SourceChain<SR, CH, S1, S2>
 {
     crate::common::source::chain::iter_impl! {}
+}
+
+impl<const SR: u32, const CH: u16, S1: ConstSource<SR, CH>, S2: ConstSource<SR, CH>>
+    ExactSizeIterator for SourceChain<SR, CH, S1, S2>
+{
 }

--- a/src/const_source/chain.rs
+++ b/src/const_source/chain.rs
@@ -1,0 +1,52 @@
+use crate::ConstSource;
+use crate::Sample;
+
+/// Two chained sources, the one played after the other.
+#[derive(Clone)]
+pub struct SourceChain<const SR: u32, const CH: u16, S1, S2> {
+    inner: S1,
+    next: S2,
+    playing_inner: bool,
+}
+
+impl<const SR: u32, const CH: u16, S1: ConstSource<SR, CH>, S2: ConstSource<SR, CH>>
+    SourceChain<SR, CH, S1, S2>
+{
+    pub(crate) fn new(s1: S1, s2: S2) -> Self {
+        SourceChain {
+            inner: s1,
+            next: s2,
+            playing_inner: true,
+        }
+    }
+}
+
+impl<const SR: u32, const CH: u16, S1: ConstSource<SR, CH>, S2: ConstSource<SR, CH>>
+    ConstSource<SR, CH> for SourceChain<SR, CH, S1, S2>
+{
+    fn total_duration(&self) -> Option<std::time::Duration> {
+        self.inner
+            .total_duration()
+            .and_then(|d| self.next.total_duration().map(|d2| d2 + d))
+    }
+}
+
+impl<const SR: u32, const CH: u16, S1: ConstSource<SR, CH>, S2: ConstSource<SR, CH>> Iterator
+    for SourceChain<SR, CH, S1, S2>
+{
+    type Item = Sample;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.playing_inner {
+            match self.inner.next() {
+                Some(sample) => Some(sample),
+                None => {
+                    self.playing_inner = false;
+                    self.next.next()
+                }
+            }
+        } else {
+            self.next.next()
+        }
+    }
+}

--- a/src/const_source/chain.rs
+++ b/src/const_source/chain.rs
@@ -1,11 +1,15 @@
+use std::any::type_name_of_val;
+use std::sync::Arc;
+
+use crate::source::SeekError;
 use crate::ConstSource;
 use crate::Sample;
 
 /// Two chained sources, the one played after the other.
 #[derive(Clone)]
 pub struct SourceChain<const SR: u32, const CH: u16, S1, S2> {
-    inner: S1,
-    next: S2,
+    first: S1,
+    second: S2,
     playing_inner: bool,
 }
 
@@ -14,20 +18,68 @@ impl<const SR: u32, const CH: u16, S1: ConstSource<SR, CH>, S2: ConstSource<SR, 
 {
     pub(crate) fn new(s1: S1, s2: S2) -> Self {
         SourceChain {
-            inner: s1,
-            next: s2,
+            first: s1,
+            second: s2,
             playing_inner: true,
         }
     }
+
+    fn try_seek_inner(&mut self, pos: std::time::Duration) -> Result<(), ChainSeekError> {
+        let Some(first) = self.first.total_duration() else {
+            return Err(ChainSeekError::NoTotalDurationForFirst {
+                ty: type_name_of_val(&self.first),
+            });
+        };
+
+        if pos < first {
+            self.first
+                .try_seek(pos)
+                .map_err(|error| ChainSeekError::FailedToSeekInFirst {
+                    ty: type_name_of_val(&self.first),
+                    error,
+                })
+        } else {
+            self.second
+                .try_seek(pos)
+                .map_err(|error| ChainSeekError::FailedToSeekInSecond {
+                    ty: type_name_of_val(&self.second),
+                    error,
+                })
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ChainSeekError {
+    #[error("Could not get duration of first source ({ty}")]
+    NoTotalDurationForFirst { ty: &'static str },
+    #[error("Could not seek in first source")]
+    FailedToSeekInFirst {
+        ty: &'static str,
+        #[source]
+        error: SeekError,
+    },
+    #[error("Could not seek in second source")]
+    FailedToSeekInSecond {
+        ty: &'static str,
+        #[source]
+        error: SeekError,
+    },
 }
 
 impl<const SR: u32, const CH: u16, S1: ConstSource<SR, CH>, S2: ConstSource<SR, CH>>
     ConstSource<SR, CH> for SourceChain<SR, CH, S1, S2>
 {
     fn total_duration(&self) -> Option<std::time::Duration> {
-        self.inner
+        self.first
             .total_duration()
-            .and_then(|d| self.next.total_duration().map(|d2| d2 + d))
+            .and_then(|d| self.second.total_duration().map(|d2| d2 + d))
+    }
+
+    fn try_seek(&mut self, pos: std::time::Duration) -> Result<(), SeekError> {
+        self.try_seek_inner(pos)
+            .map_err(Arc::new)
+            .map_err(|e| SeekError::Other(e))
     }
 }
 
@@ -38,15 +90,15 @@ impl<const SR: u32, const CH: u16, S1: ConstSource<SR, CH>, S2: ConstSource<SR, 
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.playing_inner {
-            match self.inner.next() {
+            match self.first.next() {
                 Some(sample) => Some(sample),
                 None => {
                     self.playing_inner = false;
-                    self.next.next()
+                    self.second.next()
                 }
             }
         } else {
-            self.next.next()
+            self.second.next()
         }
     }
 }

--- a/src/docs/collect_into_buffer.md
+++ b/src/docs/collect_into_buffer.md
@@ -1,0 +1,5 @@
+Builds a new `SamplesBuffer`.
+
+# Panics
+- Panics if the length of the buffer is larger than approximately 16 billion elements.
+  This is because the calculation of the duration would overflow.

--- a/src/docs/total_duration.md
+++ b/src/docs/total_duration.md
@@ -1,0 +1,6 @@
+Returns the total duration of this source, if known.
+
+`None` indicates at the same time "infinite" or "unknown".
+
+Note this value is free to change. For example if you removed an item from a
+queue the total_duration lowers.

--- a/src/docs/try_seek.md
+++ b/src/docs/try_seek.md
@@ -1,0 +1,16 @@
+Attempts to seek to a given position in the current source.
+
+As long as the duration of the source is known, seek is guaranteed to saturate
+at the end of the source. For example given a source that reports a total duration
+of 42 seconds calling `try_seek()` with 60 seconds as argument will seek to
+42 seconds.
+
+# Errors
+This function will return [`SeekError::NotSupported`] if one of the underlying
+sources does not support seeking.
+
+It will return an error if an implementation ran
+into one during the seek.
+
+Seeking beyond the end of a source might return an error if the total duration of
+the source is not known.

--- a/src/generators.rs
+++ b/src/generators.rs
@@ -1,0 +1,10 @@
+//! Sources that produce sound without consuming anything
+
+// Note we make everything be it effects or generators available under <source_type>/<thing>
+
+mod silence;
+
+/// Generators with both the sample rate and channel count known at compile time.
+pub mod const_source {
+    pub use super::silence::const_source::Silence;
+}

--- a/src/generators/silence.rs
+++ b/src/generators/silence.rs
@@ -3,6 +3,9 @@ pub mod const_source {
 
     use crate::source::SeekError;
     use crate::ConstSource;
+    use crate::Sample;
+
+    use dasp_sample::Sample as _;
 
     /// A source producing an infinite amount of Silence. Like all generators you
     /// probably want to limit the duration of this source.
@@ -52,7 +55,7 @@ pub mod const_source {
         type Item = crate::Sample;
 
         fn next(&mut self) -> Option<Self::Item> {
-            Some(0.0)
+            Some(Sample::EQUILIBRIUM)
         }
 
         fn size_hint(&self) -> (usize, Option<usize>) {

--- a/src/generators/silence.rs
+++ b/src/generators/silence.rs
@@ -1,0 +1,54 @@
+pub mod const_source {
+    use crate::ConstSource;
+
+    /// A source producing an infinite amount of Silence. Like all generators you
+    /// probably want to limit the duration of this source.
+    ///
+    /// # Example
+    /// Padding a [`TakeDuration`](crate::effects::const_source::TakeDuration) to
+    /// guarantee an exact playtime:
+    ///
+    /// ```rust,no_run
+    /// # use std::time::Duration;
+    /// # use rodio::nz;
+    /// # use rodio::generators::const_source::Silence;
+    /// # use rodio::ConstSource;
+    /// # let unknown_length = Silence::new();
+    /// let silence: Silence<44100> = Silence::new();
+    /// let two_seconds = unknown_length
+    ///     .chain_source(silence)
+    ///     .take_duration(Duration::from_secs(2));
+    /// ```
+    pub struct Silence<const SR: u32>;
+
+    impl<const SR: u32> Silence<SR> {
+        /// Create an infinite silence
+        pub fn new() -> Self {
+            Self
+        }
+    }
+    
+    impl<const SR: u32> Default for Silence<SR> {
+        fn default() -> Self {
+            Self
+        }
+    }
+
+    impl<const SR: u32> ConstSource<SR, 1> for Silence<SR> {
+        fn total_duration(&self) -> Option<std::time::Duration> {
+            None
+        }
+    }
+
+    impl<const SR: u32> Iterator for Silence<SR> {
+        type Item = crate::Sample;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            Some(0.0)
+        }
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            (usize::MAX, None)
+        }
+    }
+}

--- a/src/generators/silence.rs
+++ b/src/generators/silence.rs
@@ -1,11 +1,14 @@
 pub mod const_source {
+    use std::time::Duration;
+
+    use crate::source::SeekError;
     use crate::ConstSource;
 
     /// A source producing an infinite amount of Silence. Like all generators you
     /// probably want to limit the duration of this source.
     ///
     /// # Example
-    /// Padding a [`TakeDuration`](crate::effects::const_source::TakeDuration) to
+    /// Padding a [`TakeDuration`](crate::const_source::Placeholder) to
     /// guarantee an exact playtime:
     ///
     /// ```rust,no_run
@@ -27,7 +30,7 @@ pub mod const_source {
             Self
         }
     }
-    
+
     impl<const SR: u32> Default for Silence<SR> {
         fn default() -> Self {
             Self
@@ -37,6 +40,11 @@ pub mod const_source {
     impl<const SR: u32> ConstSource<SR, 1> for Silence<SR> {
         fn total_duration(&self) -> Option<std::time::Duration> {
             None
+        }
+
+        /// This does nothing since all silence is equal :3
+        fn try_seek(&mut self, _: Duration) -> Result<(), SeekError> {
+            Ok(())
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,6 +228,8 @@ pub mod conversions;
 pub mod decoder;
 #[cfg(feature = "experimental")]
 pub mod fixed_source;
+pub mod const_source;
+
 pub mod math;
 #[cfg(feature = "recording")]
 /// Microphone input support for audio recording.
@@ -241,6 +243,7 @@ pub use crate::common::{BitDepth, ChannelCount, Float, Sample, SampleRate, DEFAU
 pub use crate::decoder::Decoder;
 #[cfg(feature = "experimental")]
 pub use crate::fixed_source::FixedSource;
+pub use crate::const_source::ConstSource;
 pub use crate::player::Player;
 pub use crate::source::Source;
 pub use crate::spatial_player::SpatialPlayer;
@@ -250,3 +253,5 @@ pub use crate::stream::{play, DeviceSinkBuilder, DeviceSinkError, MixerDeviceSin
 pub use crate::wav_output::wav_to_file;
 #[cfg(feature = "wav_output")]
 pub use crate::wav_output::wav_to_writer;
+
+pub use Source as DynamicSource;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,6 +230,7 @@ pub mod decoder;
 pub mod fixed_source;
 pub mod const_source;
 
+pub mod generators;
 pub mod math;
 #[cfg(feature = "recording")]
 /// Microphone input support for audio recording.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,11 +224,11 @@ pub mod stream;
 mod wav_output;
 
 pub mod buffer;
+pub mod const_source;
 pub mod conversions;
 pub mod decoder;
 #[cfg(feature = "experimental")]
 pub mod fixed_source;
-pub mod const_source;
 
 pub mod generators;
 pub mod math;
@@ -241,10 +241,10 @@ pub mod source;
 pub mod static_buffer;
 
 pub use crate::common::{BitDepth, ChannelCount, Float, Sample, SampleRate, DEFAULT_SAMPLE_RATE};
+pub use crate::const_source::ConstSource;
 pub use crate::decoder::Decoder;
 #[cfg(feature = "experimental")]
 pub use crate::fixed_source::FixedSource;
-pub use crate::const_source::ConstSource;
 pub use crate::player::Player;
 pub use crate::source::Source;
 pub use crate::spatial_player::SpatialPlayer;

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -217,9 +217,7 @@ pub trait Source: Iterator<Item = Sample> {
     /// Returns the rate at which the source should be played. In number of samples per second.
     fn sample_rate(&self) -> SampleRate;
 
-    /// Returns the total duration of this source, if known.
-    ///
-    /// `None` indicates at the same time "infinite" or "unknown".
+    #[doc = include_str!("../docs/total_duration.md")]
     fn total_duration(&self) -> Option<Duration>;
 
     /// Stores the source in a buffer in addition to returning it. This iterator can be cloned.

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -695,23 +695,8 @@ pub trait Source: Iterator<Item = Sample> {
         SampleRateConverter::new(self, target_rate, config)
     }
 
-    /// Attempts to seek to a given position in the current source.
-    ///
-    /// As long as the duration of the source is known, seek is guaranteed to saturate
-    /// at the end of the source. For example given a source that reports a total duration
-    /// of 42 seconds calling `try_seek()` with 60 seconds as argument will seek to
-    /// 42 seconds.
-    ///
-    /// # Errors
-    /// This function will return [`SeekError::NotSupported`] if one of the underlying
-    /// sources does not support seeking.
-    ///
-    /// It will return an error if an implementation ran
-    /// into one during the seek.
-    ///
-    /// Seeking beyond the end of a source might return an error if the total duration of
-    /// the source is not known.
     #[allow(unused_variables)]
+    #[doc = include_str!("../docs/try_seek.md")]
     fn try_seek(&mut self, pos: Duration) -> Result<(), SeekError> {
         Err(SeekError::NotSupported {
             underlying_source: std::any::type_name::<Self>(),


### PR DESCRIPTION
supersedes #902 

Tracking issue: https://github.com/RustAudio/rodio/issues/901

Very minimal still, to get an idea of what this will all look like see: [rodio-experiments](https://github.com/RustAudio/rodio-experiments).

_Implementation notes:_
- I've moved some documentation into md files and `include_str!` those to prevent duplication. We'll be using that even more for the effects.
- For now does not rename Source but do make it available under it's new name via a pub re-export in lib.rs
- There is a placeholder so the example in the docs works