### PR TITLE
Phase2b of audio engine rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `FixedSource` which mirrors `Source` but does not allow the sample rate or
+  channel count to change.
+- Added `ConstSource` which is like `FixedSource` except the sample rate and
+  channel count are fixed at compile time.
 - Added `Skippable::skipped` function to check if the inner source was skipped.
 - All sources now implement `ExactSizeIterator` when their inner source does.
 - All sources now implement `Iterator::size_hint()`.
@@ -21,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Breaking: `Microphone` now implements `FixedSource`
 - Breaking: `Done` now calls a callback instead of decrementing an `Arc<AtomicUsize>`.
 - Updated `cpal` to v0.18.
 - Clarified `Source::current_span_len()` documentation to specify it returns total span length.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -250,7 +250,7 @@ required-features = ["playback", "wav"]
 
 [[example]]
 name = "microphone"
-required-features = ["playback", "recording", "wav_output"]
+required-features = ["playback", "recording"]
 
 [[example]]
 name = "mix_multiple_sources"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 [![Crates.io Downloads](https://img.shields.io/crates/d/rodio.svg)](https://crates.io/crates/rodio)
 [![Build Status](https://github.com/RustAudio/rodio/workflows/CI/badge.svg)](https://github.com/RustAudio/rodio/actions)
 
+> [!WARNING]
+> We are currently rewriting Rodio's core audio engine. The current state should
+> be working but under documented. This is expected to take at least a month. 
+> For the latest unreleased work pre engine rewrite see [this checkout](https://github.com/RustAudio/rodio/tree/c5f1e94290922fe4ee963ce6f85754ea6ba36243)
+
 Rust playback library.
 
 Playback is handled by [cpal](https://github.com/RustAudio/cpal). Format decoding is handled by [Symphonia](https://github.com/pdeljanov/Symphonia) by default, or by optional format-specific decoders:

--- a/README.md
+++ b/README.md
@@ -6,8 +6,11 @@
 
 > [!WARNING]
 > We are currently rewriting Rodio's core audio engine. The current state should
-> be working but under documented. This is expected to take at least a month. 
-> For the latest unreleased work pre engine rewrite see [this checkout](https://github.com/RustAudio/rodio/tree/c5f1e94290922fe4ee963ce6f85754ea6ba36243)
+> be working but under documented. This is expected to take at least a month.
+> For the latest unreleased work pre engine rewrite see [this
+> checkout](https://github.com/RustAudio/rodio/tree/c5f1e94290922fe4ee963ce6f85754ea6ba36243).
+> To follow our progress see the [tracking
+> issue](https://github.com/RustAudio/rodio/issues/901)
 
 Rust playback library.
 

--- a/codebook.toml
+++ b/codebook.toml
@@ -17,5 +17,6 @@ words = [
     "stddev",
     "tpdf",
     "tpdf's",
+    "unsafelessly",
     "voss",
 ]

--- a/examples/microphone.rs
+++ b/examples/microphone.rs
@@ -1,6 +1,6 @@
 use inquire::Select;
 use rodio::microphone::{self, MicrophoneBuilder};
-use rodio::Source;
+use rodio::FixedSource;
 use std::error::Error;
 use std::thread;
 use std::time::Duration;
@@ -22,7 +22,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     println!("Playing the recording");
     let mut output = rodio::DeviceSinkBuilder::open_default_sink()?;
-    output.mixer().add(recording);
+    output.mixer().add(recording.into_dynamic_source());
 
     thread::sleep(Duration::from_secs(5));
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -12,9 +12,8 @@
 //!
 
 use crate::common::{ChannelCount, SampleRate};
-use crate::math::{duration_to_float, NANOS_PER_SEC};
 use crate::source::{SeekError, UniformSourceIterator};
-use crate::{Float, Sample, Source};
+use crate::{Sample, Source};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -25,37 +24,19 @@ pub struct SamplesBuffer {
     pos: usize,
     channels: ChannelCount,
     sample_rate: SampleRate,
-    duration: Duration,
 }
 
 impl SamplesBuffer {
     /// Builds a new `SamplesBuffer`.
-    ///
-    /// # Panics
-    ///
-    /// - Panics if the samples rate is zero.
-    /// - Panics if the length of the buffer is larger than approximately 16 billion elements.
-    ///   This is because the calculation of the duration would overflow.
-    ///
     pub fn new<D>(channels: ChannelCount, sample_rate: SampleRate, data: D) -> Self
     where
         D: Into<Vec<Sample>>,
     {
-        let data: Arc<[Sample]> = data.into().into();
-        let duration_ns = NANOS_PER_SEC.checked_mul(data.len() as u64).unwrap()
-            / sample_rate.get() as u64
-            / channels.get() as u64;
-        let duration = Duration::new(
-            duration_ns / NANOS_PER_SEC,
-            (duration_ns % NANOS_PER_SEC) as u32,
-        );
-
         Self {
-            data,
+            data: data.into().into(),
             pos: 0,
             channels,
             sample_rate,
-            duration,
         }
     }
 
@@ -91,50 +72,11 @@ impl Source for SamplesBuffer {
         self.sample_rate
     }
 
-    #[inline]
-    fn total_duration(&self) -> Option<Duration> {
-        Some(self.duration)
-    }
-
-    /// This jumps in memory till the sample for `pos`.
-    #[inline]
-    fn try_seek(&mut self, pos: Duration) -> Result<(), SeekError> {
-        // This is fast because all the samples are in memory already
-        // and due to the constant sample_rate we can jump to the right
-        // sample directly.
-
-        let curr_channel = self.pos % self.channels().get() as usize;
-        let new_pos = duration_to_float(pos)
-            * self.sample_rate().get() as Float
-            * self.channels().get() as Float;
-        // saturate pos at the end of the source
-        let new_pos = new_pos as usize;
-        let new_pos = new_pos.min(self.data.len());
-
-        // make sure the next sample is for the right channel
-        let new_pos = new_pos.next_multiple_of(self.channels().get() as usize);
-        let new_pos = new_pos - curr_channel;
-
-        self.pos = new_pos;
-        Ok(())
-    }
+    crate::common::source::buffer::source_impl! {}
 }
 
 impl Iterator for SamplesBuffer {
-    type Item = Sample;
-
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        let sample = self.data.get(self.pos)?;
-        self.pos += 1;
-        Some(*sample)
-    }
-
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let remaining = self.data.len() - self.pos;
-        (remaining, Some(remaining))
-    }
+    crate::common::source::buffer::iter_impl! {}
 }
 
 impl ExactSizeIterator for SamplesBuffer {}

--- a/src/common.rs
+++ b/src/common.rs
@@ -3,6 +3,8 @@ use std::num::NonZero;
 
 use crate::math::nz;
 
+pub(crate) mod source;
+
 /// Sample rate (a frame rate or samples per second per channel).
 pub type SampleRate = NonZero<u32>;
 

--- a/src/common/source.rs
+++ b/src/common/source.rs
@@ -18,3 +18,27 @@
 
 pub(crate) mod buffer;
 pub(crate) mod chain;
+
+macro_rules! add_inner_accessors {
+    ($inner:ident) => {
+        /// Get immutable access to the input to this source
+        #[inline]
+        pub fn inner(&self) -> &S {
+            &self.$inner
+        }
+
+        /// Returns a mutable reference to the inner source.
+        #[inline]
+        pub fn inner_mut(&mut self) -> &mut S {
+            &mut self.$inner
+        }
+
+        /// Returns the inner source.
+        #[inline]
+        pub fn into_inner(self) -> S {
+            self.$inner
+        }
+    };
+}
+
+pub(crate) use add_inner_accessors;

--- a/src/common/source.rs
+++ b/src/common/source.rs
@@ -1,0 +1,20 @@
+//! Code shared between source types.
+//!
+//! Since we have three source types there is a lot of code duplication. We
+//! combat that by placing whatever can be shared here.
+//!
+//! This can be:
+//! - shared types like error enums
+//! - shared free functions
+//! - shared members / impl blocks through macro_rules
+//!
+//! # Note
+//! Effects are defined through a macro and do not need this kind of
+//! deduplication
+//!
+//! This modules structure mirrors that of what it deduplicates. For example
+//! the code shared between [fixed_source::chain] and [const_source::chain] is in
+//! common/source/chain.rs
+
+pub(crate) mod buffer;
+pub(crate) mod chain;

--- a/src/common/source.rs
+++ b/src/common/source.rs
@@ -19,21 +19,22 @@
 pub(crate) mod buffer;
 pub(crate) mod chain;
 
+/// TODO(yara) this should become a trait really.
 macro_rules! add_inner_accessors {
     ($inner:ident) => {
-        /// Get immutable access to the input to this source
+        /// placeholder
         #[inline]
         pub fn inner(&self) -> &S {
             &self.$inner
         }
 
-        /// Returns a mutable reference to the inner source.
+        /// placeholder
         #[inline]
         pub fn inner_mut(&mut self) -> &mut S {
             &mut self.$inner
         }
 
-        /// Returns the inner source.
+        /// placeholder
         #[inline]
         pub fn into_inner(self) -> S {
             self.$inner

--- a/src/common/source/buffer.rs
+++ b/src/common/source/buffer.rs
@@ -1,0 +1,66 @@
+macro_rules! source_impl {
+    () => {
+        /// # Panics
+        /// If the length of the buffer is larger than approximately 16 billion elements.
+        /// This is because the calculation of the duration would overflow.
+        #[inline]
+        fn total_duration(&self) -> Option<Duration> {
+            use crate::math::NANOS_PER_SEC;
+
+            let duration_ns = NANOS_PER_SEC
+                .checked_mul(self.data.len() as u64)
+                .expect("slices longer then 16 billion elements are not supported")
+                / self.sample_rate().get() as u64
+                / self.channels().get() as u64;
+            let duration = Duration::new(
+                duration_ns / NANOS_PER_SEC,
+                (duration_ns % NANOS_PER_SEC) as u32,
+            );
+
+            Some(duration)
+        }
+
+        /// This jumps in memory to the sample corresponding to `pos`.
+        #[inline]
+        fn try_seek(&mut self, pos: Duration) -> Result<(), SeekError> {
+            // This is fast because all the samples are in memory already
+            // and due to the constant sample_rate we can jump to the right
+            // sample directly.
+
+            let curr_channel = self.pos % self.channels().get() as usize;
+            let new_pos = crate::math::duration_to_float(pos)
+                * self.sample_rate().get() as crate::Float
+                * self.channels().get() as crate::Float;
+            // saturate pos at the end of the source
+            let new_pos = new_pos as usize;
+            let new_pos = new_pos.min(self.data.len());
+
+            // make sure the next sample is for the right channel
+            let new_pos = new_pos.next_multiple_of(self.channels().get() as usize);
+            let new_pos = new_pos - curr_channel;
+
+            self.pos = new_pos;
+            Ok(())
+        }
+    };
+}
+
+macro_rules! iter_impl {
+    () => {
+        type Item = Sample;
+        #[inline]
+        fn next(&mut self) -> Option<Self::Item> {
+            let sample = self.data.get(self.pos)?;
+            self.pos += 1;
+            Some(*sample)
+        }
+        #[inline]
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            let remaining = self.data.len() - self.pos;
+            (remaining, Some(remaining))
+        }
+    };
+}
+
+pub(crate) use iter_impl;
+pub(crate) use source_impl;

--- a/src/common/source/chain.rs
+++ b/src/common/source/chain.rs
@@ -1,0 +1,94 @@
+use crate::source::SeekError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ChainSeekError {
+    #[error("Could not get duration of first source ({ty}")]
+    NoTotalDurationForFirst { ty: &'static str },
+    #[error("Could not seek in first source")]
+    FailedToSeekInFirst {
+        ty: &'static str,
+        #[source]
+        error: SeekError,
+    },
+    #[error("Could not seek in second source")]
+    FailedToSeekInSecond {
+        ty: &'static str,
+        #[source]
+        error: SeekError,
+    },
+}
+
+macro_rules! source_impl {
+    () => {
+        fn channels(&self) -> crate::ChannelCount {
+            self.first.channels()
+        }
+
+        fn sample_rate(&self) -> crate::SampleRate {
+            self.first.sample_rate()
+        }
+
+        fn total_duration(&self) -> Option<std::time::Duration> {
+            self.first
+                .total_duration()
+                .and_then(|d| self.second.total_duration().map(|d2| d2 + d))
+        }
+
+        fn try_seek(&mut self, pos: std::time::Duration) -> Result<(), crate::source::SeekError> {
+            use crate::source::SeekError;
+            use std::any::type_name_of_val;
+            use std::sync::Arc;
+
+            let Some(first) = self.first.total_duration() else {
+                return Err(ChainSeekError::NoTotalDurationForFirst {
+                    ty: type_name_of_val(&self.first),
+                })
+                .map_err(Arc::new)
+                .map_err(|e| SeekError::Other(e));
+            };
+
+            if pos < first {
+                self.first
+                    .try_seek(pos)
+                    .map_err(|error| ChainSeekError::FailedToSeekInFirst {
+                        ty: type_name_of_val(&self.first),
+                        error,
+                    })
+                    .map_err(Arc::new)
+                    .map_err(|e| SeekError::Other(e))
+            } else {
+                self.second
+                    .try_seek(pos)
+                    .map_err(|error| ChainSeekError::FailedToSeekInSecond {
+                        ty: type_name_of_val(&self.second),
+                        error,
+                    })
+                    .map_err(Arc::new)
+                    .map_err(|e| SeekError::Other(e))
+            }
+        }
+    };
+}
+
+macro_rules! iter_impl {
+    () => {
+        type Item = Sample;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            if self.playing_inner {
+                match self.first.next() {
+                    Some(sample) => Some(sample),
+                    None => {
+                        self.playing_inner = false;
+                        self.second.next()
+                    }
+                }
+            } else {
+                self.second.next()
+            }
+        }
+    };
+}
+
+pub(crate) use iter_impl;
+pub(crate) use source_impl;

--- a/src/const_source.rs
+++ b/src/const_source.rs
@@ -58,6 +58,14 @@ pub trait ConstSource<const SR: u32, const CH: u16>: Iterator<Item = Sample> {
         IntoDynamicSource { inner: self }
     }
 
+    #[doc = include_str!("docs/collect_into_buffer.md")]
+    fn collect_into_buffer(self) -> SamplesBuffer<SR, CH>
+    where
+        Self: Sized,
+    {
+        SamplesBuffer::new(self.collect::<Vec<_>>())
+    }
+
     /// Add another source to play directly after this one.
     ///
     /// # Example

--- a/src/const_source.rs
+++ b/src/const_source.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 
 use crate::source::SeekError;
 use crate::ChannelCount;
+use crate::FixedSource;
 use crate::Sample;
 use crate::SampleRate;
 use crate::Source as DynamicSource; // Source will (probably) be renamed to this later
@@ -58,6 +59,33 @@ pub trait ConstSource<const SR: u32, const CH: u16>: Iterator<Item = Sample> {
         IntoDynamicSource { inner: self }
     }
 
+     /// Use this const source as if it's a fixed source which is generally
+     /// easier to work with since it drops the generics. The same effects are
+     /// available for both.
+     ///
+     /// # Example
+     ///
+     /// ```rust
+     /// # struct CustomEffect<S: FixedSource>(S);
+     /// # use rodio::{FixedSource, ConstSource};
+     /// # use rodio::generators::const_source;
+     ///
+     /// // Note custom effect can only wrap a FixedSource
+     /// fn apply_custom_effect<S: FixedSource>(source: S) -> CustomEffect<S> {
+     ///     CustomEffect(source)
+     /// }
+     ///
+     /// let source = const_source::Silence::<44100>::new();
+     /// let source = source.into_fixed_source();
+     /// apply_custom_effect(source);
+     /// ```
+     fn into_fixed_source(self) -> IntoFixedSource<SR, CH, Self>
+     where
+         Self: Sized,
+     {
+         IntoFixedSource { inner: self }
+     }
+ 
     #[doc = include_str!("docs/collect_into_buffer.md")]
     fn collect_into_buffer(self) -> SamplesBuffer<SR, CH>
     where
@@ -144,6 +172,44 @@ where
     }
 
     fn total_duration(&self) -> Option<std::time::Duration> {
+        self.inner.total_duration()
+    }
+}
+
+/// A `FixedSource` converted from a `ConstSource`. Useful for passing to APIs
+/// that do not accept a `ConstSource`.
+#[derive(Clone)]
+pub struct IntoFixedSource<const SR: u32, const CH: u16, S>
+where
+    S: ConstSource<SR, CH>,
+{
+    inner: S,
+}
+
+impl<const SR: u32, const CH: u16, S> Iterator for IntoFixedSource<SR, CH, S>
+where
+    S: ConstSource<SR, CH>,
+{
+    type Item = Sample;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+}
+
+impl<const SR: u32, const CH: u16, S> FixedSource for IntoFixedSource<SR, CH, S>
+where
+    S: ConstSource<SR, CH>,
+{
+    fn channels(&self) -> ChannelCount {
+        const { NonZeroU16::new(CH).expect("channel count must be larger then zero") }
+    }
+
+    fn sample_rate(&self) -> SampleRate {
+        const { NonZeroU32::new(SR).expect("sample rate must be larger then zero") }
+    }
+
+    fn total_duration(&self) -> Option<Duration> {
         self.inner.total_duration()
     }
 }

--- a/src/const_source.rs
+++ b/src/const_source.rs
@@ -26,6 +26,7 @@ mod conversions;
 pub use buffer::SamplesBuffer;
 pub use chain::SourceChain;
 pub use conversions::channel_count::ChannelConvertor;
+pub use conversions::sample_rate::SampleRateConvertor;
 
 /// A source which sample rate and channel count are fixed at compile time.
 pub trait ConstSource<const SR: u32, const CH: u16>: Iterator<Item = Sample> {
@@ -47,6 +48,17 @@ pub trait ConstSource<const SR: u32, const CH: u16>: Iterator<Item = Sample> {
         Err(SeekError::NotSupported {
             underlying_source: std::any::type_name::<Self>(),
         })
+    }
+
+    /// Convert from `SR` (the current sample rate) to `SR_OUT`.
+    ///
+    /// Though the defaults cover most use-cases you can configure
+    /// the resampler using [`with_config`](SampleRateConvertor::with_config).
+    fn with_sample_rate<const SR_OUT: u32>(self) -> SampleRateConvertor<SR, SR_OUT, CH, Self>
+    where
+        Self: Sized,
+    {
+        SampleRateConvertor::new(self)
     }
 
     /// Convert from the current channel count to `CH_OUT`.

--- a/src/const_source.rs
+++ b/src/const_source.rs
@@ -58,33 +58,33 @@ pub trait ConstSource<const SR: u32, const CH: u16>: Iterator<Item = Sample> {
         IntoDynamicSource { inner: self }
     }
 
-     /// Use this const source as if it's a fixed source which is generally
-     /// easier to work with since it drops the generics. The same effects are
-     /// available for both.
-     ///
-     /// # Example
-     ///
-     /// ```rust
-     /// # struct CustomEffect<S: FixedSource>(S);
-     /// # use rodio::{FixedSource, ConstSource};
-     /// # use rodio::generators::const_source;
-     ///
-     /// // Note custom effect can only wrap a FixedSource
-     /// fn apply_custom_effect<S: FixedSource>(source: S) -> CustomEffect<S> {
-     ///     CustomEffect(source)
-     /// }
-     ///
-     /// let source = const_source::Silence::<44100>::new();
-     /// let source = source.into_fixed_source();
-     /// apply_custom_effect(source);
-     /// ```
-     fn into_fixed_source(self) -> IntoFixedSource<SR, CH, Self>
-     where
-         Self: Sized,
-     {
-         IntoFixedSource { inner: self }
-     }
- 
+    /// Use this const source as if it's a fixed source which is generally
+    /// easier to work with since it drops the generics. The same effects are
+    /// available for both.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # struct CustomEffect<S: FixedSource>(S);
+    /// # use rodio::{FixedSource, ConstSource};
+    /// # use rodio::generators::const_source;
+    ///
+    /// // Note custom effect can only wrap a FixedSource
+    /// fn apply_custom_effect<S: FixedSource>(source: S) -> CustomEffect<S> {
+    ///     CustomEffect(source)
+    /// }
+    ///
+    /// let source = const_source::Silence::<44100>::new();
+    /// let source = source.into_fixed_source();
+    /// apply_custom_effect(source);
+    /// ```
+    fn into_fixed_source(self) -> IntoFixedSource<SR, CH, Self>
+    where
+        Self: Sized,
+    {
+        IntoFixedSource { inner: self }
+    }
+
     #[doc = include_str!("docs/collect_into_buffer.md")]
     fn collect_into_buffer(self) -> SamplesBuffer<SR, CH>
     where

--- a/src/const_source.rs
+++ b/src/const_source.rs
@@ -21,9 +21,11 @@ use crate::Source as DynamicSource; // Source will (probably) be renamed to this
 
 mod buffer;
 mod chain;
+mod conversions;
 
 pub use buffer::SamplesBuffer;
 pub use chain::SourceChain;
+pub use conversions::channel_count::ChannelConvertor;
 
 /// A source which sample rate and channel count are fixed at compile time.
 pub trait ConstSource<const SR: u32, const CH: u16>: Iterator<Item = Sample> {
@@ -45,6 +47,14 @@ pub trait ConstSource<const SR: u32, const CH: u16>: Iterator<Item = Sample> {
         Err(SeekError::NotSupported {
             underlying_source: std::any::type_name::<Self>(),
         })
+    }
+
+    /// Convert from the current channel count to `CH_OUT`.
+    fn with_channel_count<const CH_OUT: u16>(self) -> ChannelConvertor<SR, CH, CH_OUT, Self>
+    where
+        Self: Sized,
+    {
+        ChannelConvertor::new(self)
     }
 
     /// Use this const source as if it's a dynamic source. You generally do not

--- a/src/const_source.rs
+++ b/src/const_source.rs
@@ -1,4 +1,4 @@
-//! A sound source that has it's sample rate and number of channels fixed at compile time. 
+//! A sound source that has it's sample rate and number of channels fixed at compile time.
 //! Some practical examples:
 //! - An effect performed by a neural network trained on a specific channel
 //!   count and sample rate
@@ -13,16 +13,17 @@ use std::num::NonZeroU16;
 use std::num::NonZeroU32;
 use std::time::Duration;
 
+use crate::source::SeekError;
 use crate::ChannelCount;
 use crate::Sample;
 use crate::SampleRate;
-use crate::Source as DynamicSource; // will be renamed to this upstream
+use crate::Source as DynamicSource; // Source will (probably) be renamed to this later
 
-mod chain;
 mod buffer;
+mod chain;
 
-pub use chain::SourceChain;
 pub use buffer::SamplesBuffer;
+pub use chain::SourceChain;
 
 /// A source which sample rate and channel count are fixed at compile time.
 pub trait ConstSource<const SR: u32, const CH: u16>: Iterator<Item = Sample> {
@@ -37,6 +38,14 @@ pub trait ConstSource<const SR: u32, const CH: u16>: Iterator<Item = Sample> {
 
     #[doc = include_str!("docs/total_duration.md")]
     fn total_duration(&self) -> Option<Duration>;
+
+    #[allow(unused_variables)]
+    #[doc = include_str!("docs/try_seek.md")]
+    fn try_seek(&mut self, pos: Duration) -> Result<(), SeekError> {
+        Err(SeekError::NotSupported {
+            underlying_source: std::any::type_name::<Self>(),
+        })
+    }
 
     /// Use this const source as if it's a dynamic source. You generally do not
     /// want to do this since there are less effects for dynamic sources and

--- a/src/const_source.rs
+++ b/src/const_source.rs
@@ -8,7 +8,6 @@
 //! A const pipeline _may_ also be optimized more by the compiler as many
 //! branches are known at compile time, like when converting from one channel
 //! count to another.
-use std::marker::PhantomData;
 use std::num::NonZeroU16;
 use std::num::NonZeroU32;
 use std::time::Duration;
@@ -131,7 +130,7 @@ pub struct Placeholder<const SR: u32, const CH: u16, S>
 where
     S: ConstSource<SR, CH>,
 {
-    inner: PhantomData<S>,
+    inner: std::marker::PhantomData<S>,
 }
 
 /// A `DynamicSource` converted from a `ConstSource`. Useful for passing to old

--- a/src/const_source.rs
+++ b/src/const_source.rs
@@ -1,0 +1,132 @@
+//! A sound source that has it's sample rate and number of channels fixed at compile time. 
+//! Some practical examples:
+//! - An effect performed by a neural network trained on a specific channel
+//!   count and sample rate
+//! - A custom audio source streaming in at a pre-determined fixed sample rate.
+//!   We use this in our VoIP example.
+//!
+//! A const pipeline _may_ also be optimized more by the compiler as many
+//! branches are known at compile time, like when converting from one channel
+//! count to another.
+use std::marker::PhantomData;
+use std::num::NonZeroU16;
+use std::num::NonZeroU32;
+use std::time::Duration;
+
+use crate::ChannelCount;
+use crate::Sample;
+use crate::SampleRate;
+use crate::Source as DynamicSource; // will be renamed to this upstream
+
+mod chain;
+mod buffer;
+
+pub use chain::SourceChain;
+pub use buffer::SamplesBuffer;
+
+/// A source which sample rate and channel count are fixed at compile time.
+pub trait ConstSource<const SR: u32, const CH: u16>: Iterator<Item = Sample> {
+    /// Returns the sample rate which is the first generic (SR) of a ConstSource
+    fn sample_rate(&self) -> SampleRate {
+        const { NonZeroU32::new(SR).expect("SampleRate must be > 0") }
+    }
+    /// Returns the channel count which is the second generic (CH) of a ConstSource
+    fn channels(&self) -> ChannelCount {
+        const { NonZeroU16::new(CH).expect("Channel count must be > 0") }
+    }
+
+    #[doc = include_str!("docs/total_duration.md")]
+    fn total_duration(&self) -> Option<Duration>;
+
+    /// Use this const source as if it's a dynamic source. You generally do not
+    /// want to do this since there are less effects for dynamic sources and
+    /// those that are available can not be implemented as efficient. This is
+    /// therefore purely provided for backwards compatibility.
+    fn into_dynamic_source(self) -> IntoDynamicSource<SR, CH, Self>
+    where
+        Self: Sized,
+    {
+        IntoDynamicSource { inner: self }
+    }
+
+    /// Add another source to play directly after this one.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use rodio::const_source::ConstSource;
+    /// # use rodio::const_source::SamplesBuffer;
+    /// let preamble = SamplesBuffer::<44100, 1>::new([1.0, 1.0]);
+    /// let signal = SamplesBuffer::<44100, 1>::new([2.0, 2.0]);
+    ///
+    /// let mixed = preamble.chain_source(signal);
+    /// assert_eq!(mixed.collect::<Vec<_>>(), vec![1.0,1.0,2.0,2.0])
+    /// ```
+    fn chain_source<S>(self, next: S) -> SourceChain<SR, CH, Self, S>
+    where
+        Self: Sized,
+        S: ConstSource<SR, CH>,
+    {
+        SourceChain::new(self, next)
+    }
+
+    // placeholder until effects land (need this for some examples)
+    #[allow(missing_docs)]
+    fn take_duration(self, _duration: Duration) -> Placeholder<SR, CH, Self>
+    where
+        Self: Sized,
+    {
+        todo!()
+    }
+}
+
+// placeholder until effects land (need this for some examples)
+#[allow(missing_docs)]
+pub struct Placeholder<const SR: u32, const CH: u16, S>
+where
+    S: ConstSource<SR, CH>,
+{
+    inner: PhantomData<S>,
+}
+
+/// A `DynamicSource` converted from a `ConstSource`. Useful for passing to old
+/// APIs that do not accept a `ConstSource` nor `FixedSource`.
+#[derive(Clone)]
+pub struct IntoDynamicSource<const SR: u32, const CH: u16, S>
+where
+    S: ConstSource<SR, CH>,
+{
+    inner: S,
+}
+
+impl<const SR: u32, const CH: u16, S> Iterator for IntoDynamicSource<SR, CH, S>
+where
+    S: ConstSource<SR, CH>,
+{
+    type Item = Sample;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+}
+
+impl<const SR: u32, const CH: u16, S> DynamicSource for IntoDynamicSource<SR, CH, S>
+where
+    S: ConstSource<SR, CH>,
+{
+    fn current_span_len(&self) -> Option<usize> {
+        None
+    }
+
+    fn channels(&self) -> ChannelCount {
+        const { NonZeroU16::new(CH).expect("channel count must be larger then zero") }
+    }
+
+    fn sample_rate(&self) -> SampleRate {
+        const { NonZeroU32::new(SR).expect("sample rate must be larger then zero") }
+    }
+
+    fn total_duration(&self) -> Option<std::time::Duration> {
+        self.inner.total_duration()
+    }
+}

--- a/src/const_source/buffer.rs
+++ b/src/const_source/buffer.rs
@@ -1,0 +1,80 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::Sample;
+use crate::ConstSource;
+
+/// A buffer of samples treated as a source.
+#[derive(Debug, Clone)]
+pub struct SamplesBuffer<const SR: u32, const CH: u16> {
+    data: Arc<[Sample]>,
+    pos: usize,
+}
+
+impl<const SR: u32, const CH: u16> SamplesBuffer<SR, CH> {
+    /// Builds a new `SamplesBuffer`.
+    ///
+    /// Note any call to total_duration will panic if the buffer is larger then
+    /// 16 billion elements.
+    pub fn new<D>(data: D) -> SamplesBuffer<SR, CH>
+    where
+        D: Into<Vec<Sample>>,
+    {
+        const { assert!(SR > 0) };
+        const { assert!(CH > 0) };
+
+        SamplesBuffer {
+            data: data.into().into(),
+            pos: 0,
+        }
+    }
+}
+
+impl<const SR: u32, const CH: u16> ConstSource<SR, CH> for SamplesBuffer<SR, CH> {
+    /// # Panics
+    /// If the length of the buffer is larger than approximately 16 billion elements.
+    /// This is because the calculation of the duration would overflow.
+    #[inline]
+    fn total_duration(&self) -> Option<Duration> {
+        let duration_ns = 1_000_000_000u64
+            .checked_mul(self.data.len() as u64)
+            .unwrap()
+            / SR as u64
+            / CH as u64;
+        Some(Duration::new(
+            duration_ns / 1_000_000_000,
+            (duration_ns % 1_000_000_000) as u32,
+        ))
+    }
+    // /// This jumps in memory till the sample for `pos`.
+    // #[inline]
+    // fn try_seek(&mut self, pos: Duration) -> Result<(), SeekError> {
+    //     // This is fast because all the samples are in memory already
+    //     // and due to the constant sample_rate we can jump to the right
+    //     // sample directly.
+    //     let curr_channel = self.pos % self.channels() as usize;
+    //     let new_pos = pos.as_secs_f32() * self.sample_rate() as f32 * self.channels() as f32;
+    //     // saturate pos at the end of the source
+    //     let new_pos = new_pos as usize;
+    //     let new_pos = new_pos.min(self.data.len());
+    //     // make sure the next sample is for the right channel
+    //     let new_pos = new_pos.next_multiple_of(self.channels() as usize);
+    //     let new_pos = new_pos - curr_channel;
+    //     self.pos = new_pos;
+    //     Ok(())
+    // }
+}
+
+impl<const SR: u32, const CH: u16> Iterator for SamplesBuffer<SR, CH> {
+    type Item = Sample;
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let sample = self.data.get(self.pos)?;
+        self.pos += 1;
+        Some(*sample)
+    }
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.data.len(), Some(self.data.len()))
+    }
+}

--- a/src/const_source/buffer.rs
+++ b/src/const_source/buffer.rs
@@ -32,51 +32,9 @@ impl<const SR: u32, const CH: u16> SamplesBuffer<SR, CH> {
 }
 
 impl<const SR: u32, const CH: u16> ConstSource<SR, CH> for SamplesBuffer<SR, CH> {
-    /// # Panics
-    /// If the length of the buffer is larger than approximately 16 billion elements.
-    /// This is because the calculation of the duration would overflow.
-    #[inline]
-    fn total_duration(&self) -> Option<Duration> {
-        let duration_ns = 1_000_000_000u64
-            .checked_mul(self.data.len() as u64)
-            .unwrap()
-            / SR as u64
-            / CH as u64;
-        Some(Duration::new(
-            duration_ns / 1_000_000_000,
-            (duration_ns % 1_000_000_000) as u32,
-        ))
-    }
-    /// This jumps in memory till the sample for `pos`.
-    #[inline]
-    fn try_seek(&mut self, pos: Duration) -> Result<(), SeekError> {
-        // This is fast because all the samples are in memory already
-        // and due to the constant sample_rate we can jump to the right
-        // sample directly.
-        let curr_channel = self.pos % self.channels().get() as usize;
-        let new_pos =
-            pos.as_secs_f32() * self.sample_rate().get() as f32 * self.channels().get() as f32;
-        // saturate pos at the end of the source
-        let new_pos = new_pos as usize;
-        let new_pos = new_pos.min(self.data.len());
-        // make sure the next sample is for the right channel
-        let new_pos = new_pos.next_multiple_of(self.channels().get() as usize);
-        let new_pos = new_pos - curr_channel;
-        self.pos = new_pos;
-        Ok(())
-    }
+    crate::common::source::buffer::source_impl! {}
 }
 
 impl<const SR: u32, const CH: u16> Iterator for SamplesBuffer<SR, CH> {
-    type Item = Sample;
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        let sample = self.data.get(self.pos)?;
-        self.pos += 1;
-        Some(*sample)
-    }
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.data.len(), Some(self.data.len()))
-    }
+    crate::common::source::buffer::iter_impl! {}
 }

--- a/src/const_source/buffer.rs
+++ b/src/const_source/buffer.rs
@@ -1,8 +1,9 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::Sample;
+use crate::source::SeekError;
 use crate::ConstSource;
+use crate::Sample;
 
 /// A buffer of samples treated as a source.
 #[derive(Debug, Clone)]
@@ -46,23 +47,24 @@ impl<const SR: u32, const CH: u16> ConstSource<SR, CH> for SamplesBuffer<SR, CH>
             (duration_ns % 1_000_000_000) as u32,
         ))
     }
-    // /// This jumps in memory till the sample for `pos`.
-    // #[inline]
-    // fn try_seek(&mut self, pos: Duration) -> Result<(), SeekError> {
-    //     // This is fast because all the samples are in memory already
-    //     // and due to the constant sample_rate we can jump to the right
-    //     // sample directly.
-    //     let curr_channel = self.pos % self.channels() as usize;
-    //     let new_pos = pos.as_secs_f32() * self.sample_rate() as f32 * self.channels() as f32;
-    //     // saturate pos at the end of the source
-    //     let new_pos = new_pos as usize;
-    //     let new_pos = new_pos.min(self.data.len());
-    //     // make sure the next sample is for the right channel
-    //     let new_pos = new_pos.next_multiple_of(self.channels() as usize);
-    //     let new_pos = new_pos - curr_channel;
-    //     self.pos = new_pos;
-    //     Ok(())
-    // }
+    /// This jumps in memory till the sample for `pos`.
+    #[inline]
+    fn try_seek(&mut self, pos: Duration) -> Result<(), SeekError> {
+        // This is fast because all the samples are in memory already
+        // and due to the constant sample_rate we can jump to the right
+        // sample directly.
+        let curr_channel = self.pos % self.channels().get() as usize;
+        let new_pos =
+            pos.as_secs_f32() * self.sample_rate().get() as f32 * self.channels().get() as f32;
+        // saturate pos at the end of the source
+        let new_pos = new_pos as usize;
+        let new_pos = new_pos.min(self.data.len());
+        // make sure the next sample is for the right channel
+        let new_pos = new_pos.next_multiple_of(self.channels().get() as usize);
+        let new_pos = new_pos - curr_channel;
+        self.pos = new_pos;
+        Ok(())
+    }
 }
 
 impl<const SR: u32, const CH: u16> Iterator for SamplesBuffer<SR, CH> {

--- a/src/const_source/chain.rs
+++ b/src/const_source/chain.rs
@@ -1,7 +1,3 @@
-use std::any::type_name_of_val;
-use std::sync::Arc;
-
-use crate::source::SeekError;
 use crate::ConstSource;
 use crate::Sample;
 
@@ -23,82 +19,17 @@ impl<const SR: u32, const CH: u16, S1: ConstSource<SR, CH>, S2: ConstSource<SR, 
             playing_inner: true,
         }
     }
-
-    fn try_seek_inner(&mut self, pos: std::time::Duration) -> Result<(), ChainSeekError> {
-        let Some(first) = self.first.total_duration() else {
-            return Err(ChainSeekError::NoTotalDurationForFirst {
-                ty: type_name_of_val(&self.first),
-            });
-        };
-
-        if pos < first {
-            self.first
-                .try_seek(pos)
-                .map_err(|error| ChainSeekError::FailedToSeekInFirst {
-                    ty: type_name_of_val(&self.first),
-                    error,
-                })
-        } else {
-            self.second
-                .try_seek(pos)
-                .map_err(|error| ChainSeekError::FailedToSeekInSecond {
-                    ty: type_name_of_val(&self.second),
-                    error,
-                })
-        }
-    }
 }
 
-#[derive(Debug, thiserror::Error)]
-pub enum ChainSeekError {
-    #[error("Could not get duration of first source ({ty}")]
-    NoTotalDurationForFirst { ty: &'static str },
-    #[error("Could not seek in first source")]
-    FailedToSeekInFirst {
-        ty: &'static str,
-        #[source]
-        error: SeekError,
-    },
-    #[error("Could not seek in second source")]
-    FailedToSeekInSecond {
-        ty: &'static str,
-        #[source]
-        error: SeekError,
-    },
-}
-
+pub use crate::common::source::chain::ChainSeekError;
 impl<const SR: u32, const CH: u16, S1: ConstSource<SR, CH>, S2: ConstSource<SR, CH>>
     ConstSource<SR, CH> for SourceChain<SR, CH, S1, S2>
 {
-    fn total_duration(&self) -> Option<std::time::Duration> {
-        self.first
-            .total_duration()
-            .and_then(|d| self.second.total_duration().map(|d2| d2 + d))
-    }
-
-    fn try_seek(&mut self, pos: std::time::Duration) -> Result<(), SeekError> {
-        self.try_seek_inner(pos)
-            .map_err(Arc::new)
-            .map_err(|e| SeekError::Other(e))
-    }
+    crate::common::source::chain::source_impl! {}
 }
 
 impl<const SR: u32, const CH: u16, S1: ConstSource<SR, CH>, S2: ConstSource<SR, CH>> Iterator
     for SourceChain<SR, CH, S1, S2>
 {
-    type Item = Sample;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.playing_inner {
-            match self.first.next() {
-                Some(sample) => Some(sample),
-                None => {
-                    self.playing_inner = false;
-                    self.second.next()
-                }
-            }
-        } else {
-            self.second.next()
-        }
-    }
+    crate::common::source::chain::iter_impl! {}
 }

--- a/src/const_source/chain.rs
+++ b/src/const_source/chain.rs
@@ -1,0 +1,52 @@
+use crate::ConstSource;
+use crate::Sample;
+
+/// Two chained sources, the one played after the other.
+#[derive(Clone)]
+pub struct SourceChain<const SR: u32, const CH: u16, S1, S2> {
+    inner: S1,
+    next: S2,
+    playing_inner: bool,
+}
+
+impl<const SR: u32, const CH: u16, S1: ConstSource<SR, CH>, S2: ConstSource<SR, CH>>
+    SourceChain<SR, CH, S1, S2>
+{
+    pub(crate) fn new(s1: S1, s2: S2) -> Self {
+        SourceChain {
+            inner: s1,
+            next: s2,
+            playing_inner: true,
+        }
+    }
+}
+
+impl<const SR: u32, const CH: u16, S1: ConstSource<SR, CH>, S2: ConstSource<SR, CH>>
+    ConstSource<SR, CH> for SourceChain<SR, CH, S1, S2>
+{
+    fn total_duration(&self) -> Option<std::time::Duration> {
+        self.inner
+            .total_duration()
+            .and_then(|d| self.next.total_duration().map(|d2| d2 + d))
+    }
+}
+
+impl<const SR: u32, const CH: u16, S1: ConstSource<SR, CH>, S2: ConstSource<SR, CH>> Iterator
+    for SourceChain<SR, CH, S1, S2>
+{
+    type Item = Sample;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.playing_inner {
+            match self.inner.next() {
+                Some(sample) => Some(sample),
+                None => {
+                    self.playing_inner = false;
+                    self.next.next()
+                }
+            }
+        } else {
+            self.next.next()
+        }
+    }
+}

--- a/src/const_source/chain.rs
+++ b/src/const_source/chain.rs
@@ -1,11 +1,15 @@
+use std::any::type_name_of_val;
+use std::sync::Arc;
+
+use crate::source::SeekError;
 use crate::ConstSource;
 use crate::Sample;
 
 /// Two chained sources, the one played after the other.
 #[derive(Clone)]
 pub struct SourceChain<const SR: u32, const CH: u16, S1, S2> {
-    inner: S1,
-    next: S2,
+    first: S1,
+    second: S2,
     playing_inner: bool,
 }
 
@@ -14,20 +18,68 @@ impl<const SR: u32, const CH: u16, S1: ConstSource<SR, CH>, S2: ConstSource<SR, 
 {
     pub(crate) fn new(s1: S1, s2: S2) -> Self {
         SourceChain {
-            inner: s1,
-            next: s2,
+            first: s1,
+            second: s2,
             playing_inner: true,
         }
     }
+
+    fn try_seek_inner(&mut self, pos: std::time::Duration) -> Result<(), ChainSeekError> {
+        let Some(first) = self.first.total_duration() else {
+            return Err(ChainSeekError::NoTotalDurationForFirst {
+                ty: type_name_of_val(&self.first),
+            });
+        };
+
+        if pos < first {
+            self.first
+                .try_seek(pos)
+                .map_err(|error| ChainSeekError::FailedToSeekInFirst {
+                    ty: type_name_of_val(&self.first),
+                    error,
+                })
+        } else {
+            self.second
+                .try_seek(pos)
+                .map_err(|error| ChainSeekError::FailedToSeekInSecond {
+                    ty: type_name_of_val(&self.second),
+                    error,
+                })
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ChainSeekError {
+    #[error("Could not get duration of first source ({ty}")]
+    NoTotalDurationForFirst { ty: &'static str },
+    #[error("Could not seek in first source")]
+    FailedToSeekInFirst {
+        ty: &'static str,
+        #[source]
+        error: SeekError,
+    },
+    #[error("Could not seek in second source")]
+    FailedToSeekInSecond {
+        ty: &'static str,
+        #[source]
+        error: SeekError,
+    },
 }
 
 impl<const SR: u32, const CH: u16, S1: ConstSource<SR, CH>, S2: ConstSource<SR, CH>>
     ConstSource<SR, CH> for SourceChain<SR, CH, S1, S2>
 {
     fn total_duration(&self) -> Option<std::time::Duration> {
-        self.inner
+        self.first
             .total_duration()
-            .and_then(|d| self.next.total_duration().map(|d2| d2 + d))
+            .and_then(|d| self.second.total_duration().map(|d2| d2 + d))
+    }
+
+    fn try_seek(&mut self, pos: std::time::Duration) -> Result<(), SeekError> {
+        self.try_seek_inner(pos)
+            .map_err(Arc::new)
+            .map_err(|e| SeekError::Other(e))
     }
 }
 
@@ -38,15 +90,15 @@ impl<const SR: u32, const CH: u16, S1: ConstSource<SR, CH>, S2: ConstSource<SR, 
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.playing_inner {
-            match self.inner.next() {
+            match self.first.next() {
                 Some(sample) => Some(sample),
                 None => {
                     self.playing_inner = false;
-                    self.next.next()
+                    self.second.next()
                 }
             }
         } else {
-            self.next.next()
+            self.second.next()
         }
     }
 }

--- a/src/const_source/conversions.rs
+++ b/src/const_source/conversions.rs
@@ -1,0 +1,1 @@
+pub mod channel_count;

--- a/src/const_source/conversions.rs
+++ b/src/const_source/conversions.rs
@@ -1,1 +1,2 @@
 pub mod channel_count;
+pub mod sample_rate;

--- a/src/const_source/conversions/channel_count.rs
+++ b/src/const_source/conversions/channel_count.rs
@@ -1,0 +1,78 @@
+use std::time::Duration;
+
+use crate::source::SeekError;
+use crate::{ConstSource, Sample};
+
+/// Converts between two channel counts, created using
+/// [with_channel_count](ConstSource::with_channel_count)
+pub struct ChannelConvertor<const SR: u32, const CH_IN: u16, const CH_OUT: u16, S> {
+    input: S,
+    sample_repeat: Option<Sample>,
+    next_output_sample_pos: u16,
+}
+
+impl<const SR: u32, const CH_IN: u16, const CH_OUT: u16, S: ConstSource<SR, CH_IN>>
+    ChannelConvertor<SR, CH_IN, CH_OUT, S>
+{
+    pub(crate) fn new(input: S) -> Self {
+        Self {
+            input,
+            sample_repeat: None,
+            next_output_sample_pos: 0,
+        }
+    }
+
+    crate::common::source::add_inner_accessors! {input}
+}
+
+impl<const SR: u32, const CH_IN: u16, const CH_OUT: u16, S: ConstSource<SR, CH_IN>>
+    ConstSource<SR, CH_OUT> for ChannelConvertor<SR, CH_IN, CH_OUT, S>
+{
+    fn total_duration(&self) -> Option<std::time::Duration> {
+        self.input.total_duration()
+    }
+
+    fn try_seek(&mut self, pos: Duration) -> Result<(), SeekError> {
+        self.input.try_seek(pos)
+    }
+}
+
+impl<const SR: u32, const CH_IN: u16, const CH_OUT: u16, S: ConstSource<SR, CH_IN>> Iterator
+    for ChannelConvertor<SR, CH_IN, CH_OUT, S>
+{
+    type Item = Sample;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let result = match self.next_output_sample_pos {
+            0 => {
+                // save first sample for mono -> stereo conversion
+                let value = self.input.next();
+                self.sample_repeat = value;
+                value
+            }
+            x if x < CH_IN => {
+                // make sure we always end on a frame boundary
+                let value = self.input.next();
+                assert!(value.is_some(), "Sources may not emit half frames");
+                value
+            }
+            1 => self.sample_repeat,
+            _ => Some(0.0), // all other added channels are empty
+        };
+
+        if result.is_some() {
+            self.next_output_sample_pos += 1;
+        }
+
+        if self.next_output_sample_pos == CH_OUT {
+            self.next_output_sample_pos = 0;
+
+            if CH_IN > CH_OUT {
+                for _ in CH_OUT..CH_IN {
+                    self.input.next(); // discarding extra input
+                }
+            }
+        }
+        result
+    }
+}

--- a/src/const_source/conversions/sample_rate.rs
+++ b/src/const_source/conversions/sample_rate.rs
@@ -1,39 +1,47 @@
+use crate::conversions::sample_rate::rubato::{ResampleInner, RubatoAsyncResample};
 use crate::conversions::Interpolation;
 use crate::math::gcd;
 use crate::source::ResampleConfig;
-use crate::{FixedSource, Sample, SampleRate, Source};
+use crate::{ConstSource, Sample, SampleRate, Source};
 
+use crate::const_source::IntoDynamicSource;
 #[cfg(feature = "rubato-fft")]
 use crate::conversions::sample_rate::rubato::RubatoFftResample;
-use crate::conversions::sample_rate::rubato::{ResampleInner, RubatoAsyncResample};
-
 use crate::conversions::sample_rate::{InSamples, OutSamples};
-use crate::fixed_source::IntoDynamicSource;
 
 /// Resamples an audio source to a target sample rate using Rubato.
-pub struct SampleRateConvertor<S: FixedSource> {
+pub struct SampleRateConvertor<
+    const SR_IN: u32,
+    const SR_OUT: u32,
+    const CH: u16,
+    S: ConstSource<SR_IN, CH>,
+> {
     // Option so we can take out the source and rebuild the resampler without unsafe
-    inner: Option<ResampleInner<IntoDynamicSource<S>>>,
-    target_rate: SampleRate,
+    inner: Option<ResampleInner<IntoDynamicSource<SR_IN, CH, S>>>,
 }
 
 #[derive(thiserror::Error)]
 #[error("The resampler was already running")]
-pub struct ResamplerRunning<S: FixedSource>(SampleRateConvertor<S>);
+pub struct ResamplerRunning<
+    const SR_IN: u32,
+    const SR_OUT: u32,
+    const CH: u16,
+    S: ConstSource<SR_IN, CH>,
+>(SampleRateConvertor<SR_IN, SR_OUT, CH, S>);
 
-impl<S: FixedSource> SampleRateConvertor<S> {
-    pub(crate) fn new(source: S, target_rate: SampleRate) -> Self {
+impl<const SR_IN: u32, const SR_OUT: u32, const CH: u16, S: ConstSource<SR_IN, CH>>
+    SampleRateConvertor<SR_IN, SR_OUT, CH, S>
+{
+    pub(crate) fn new(source: S) -> Self {
         Self {
             inner: Some(Self::create_resampler(
                 source.into_dynamic_source(),
-                target_rate,
                 ResampleConfig::default(),
             )),
-            target_rate,
         }
     }
 
-    /// Further configure the resampler created with [`with_sample_rate`](FixedSource::with_sample_rate).
+    /// Further configure the resampler created with [`with_sample_rate`](ConstSource::with_sample_rate).
     /// You usually do not need to do this unless you have a specific use-case that requires very
     /// fast or extremely high quality resampling. The [`ResampleConfig`] has a number of factories
     /// with good defaults for such use-cases.
@@ -44,22 +52,25 @@ impl<S: FixedSource> SampleRateConvertor<S> {
     ///
     /// # Example
     /// ```
-    /// # use rodio::generators::fixed_source::Silence;
+    /// # use rodio::generators::const_source::Silence;
     /// # use rodio::SampleRate;
     /// # fn hi() -> Option<()> { // to enable ? in the example
-    /// use rodio::FixedSource;
+    /// use rodio::ConstSource;
     /// use rodio::conversions::ResampleConfig;
     ///
-    /// let source = Silence::new(SampleRate::new(44_100)?);
+    /// let source: Silence<44100> = Silence::new();
     /// let resampled = source
-    ///     .with_sample_rate(SampleRate::new(48_000)?)
+    ///     .with_sample_rate::<48000>()
     ///     .with_config(ResampleConfig::fast());
     /// # Some(())
     /// # }
     /// # hi().unwrap();
     /// ```
     #[allow(clippy::result_large_err, reason = "the Ok variant is the same size")]
-    pub fn with_config(mut self, config: ResampleConfig) -> Result<Self, ResamplerRunning<S>> {
+    pub fn with_config(
+        mut self,
+        config: ResampleConfig,
+    ) -> Result<Self, ResamplerRunning<SR_IN, SR_OUT, CH, S>> {
         if !self.resampler().can_reconfigure() {
             return Err(ResamplerRunning(self));
         }
@@ -74,37 +85,37 @@ impl<S: FixedSource> SampleRateConvertor<S> {
             .into_inner();
 
         Ok(Self {
-            inner: Some(Self::create_resampler(source, self.target_rate, config)),
-            target_rate: self.target_rate,
+            inner: Some(Self::create_resampler(source, config)),
         })
     }
 
-    fn resampler(&self) -> &ResampleInner<IntoDynamicSource<S>> {
+    fn resampler(&self) -> &ResampleInner<IntoDynamicSource<SR_IN, CH, S>> {
         self.inner
             .as_ref()
             .expect("never none outside `with_config`")
     }
 
-    fn resampler_mut(&mut self) -> &mut ResampleInner<IntoDynamicSource<S>> {
+    fn resampler_mut(&mut self) -> &mut ResampleInner<IntoDynamicSource<SR_IN, CH, S>> {
         self.inner
             .as_mut()
             .expect("never none outside `with_config`")
     }
 
     fn create_resampler(
-        source: IntoDynamicSource<S>,
-        target_rate: SampleRate,
+        source: IntoDynamicSource<SR_IN, CH, S>,
         config: ResampleConfig,
-    ) -> ResampleInner<IntoDynamicSource<S>> {
-        if source.sample_rate() == target_rate {
+    ) -> ResampleInner<IntoDynamicSource<SR_IN, CH, S>> {
+        let source_rate = const { SampleRate::new(SR_IN).expect("checked in 'new'") };
+        if SR_IN == SR_OUT {
             let channels = source.channels();
             ResampleInner::Passthrough {
-                source_rate: source.sample_rate(),
+                source_rate,
                 source,
                 input_span_pos: InSamples::ZERO,
                 channels,
             }
         } else {
+            let target_rate = const { SampleRate::new(SR_OUT).expect("checked in 'new'") };
             match config {
                 ResampleConfig::Poly { degree, chunk_size } => {
                     let resampler =
@@ -114,7 +125,7 @@ impl<S: FixedSource> SampleRateConvertor<S> {
                 }
                 ResampleConfig::Sinc(mut sinc) => {
                     #[cfg(feature = "rubato-fft")]
-                    if sinc.is_supported_fixed_ratio(target_rate, source.sample_rate()) {
+                    if sinc.is_supported_fixed_ratio(target_rate, source_rate) {
                         let resampler = RubatoFftResample::new(
                             source,
                             target_rate,
@@ -140,23 +151,18 @@ impl<S: FixedSource> SampleRateConvertor<S> {
     }
 }
 
-impl<S: FixedSource> FixedSource for SampleRateConvertor<S> {
-    fn channels(&self) -> crate::ChannelCount {
-        self.resampler().inner().channels()
-    }
-
-    fn sample_rate(&self) -> SampleRate {
-        self.target_rate
-    }
-
+impl<const SR_IN: u32, const SR_OUT: u32, const CH: u16, S: ConstSource<SR_IN, CH>>
+    ConstSource<SR_OUT, CH> for SampleRateConvertor<SR_IN, SR_OUT, CH, S>
+{
     fn total_duration(&self) -> Option<std::time::Duration> {
         self.resampler().inner().total_duration()
     }
 }
 
-impl<S> Iterator for SampleRateConvertor<S>
+impl<const SR_IN: u32, const SR_OUT: u32, const CH: u16, S> Iterator
+    for SampleRateConvertor<SR_IN, SR_OUT, CH, S>
 where
-    S: FixedSource,
+    S: ConstSource<SR_IN, CH>,
 {
     type Item = Sample;
 

--- a/src/conversions/channels.rs
+++ b/src/conversions/channels.rs
@@ -1,3 +1,4 @@
+use crate::common::source::add_inner_accessors;
 use crate::common::ChannelCount;
 use crate::{Sample, Source};
 use dasp_sample::Sample as _;
@@ -18,13 +19,13 @@ where
     next_output_sample_pos: u16,
 }
 
-impl<I> ChannelCountConverter<I>
+impl<S> ChannelCountConverter<S>
 where
-    I: Iterator<Item = Sample>,
+    S: Iterator<Item = Sample>,
 {
     /// Initializes the iterator.
     #[inline]
-    pub fn new(input: I, from: ChannelCount, to: ChannelCount) -> ChannelCountConverter<I> {
+    pub fn new(input: S, from: ChannelCount, to: ChannelCount) -> ChannelCountConverter<S> {
         ChannelCountConverter {
             input,
             from,
@@ -34,23 +35,7 @@ where
         }
     }
 
-    /// Destroys this iterator and returns the underlying iterator.
-    #[inline]
-    pub fn into_inner(self) -> I {
-        self.input
-    }
-
-    /// Get immutable access to the underlying iterator.
-    #[inline]
-    pub fn inner(&self) -> &I {
-        &self.input
-    }
-
-    /// Get mutable access to the underlying iterator.
-    #[inline]
-    pub fn inner_mut(&mut self) -> &mut I {
-        &mut self.input
-    }
+    add_inner_accessors! {input}
 }
 
 impl<I> Iterator for ChannelCountConverter<I>

--- a/src/conversions/sample.rs
+++ b/src/conversions/sample.rs
@@ -11,33 +11,17 @@ pub struct SampleTypeConverter<I, O> {
     marker: PhantomData<O>,
 }
 
-impl<I, O> SampleTypeConverter<I, O> {
+impl<S, O> SampleTypeConverter<S, O> {
     /// Builds a new converter.
     #[inline]
-    pub fn new(input: I) -> SampleTypeConverter<I, O> {
+    pub fn new(input: S) -> SampleTypeConverter<S, O> {
         SampleTypeConverter {
             input,
             marker: PhantomData,
         }
     }
 
-    /// Destroys this iterator and returns the underlying iterator.
-    #[inline]
-    pub fn into_inner(self) -> I {
-        self.input
-    }
-
-    /// Get immutable access to the underlying iterator.
-    #[inline]
-    pub fn inner(&self) -> &I {
-        &self.input
-    }
-
-    /// Get mutable access to the underlying iterator.
-    #[inline]
-    pub fn inner_mut(&mut self) -> &mut I {
-        &mut self.input
-    }
+    crate::common::source::add_inner_accessors! {input}
 }
 
 impl<I, O> Iterator for SampleTypeConverter<I, O>

--- a/src/conversions/sample_rate/buffer.rs
+++ b/src/conversions/sample_rate/buffer.rs
@@ -3,7 +3,7 @@
 use std::fmt::{Debug, Write};
 
 use super::{InSamples, OutFrameCount, OutSamples};
-use crate::{ChannelCount, Sample, SampleRate};
+use crate::{ChannelCount, Sample};
 
 pub(crate) struct Input {
     pub samples: Box<[Sample]>,
@@ -61,7 +61,6 @@ pub(crate) struct Output {
 
     pub samples: Box<[Sample]>,
     pub channels: ChannelCount,
-    pub source_rate: SampleRate,
 }
 
 impl Debug for Output {
@@ -75,7 +74,6 @@ impl Debug for Output {
                 &LimitLength(&self.samples[self.pos.raw()..self.end.raw()]),
             )
             .field("channels", &self.channels)
-            .field("source_rate", &self.source_rate)
             .finish()
     }
 }
@@ -114,7 +112,6 @@ impl Debug for LimitLength<'_> {
 
 impl Output {
     pub(super) fn new(
-        source_rate: SampleRate,
         channels: ChannelCount,
         capacity: OutFrameCount,
     ) -> Self {
@@ -127,7 +124,6 @@ impl Output {
             end: OutSamples::ZERO,
             samples: samples.into_boxed_slice(),
             channels,
-            source_rate,
         }
     }
 
@@ -135,7 +131,7 @@ impl Output {
         OutSamples(self.samples.len()).frames(self.channels)
     }
 
-    pub(super) fn len(&self) -> OutSamples {
+    pub(crate) fn len(&self) -> OutSamples {
         self.end - self.pos
     }
 

--- a/src/conversions/sample_rate/buffer.rs
+++ b/src/conversions/sample_rate/buffer.rs
@@ -111,10 +111,7 @@ impl Debug for LimitLength<'_> {
 }
 
 impl Output {
-    pub(super) fn new(
-        channels: ChannelCount,
-        capacity: OutFrameCount,
-    ) -> Self {
+    pub(super) fn new(channels: ChannelCount, capacity: OutFrameCount) -> Self {
         let mut samples = Vec::new();
         samples.reserve_exact(capacity.samples(channels).raw());
         samples.resize(samples.capacity(), 0.0);

--- a/src/conversions/sample_rate/builder.rs
+++ b/src/conversions/sample_rate/builder.rs
@@ -208,7 +208,7 @@ impl Default for SincConfigBuilder {
 /// let config = ResampleConfig::sinc().chunk_size(nz!(512));
 /// let config = ResampleConfig::poly().degree(Poly::Cubic);
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum ResampleConfig {
     /// Polynomial resampling (fast, no anti-aliasing)
     Poly {
@@ -221,7 +221,7 @@ pub enum ResampleConfig {
     Sinc(Sinc),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct Sinc {
     /// Length of the windowed sinc interpolation filter
     pub sinc_len: usize,

--- a/src/conversions/sample_rate/mod.rs
+++ b/src/conversions/sample_rate/mod.rs
@@ -84,10 +84,10 @@ use crate::{
     Source,
 };
 
-mod buffer;
+pub(crate) mod buffer;
 mod builder;
-mod rubato;
-mod types;
+pub(crate) mod rubato;
+pub(crate) mod types;
 pub(crate) use types::{InFrameCount, InSamples, OutFrameCount, OutSamples};
 #[cfg(test)]
 mod tests;
@@ -127,7 +127,7 @@ where
     fn clone(&self) -> Self {
         // Shallow clone: this resets filter state
         let source = self.inner().clone();
-        SampleRateConverter::new(source, self.target_rate, self.config.clone())
+        SampleRateConverter::new(source, self.target_rate, self.config)
     }
 }
 
@@ -191,8 +191,7 @@ where
                             .expect("Failed to create polynomial resampler");
                     ResampleInner::Poly(resampler)
                 }
-                ResampleConfig::Sinc(sinc) => {
-                    let mut sinc = sinc.clone();
+                ResampleConfig::Sinc(mut sinc) => {
                     #[cfg(feature = "rubato-fft")]
                     if sinc.is_supported_fixed_ratio(target_rate, source_rate) {
                         let resampler = RubatoFftResample::new(

--- a/src/conversions/sample_rate/rubato.rs
+++ b/src/conversions/sample_rate/rubato.rs
@@ -45,13 +45,36 @@ pub enum ResampleInner<I: Source> {
 }
 
 impl<I: Source> ResampleInner<I> {
+    pub fn can_reconfigure(&self) -> bool {
+        match self {
+            ResampleInner::Passthrough { .. } => false,
+            ResampleInner::Poly(resampler) | ResampleInner::Sinc(resampler) => {
+                resampler.output_delay_remaining == output_delay(&resampler.resampler)
+            }
+            #[cfg(feature = "rubato-fft")]
+            ResampleInner::Fft(resampler) => {
+                resampler.output_delay_remaining == output_delay(&resampler.resampler)
+            }
+        }
+    }
+
     /// Get a reference to the inner input source
     #[inline]
     pub fn input(&self) -> &I {
         match self {
             ResampleInner::Passthrough { source, .. } => source,
-            ResampleInner::Poly(resampler) => &resampler.input,
-            ResampleInner::Sinc(resampler) => &resampler.input,
+            ResampleInner::Poly(resampler) | ResampleInner::Sinc(resampler) => &resampler.input,
+            #[cfg(feature = "rubato-fft")]
+            ResampleInner::Fft(resampler) => &resampler.input,
+        }
+    }
+
+    /// Extract the inner input source, consuming the resampler
+    #[inline]
+    pub fn inner(&self) -> &I {
+        match self {
+            ResampleInner::Passthrough { source, .. } => source,
+            ResampleInner::Poly(resampler) | ResampleInner::Sinc(resampler) => &resampler.input,
             #[cfg(feature = "rubato-fft")]
             ResampleInner::Fft(resampler) => &resampler.input,
         }
@@ -76,7 +99,7 @@ pub struct RubatoResample<I: Source, R: rubato::Resampler<Sample>> {
     pub input: I,
     pub resampler: R,
 
-    pub input_buffer: super::buffer::Input,
+    pub(crate) input_buffer: super::buffer::Input,
     pub(crate) output: super::buffer::Output,
 
     /// The following are cached at construction for parameter-change detection.
@@ -88,15 +111,14 @@ pub struct RubatoResample<I: Source, R: rubato::Resampler<Sample>> {
     pub frames_being_resampled: OutFrameCount,
 }
 
-impl<I: Source, R: rubato::Resampler<Sample>> RubatoResample<I, R> {
-    /// Calculate the number of output samples to skip for delay compensation.
-    pub fn output_delay(resampler: &R) -> OutFrameCount {
-        // Skip delay-1 frames to align the first output frame with input position 0.
-        let delay_frames = resampler.output_delay();
-        let delay_frames = delay_frames.saturating_sub(1);
-        OutFrameCount(delay_frames)
-    }
+pub fn output_delay(resampler: &impl rubato::Resampler<Sample>) -> OutFrameCount {
+    // Skip delay-1 frames to align the first output frame with input position 0.
+    let delay_frames = resampler.output_delay();
+    let delay_frames = delay_frames.saturating_sub(1);
+    OutFrameCount(delay_frames)
+}
 
+impl<I: Source, R: rubato::Resampler<Sample>> RubatoResample<I, R> {
     pub fn span_length(&self) -> Option<usize> {
         if !self.output.is_empty() {
             // rest of the output buffer is rest of span
@@ -119,7 +141,7 @@ impl<I: Source, R: rubato::Resampler<Sample>> RubatoResample<I, R> {
         self.resampler.reset();
         self.output.reset();
         self.pos_in_current_span = InSamples::ZERO;
-        self.output_delay_remaining = Self::output_delay(&self.resampler);
+        self.output_delay_remaining = output_delay(&self.resampler);
     }
 
     pub fn next_sample(&mut self) -> Option<Sample> {
@@ -239,14 +261,13 @@ impl<I: Source> RubatoAsyncResample<I> {
         let input_buf_size = InFrameCount(resampler.input_frames_max());
         let output_buf_size = OutFrameCount(resampler.output_frames_max());
 
-        let initial_output_delay =
-            RubatoResample::<I, rubato::Async<Sample>>::output_delay(&resampler);
+        let initial_output_delay = output_delay(&resampler);
 
         Ok(Self {
             input,
             resampler,
             input_buffer: Input::new(input_buf_size.samples(channels)),
-            output: Output::new(source_rate, channels, output_buf_size),
+            output: Output::new(channels, output_buf_size),
             pos_in_current_span: InSamples::ZERO,
             output_delay_remaining: initial_output_delay,
             resample_ratio,
@@ -290,14 +311,13 @@ impl<I: Source> RubatoAsyncResample<I> {
         let input_buf_size = InFrameCount(resampler.input_frames_max());
         let output_buf_size = OutFrameCount(resampler.output_frames_max());
 
-        let initial_output_delay =
-            RubatoResample::<I, rubato::Async<Sample>>::output_delay(&resampler);
+        let initial_output_delay = output_delay(&resampler);
 
         Ok(Self {
             input,
             resampler,
             input_buffer: Input::new(input_buf_size.samples(channels)),
-            output: Output::new(source_rate, channels, output_buf_size),
+            output: Output::new(channels, output_buf_size),
             pos_in_current_span: InSamples::ZERO,
             output_delay_remaining: initial_output_delay,
             resample_ratio,
@@ -341,7 +361,7 @@ impl<I: Source> RubatoFftResample<I> {
         let output_buf_size = OutFrameCount(resampler.output_frames_max());
         let resample_ratio = target_rate.get() as Float / source_rate.get() as Float;
 
-        let output_delay_remaining = RubatoFftResample::<I>::output_delay(&resampler);
+        let output_delay_remaining = output_delay(&resampler);
 
         Ok(Self {
             input,

--- a/src/conversions/sample_rate/rubato.rs
+++ b/src/conversions/sample_rate/rubato.rs
@@ -367,7 +367,7 @@ impl<I: Source> RubatoFftResample<I> {
             input,
             resampler,
             input_buffer: Input::new(input_buf_size.samples(channels)),
-            output: Output::new(source_rate, channels, output_buf_size),
+            output: Output::new(channels, output_buf_size),
             pos_in_current_span: InSamples::ZERO,
             output_delay_remaining,
             resample_ratio,

--- a/src/docs/collect_into_buffer.md
+++ b/src/docs/collect_into_buffer.md
@@ -1,0 +1,5 @@
+Builds a new `SamplesBuffer`.
+
+# Panics
+- Panics if the length of the buffer is larger than approximately 16 billion elements.
+  This is because the calculation of the duration would overflow.

--- a/src/docs/total_duration.md
+++ b/src/docs/total_duration.md
@@ -1,0 +1,6 @@
+Returns the total duration of this source, if known.
+
+`None` indicates at the same time "infinite" or "unknown".
+
+Note this value is free to change. For example if you removed an item from a
+queue the total_duration lowers.

--- a/src/docs/try_seek.md
+++ b/src/docs/try_seek.md
@@ -1,0 +1,16 @@
+Attempts to seek to a given position in the current source.
+
+As long as the duration of the source is known, seek is guaranteed to saturate
+at the end of the source. For example given a source that reports a total duration
+of 42 seconds calling `try_seek()` with 60 seconds as argument will seek to
+42 seconds.
+
+# Errors
+This function will return [`SeekError::NotSupported`] if one of the underlying
+sources does not support seeking.
+
+It will return an error if an implementation ran
+into one during the seek.
+
+Seeking beyond the end of a source might return an error if the total duration of
+the source is not known.

--- a/src/fixed_source.rs
+++ b/src/fixed_source.rs
@@ -12,6 +12,7 @@ mod conversions;
 pub use buffer::SamplesBuffer;
 pub use chain::SourceChain;
 pub use conversions::channel_count::ChannelConverter;
+pub use conversions::sample_rate::SampleRateConvertor;
 
 /// Similar to `Source`, something that can produce interleaved samples for a
 /// fixed amount of channels at a fixed sample rate. Those parameters never
@@ -34,6 +35,17 @@ pub trait FixedSource: Iterator<Item = Sample> {
         })
     }
 
+    /// Convert from the current channel count to `channel count`.
+    ///
+    /// Though the defaults cover most use-cases you can configure 
+    /// the resampler using [`with_config`](SampleRateConvertor::with_config).
+    fn with_sample_rate(self, sample_rate: SampleRate) -> SampleRateConvertor<Self>
+    where
+        Self: Sized,
+    {
+        SampleRateConvertor::new(self, sample_rate)
+    }
+
     /// Convert from the current channel count to `channel_count`.
     fn with_channel_count(self, channel_count: ChannelCount) -> ChannelConverter<Self>
     where
@@ -46,7 +58,7 @@ pub trait FixedSource: Iterator<Item = Sample> {
     /// the parameters already match. If they do not this returns an error.
     ///
     /// If the parameters do not match you can resample using:
-    /// [`with_sample_rate`](Self::placeholder) and
+    /// [`with_sample_rate`](Self::with_sample_rate) and
     /// [`with_channel_count`](Self::with_channel_count).
     fn try_into_const_source<const SR: u32, const CH: u16>(
         self,

--- a/src/fixed_source.rs
+++ b/src/fixed_source.rs
@@ -4,6 +4,12 @@ use std::time::Duration;
 
 use crate::{ChannelCount, ConstSource, Sample, SampleRate};
 
+mod buffer;
+mod chain;
+
+pub use buffer::SamplesBuffer;
+pub use chain::SourceChain;
+
 /// Similar to `Source`, something that can produce interleaved samples for a
 /// fixed amount of channels at a fixed sample rate. Those parameters never
 /// change.
@@ -21,8 +27,8 @@ pub trait FixedSource: Iterator<Item = Sample> {
     /// the parameters already match. If they do not this returns an error.
     ///
     /// If the parameters do not match you can resample using:
-    /// [`with_sample_rate`](Self::with_sample_rate) and
-    /// [`with_channel_count`](Self::with_channel_count).
+    /// [`with_sample_rate`](Self::placeholder) and
+    /// [`with_channel_count`](Self::placeholder).
     fn try_into_const_source<const SR: u32, const CH: u16>(
         self,
     ) -> Result<IntoConstSource<SR, CH, Self>, ParameterMismatch<SR, CH>>
@@ -49,6 +55,55 @@ pub trait FixedSource: Iterator<Item = Sample> {
     {
         IntoDynamicSource(self)
     }
+
+    /// Add another source to play directly after this one.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use rodio::nz;
+    /// # use rodio::FixedSource;
+    /// # use rodio::fixed_source::SamplesBuffer;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let preamble = SamplesBuffer::new(nz!(1), nz!(1), [1.0, 1.0]);
+    /// let signal = SamplesBuffer::new(nz!(1), nz!(1), [2.0, 2.0]);
+    ///
+    /// let mixed = preamble.try_chain_source(signal)?;
+    /// assert_eq!(mixed.collect::<Vec<_>>(), vec![1.0,1.0,2.0,2.0]);
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn try_chain_source<S: FixedSource>(
+        self,
+        next: S,
+    ) -> Result<SourceChain<Self, S>, chain::ParamsMismatch>
+    where
+        Self: Sized,
+    {
+        SourceChain::new(self, next)
+    }
+
+    // placeholder until effects land (need this for some examples)
+    #[allow(missing_docs)]
+    fn take_duration(self, _duration: Duration) -> Placeholder<Self>
+    where
+        Self: Sized,
+    {
+        todo!()
+    }
+
+    /// here to make docs links work without the linked item being in
+    /// remove before next release
+    fn placeholder(&self) {}
+}
+
+// placeholder until effects land (need this for some examples)
+#[allow(missing_docs)]
+pub struct Placeholder<S>
+where
+    S: FixedSource,
+{
+    inner: std::marker::PhantomData<S>,
 }
 
 /// A [`ConstSource`] adapted from a [`FixedSource`].
@@ -94,7 +149,7 @@ impl<const SR: u32, const CH: u16> std::fmt::Display for ParameterMismatch<SR, C
     }
 }
 
-/// A [`DynamicSource`] adapted from a [`FixedSource`].
+/// A [`DynamicSource`](crate::DynamicSource) adapted from a [`FixedSource`].
 pub struct IntoDynamicSource<S: FixedSource>(S);
 
 impl<S: FixedSource> crate::DynamicSource for IntoDynamicSource<S> {

--- a/src/fixed_source.rs
+++ b/src/fixed_source.rs
@@ -2,6 +2,7 @@
 //! channel count.
 use std::time::Duration;
 
+use crate::source::SeekError;
 use crate::{ChannelCount, ConstSource, Sample, SampleRate};
 
 mod buffer;
@@ -22,6 +23,14 @@ pub trait FixedSource: Iterator<Item = Sample> {
     ///
     /// `None` indicates at the same time "infinite" or "unknown".
     fn total_duration(&self) -> Option<Duration>;
+
+    #[allow(unused_variables)]
+    #[doc = include_str!("docs/try_seek.md")]
+    fn try_seek(&mut self, pos: Duration) -> Result<(), SeekError> {
+        Err(SeekError::NotSupported {
+            underlying_source: std::any::type_name::<Self>(),
+        })
+    }
 
     /// Tries to convert from a fixed source to a const one assuming
     /// the parameters already match. If they do not this returns an error.
@@ -54,6 +63,18 @@ pub trait FixedSource: Iterator<Item = Sample> {
         Self: Sized,
     {
         IntoDynamicSource(self)
+    }
+
+    #[doc = include_str!("docs/collect_into_buffer.md")]
+    fn collect_into_buffer(self) -> SamplesBuffer
+    where
+        Self: Sized,
+    {
+        SamplesBuffer::new(
+            self.channels(),
+            self.sample_rate(),
+            self.collect::<Vec<_>>(),
+        )
     }
 
     /// Add another source to play directly after this one.
@@ -104,6 +125,35 @@ where
     S: FixedSource,
 {
     inner: std::marker::PhantomData<S>,
+}
+
+impl<S> Placeholder<S>
+where
+    S: FixedSource,
+{
+    /// placeholder
+    pub fn record(self) -> Placeholder<S> {
+        self
+    }
+}
+
+impl<S: FixedSource> FixedSource for Placeholder<S> {
+    fn channels(&self) -> ChannelCount {
+        unimplemented!("placeholder")
+    }
+    fn sample_rate(&self) -> SampleRate {
+        unimplemented!("placeholder")
+    }
+    fn total_duration(&self) -> Option<Duration> {
+        unimplemented!("placeholder")
+    }
+}
+
+impl<S: FixedSource> Iterator for Placeholder<S> {
+    type Item = Sample;
+    fn next(&mut self) -> Option<Self::Item> {
+        unimplemented!("placeholder")
+    }
 }
 
 /// A [`ConstSource`] adapted from a [`FixedSource`].

--- a/src/fixed_source.rs
+++ b/src/fixed_source.rs
@@ -2,7 +2,7 @@
 //! channel count.
 use std::time::Duration;
 
-use crate::{ChannelCount, Sample, SampleRate};
+use crate::{ChannelCount, ConstSource, Sample, SampleRate};
 
 /// Similar to `Source`, something that can produce interleaved samples for a
 /// fixed amount of channels at a fixed sample rate. Those parameters never
@@ -16,4 +16,109 @@ pub trait FixedSource: Iterator<Item = Sample> {
     ///
     /// `None` indicates at the same time "infinite" or "unknown".
     fn total_duration(&self) -> Option<Duration>;
+
+    /// Tries to convert from a fixed source to a const one assuming
+    /// the parameters already match. If they do not this returns an error.
+    ///
+    /// If the parameters do not match you can resample using:
+    /// [`with_sample_rate`](Self::with_sample_rate) and
+    /// [`with_channel_count`](Self::with_channel_count).
+    fn try_into_const_source<const SR: u32, const CH: u16>(
+        self,
+    ) -> Result<IntoConstSource<SR, CH, Self>, ParameterMismatch<SR, CH>>
+    where
+        Self: Sized,
+    {
+        if self.channels().get() != CH || self.sample_rate().get() != SR {
+            Err(ParameterMismatch {
+                sample_rate: self.sample_rate(),
+                channel_count: self.channels(),
+            })
+        } else {
+            Ok(IntoConstSource(self))
+        }
+    }
+
+    /// Use this fixed source as if it's a dynamic source. You generally do not
+    /// want to do this since there are less effects for dynamic sources and
+    /// those that are available can not be implemented as efficient. This is
+    /// therefore purely provided for backwards compatibility.
+    fn into_dynamic_source(self) -> IntoDynamicSource<Self>
+    where
+        Self: Sized,
+    {
+        IntoDynamicSource(self)
+    }
+}
+
+/// A [`ConstSource`] adapted from a [`FixedSource`].
+pub struct IntoConstSource<const SR: u32, const CH: u16, S: FixedSource>(S);
+
+impl<const SR: u32, const CH: u16, S: FixedSource> ConstSource<SR, CH>
+    for IntoConstSource<SR, CH, S>
+{
+    fn total_duration(&self) -> Option<Duration> {
+        self.0.total_duration()
+    }
+}
+
+impl<const SR: u32, const CH: u16, S: FixedSource> Iterator for IntoConstSource<SR, CH, S> {
+    type Item = Sample;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+/// Error that occurs when a [`FixedSource`] can not be converted into a
+/// [`ConstSource`] with a certain sample rate and channel count.
+#[derive(Debug)]
+pub struct ParameterMismatch<const SR: u32, const CH: u16> {
+    sample_rate: SampleRate,
+    channel_count: ChannelCount,
+}
+
+impl<const SR: u32, const CH: u16> std::error::Error for ParameterMismatch<SR, CH> {}
+
+impl<const SR: u32, const CH: u16> std::fmt::Display for ParameterMismatch<SR, CH> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.sample_rate.get() == SR && self.channel_count.get() == CH {
+            unreachable!("ParameterMismatch error can only occur when params mismatch");
+        } else if self.sample_rate.get() == SR && self.channel_count.get() != CH {
+            f.write_fmt(format_args!("Fixed source's channel count: {}, does not match target const source's channel count: {}", self.channel_count.get(), CH))
+        } else if self.sample_rate.get() != SR && self.channel_count.get() != CH {
+            f.write_fmt(format_args!("Fixed source's sample rate and channel count ({}, {}) do not match target const source's sample rate and channel count ({} {})", self.sample_rate.get(), self.channel_count.get(), SR, CH))
+        } else {
+            f.write_fmt(format_args!("Fixed source's sample rate : {}, does not match target const source's sample rate: {}", self.sample_rate.get(), SR))
+        }
+    }
+}
+
+/// A [`DynamicSource`] adapted from a [`FixedSource`].
+pub struct IntoDynamicSource<S: FixedSource>(S);
+
+impl<S: FixedSource> crate::DynamicSource for IntoDynamicSource<S> {
+    fn current_span_len(&self) -> Option<usize> {
+        None
+    }
+
+    fn channels(&self) -> ChannelCount {
+        self.0.channels()
+    }
+
+    fn sample_rate(&self) -> SampleRate {
+        self.0.sample_rate()
+    }
+
+    fn total_duration(&self) -> Option<Duration> {
+        self.0.total_duration()
+    }
+}
+
+impl<S: FixedSource> Iterator for IntoDynamicSource<S> {
+    type Item = crate::Sample;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
 }

--- a/src/fixed_source.rs
+++ b/src/fixed_source.rs
@@ -37,7 +37,7 @@ pub trait FixedSource: Iterator<Item = Sample> {
 
     /// Convert from the current channel count to `channel count`.
     ///
-    /// Though the defaults cover most use-cases you can configure 
+    /// Though the defaults cover most use-cases you can configure
     /// the resampler using [`with_config`](SampleRateConvertor::with_config).
     fn with_sample_rate(self, sample_rate: SampleRate) -> SampleRateConvertor<Self>
     where

--- a/src/fixed_source.rs
+++ b/src/fixed_source.rs
@@ -7,9 +7,11 @@ use crate::{ChannelCount, ConstSource, Sample, SampleRate};
 
 mod buffer;
 mod chain;
+mod conversions;
 
 pub use buffer::SamplesBuffer;
 pub use chain::SourceChain;
+pub use conversions::channel_count::ChannelConverter;
 
 /// Similar to `Source`, something that can produce interleaved samples for a
 /// fixed amount of channels at a fixed sample rate. Those parameters never
@@ -32,12 +34,20 @@ pub trait FixedSource: Iterator<Item = Sample> {
         })
     }
 
+    /// Convert from the current channel count to `channel_count`.
+    fn with_channel_count(self, channel_count: ChannelCount) -> ChannelConverter<Self>
+    where
+        Self: Sized,
+    {
+        ChannelConverter::new(self, channel_count)
+    }
+
     /// Tries to convert from a fixed source to a const one assuming
     /// the parameters already match. If they do not this returns an error.
     ///
     /// If the parameters do not match you can resample using:
     /// [`with_sample_rate`](Self::placeholder) and
-    /// [`with_channel_count`](Self::placeholder).
+    /// [`with_channel_count`](Self::with_channel_count).
     fn try_into_const_source<const SR: u32, const CH: u16>(
         self,
     ) -> Result<IntoConstSource<SR, CH, Self>, ParameterMismatch<SR, CH>>

--- a/src/fixed_source/buffer.rs
+++ b/src/fixed_source/buffer.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::source::SeekError;
 use crate::FixedSource;
 use crate::{ChannelCount, Sample, SampleRate};
 
@@ -19,7 +20,7 @@ impl SamplesBuffer {
     where
         D: Into<Vec<Sample>>,
     {
-        let data: Arc<[f32]> = data.into().into();
+        let data: Arc<[Sample]> = data.into().into();
         SamplesBuffer {
             data,
             pos: 0,
@@ -38,52 +39,9 @@ impl FixedSource for SamplesBuffer {
     fn sample_rate(&self) -> SampleRate {
         self.sample_rate
     }
-    /// # Panics
-    /// If the length of the buffer is larger than approximately 16 billion elements.
-    /// This is because the calculation of the duration would overflow.
-    #[inline]
-    fn total_duration(&self) -> Option<Duration> {
-        let duration_ns = 1_000_000_000u64
-            .checked_mul(self.data.len() as u64)
-            .unwrap()
-            / self.sample_rate.get() as u64
-            / self.channels.get() as u64;
-        let duration = Duration::new(
-            duration_ns / 1_000_000_000,
-            (duration_ns % 1_000_000_000) as u32,
-        );
-
-        Some(duration)
-    }
-    // /// This jumps in memory till the sample for `pos`.
-    // #[inline]
-    // fn try_seek(&mut self, pos: Duration) -> Result<(), SeekError> {
-    //     // This is fast because all the samples are in memory already
-    //     // and due to the constant sample_rate we can jump to the right
-    //     // sample directly.
-    //     let curr_channel = self.pos % self.channels() as usize;
-    //     let new_pos = pos.as_secs_f32() * self.sample_rate() as f32 * self.channels() as f32;
-    //     // saturate pos at the end of the source
-    //     let new_pos = new_pos as usize;
-    //     let new_pos = new_pos.min(self.data.len());
-    //     // make sure the next sample is for the right channel
-    //     let new_pos = new_pos.next_multiple_of(self.channels() as usize);
-    //     let new_pos = new_pos - curr_channel;
-    //     self.pos = new_pos;
-    //     Ok(())
-    // }
+    crate::common::source::buffer::source_impl! {}
 }
 
 impl Iterator for SamplesBuffer {
-    type Item = Sample;
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        let sample = self.data.get(self.pos)?;
-        self.pos += 1;
-        Some(*sample)
-    }
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.data.len(), Some(self.data.len()))
-    }
+    crate::common::source::buffer::iter_impl! {}
 }

--- a/src/fixed_source/buffer.rs
+++ b/src/fixed_source/buffer.rs
@@ -1,0 +1,89 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::FixedSource;
+use crate::{ChannelCount, Sample, SampleRate};
+
+/// A buffer of samples treated as a source.
+#[derive(Debug, Clone)]
+pub struct SamplesBuffer {
+    data: Arc<[Sample]>,
+    pos: usize,
+    channels: ChannelCount,
+    sample_rate: SampleRate,
+}
+
+impl SamplesBuffer {
+    /// Builds a new `SamplesBuffer`.
+    pub fn new<D>(channels: ChannelCount, sample_rate: SampleRate, data: D) -> SamplesBuffer
+    where
+        D: Into<Vec<Sample>>,
+    {
+        let data: Arc<[f32]> = data.into().into();
+        SamplesBuffer {
+            data,
+            pos: 0,
+            channels,
+            sample_rate,
+        }
+    }
+}
+
+impl FixedSource for SamplesBuffer {
+    #[inline]
+    fn channels(&self) -> ChannelCount {
+        self.channels
+    }
+    #[inline]
+    fn sample_rate(&self) -> SampleRate {
+        self.sample_rate
+    }
+    /// # Panics
+    /// If the length of the buffer is larger than approximately 16 billion elements.
+    /// This is because the calculation of the duration would overflow.
+    #[inline]
+    fn total_duration(&self) -> Option<Duration> {
+        let duration_ns = 1_000_000_000u64
+            .checked_mul(self.data.len() as u64)
+            .unwrap()
+            / self.sample_rate.get() as u64
+            / self.channels.get() as u64;
+        let duration = Duration::new(
+            duration_ns / 1_000_000_000,
+            (duration_ns % 1_000_000_000) as u32,
+        );
+
+        Some(duration)
+    }
+    // /// This jumps in memory till the sample for `pos`.
+    // #[inline]
+    // fn try_seek(&mut self, pos: Duration) -> Result<(), SeekError> {
+    //     // This is fast because all the samples are in memory already
+    //     // and due to the constant sample_rate we can jump to the right
+    //     // sample directly.
+    //     let curr_channel = self.pos % self.channels() as usize;
+    //     let new_pos = pos.as_secs_f32() * self.sample_rate() as f32 * self.channels() as f32;
+    //     // saturate pos at the end of the source
+    //     let new_pos = new_pos as usize;
+    //     let new_pos = new_pos.min(self.data.len());
+    //     // make sure the next sample is for the right channel
+    //     let new_pos = new_pos.next_multiple_of(self.channels() as usize);
+    //     let new_pos = new_pos - curr_channel;
+    //     self.pos = new_pos;
+    //     Ok(())
+    // }
+}
+
+impl Iterator for SamplesBuffer {
+    type Item = Sample;
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let sample = self.data.get(self.pos)?;
+        self.pos += 1;
+        Some(*sample)
+    }
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.data.len(), Some(self.data.len()))
+    }
+}

--- a/src/fixed_source/chain.rs
+++ b/src/fixed_source/chain.rs
@@ -1,0 +1,86 @@
+use std::fmt::Display;
+
+use crate::FixedSource;
+use crate::Sample;
+use crate::{ChannelCount, SampleRate};
+
+/// Two chained sources, the one played after the other.
+#[derive(Clone)]
+pub struct SourceChain<S1, S2> {
+    inner: S1,
+    next: S2,
+    playing_inner: bool,
+}
+
+#[derive(Debug, Clone, Copy, thiserror::Error, PartialEq, Eq)]
+pub struct ParamsMismatch {
+    sample_rate_self: SampleRate,
+    channel_count_self: ChannelCount,
+    sample_rate_adding: SampleRate,
+    channel_count_adding: ChannelCount,
+}
+
+impl Display for ParamsMismatch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let ParamsMismatch {
+            sample_rate_self,
+            channel_count_self,
+            sample_rate_adding,
+            channel_count_adding,
+        } = self;
+        f.write_fmt(format_args!("Parameters mismatch the source chained onto Self does not have the same parameters. Self has sample rate: {sample_rate_self} and channel count: {channel_count_self} while the source being chained has sample rate: {sample_rate_adding} and channel count: {channel_count_adding}."))
+    }
+}
+
+impl<S1: FixedSource, S2: FixedSource> SourceChain<S1, S2> {
+    pub(crate) fn new(s1: S1, s2: S2) -> Result<Self, ParamsMismatch> {
+        if s1.sample_rate() != s2.sample_rate() || s1.channels() != s2.channels() {
+            Err(ParamsMismatch {
+                sample_rate_self: s1.sample_rate(),
+                channel_count_self: s1.channels(),
+                sample_rate_adding: s2.sample_rate(),
+                channel_count_adding: s2.channels(),
+            })
+        } else {
+            Ok(SourceChain {
+                inner: s1,
+                next: s2,
+                playing_inner: true,
+            })
+        }
+    }
+}
+
+impl<S1: FixedSource, S2: FixedSource> FixedSource for SourceChain<S1, S2> {
+    fn channels(&self) -> ChannelCount {
+        self.inner.channels()
+    }
+
+    fn sample_rate(&self) -> SampleRate {
+        self.inner.sample_rate()
+    }
+
+    fn total_duration(&self) -> Option<std::time::Duration> {
+        self.inner
+            .total_duration()
+            .and_then(|d| self.next.total_duration().map(|d2| d2 + d))
+    }
+}
+
+impl<S1: FixedSource, S2: FixedSource> Iterator for SourceChain<S1, S2> {
+    type Item = Sample;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.playing_inner {
+            match self.inner.next() {
+                Some(sample) => Some(sample),
+                None => {
+                    self.playing_inner = false;
+                    self.next.next()
+                }
+            }
+        } else {
+            self.next.next()
+        }
+    }
+}

--- a/src/fixed_source/chain.rs
+++ b/src/fixed_source/chain.rs
@@ -7,8 +7,8 @@ use crate::{ChannelCount, SampleRate};
 /// Two chained sources, the one played after the other.
 #[derive(Clone)]
 pub struct SourceChain<S1, S2> {
-    inner: S1,
-    next: S2,
+    first: S1,
+    second: S2,
     playing_inner: bool,
 }
 
@@ -43,44 +43,19 @@ impl<S1: FixedSource, S2: FixedSource> SourceChain<S1, S2> {
             })
         } else {
             Ok(SourceChain {
-                inner: s1,
-                next: s2,
+                first: s1,
+                second: s2,
                 playing_inner: true,
             })
         }
     }
 }
 
+pub use crate::common::source::chain::ChainSeekError;
 impl<S1: FixedSource, S2: FixedSource> FixedSource for SourceChain<S1, S2> {
-    fn channels(&self) -> ChannelCount {
-        self.inner.channels()
-    }
-
-    fn sample_rate(&self) -> SampleRate {
-        self.inner.sample_rate()
-    }
-
-    fn total_duration(&self) -> Option<std::time::Duration> {
-        self.inner
-            .total_duration()
-            .and_then(|d| self.next.total_duration().map(|d2| d2 + d))
-    }
+    crate::common::source::chain::source_impl! {}
 }
 
 impl<S1: FixedSource, S2: FixedSource> Iterator for SourceChain<S1, S2> {
-    type Item = Sample;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.playing_inner {
-            match self.inner.next() {
-                Some(sample) => Some(sample),
-                None => {
-                    self.playing_inner = false;
-                    self.next.next()
-                }
-            }
-        } else {
-            self.next.next()
-        }
-    }
+    crate::common::source::chain::iter_impl! {}
 }

--- a/src/fixed_source/conversions.rs
+++ b/src/fixed_source/conversions.rs
@@ -1,0 +1,1 @@
+pub mod channel_count;

--- a/src/fixed_source/conversions.rs
+++ b/src/fixed_source/conversions.rs
@@ -1,1 +1,2 @@
 pub mod channel_count;
+pub mod sample_rate;

--- a/src/fixed_source/conversions/channel_count.rs
+++ b/src/fixed_source/conversions/channel_count.rs
@@ -1,0 +1,84 @@
+use std::time::Duration;
+
+use crate::source::SeekError;
+use crate::{ChannelCount, Sample};
+use crate::{FixedSource, SampleRate};
+
+/// Converts between two channel counts, created using
+/// [with_channel_count](FixedSource::with_channel_count)
+pub struct ChannelConverter<S> {
+    input: S,
+    pub(crate) target: ChannelCount,
+    sample_repeat: Option<Sample>,
+    next_output_sample_pos: u16,
+}
+
+impl<S: FixedSource> ChannelConverter<S> {
+    pub(crate) fn new(input: S, target: ChannelCount) -> Self {
+        Self {
+            input,
+            target,
+            sample_repeat: None,
+            next_output_sample_pos: 0,
+        }
+    }
+
+    crate::common::source::add_inner_accessors! {input}
+}
+
+impl<S: FixedSource> FixedSource for ChannelConverter<S> {
+    fn channels(&self) -> ChannelCount {
+        self.target
+    }
+
+    fn sample_rate(&self) -> SampleRate {
+        self.input.sample_rate()
+    }
+
+    fn total_duration(&self) -> Option<std::time::Duration> {
+        self.input.total_duration()
+    }
+
+    fn try_seek(&mut self, pos: Duration) -> Result<(), SeekError> {
+        self.input.try_seek(pos)
+    }
+}
+
+// TODO optimize (still assumes dynamicsource)
+impl<S: FixedSource> Iterator for ChannelConverter<S> {
+    type Item = crate::Sample;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let result = match self.next_output_sample_pos {
+            0 => {
+                // save first sample for mono -> stereo conversion
+                let value = self.input.next();
+                self.sample_repeat = value;
+                value
+            }
+            x if x < self.input.channels().get() => {
+                // make sure we always end on a frame boundary
+                let value = self.input.next();
+                assert!(value.is_some(), "Sources may not emit half frames");
+                value
+            }
+            1 => self.sample_repeat,
+            _ => Some(0.0), // all other added channels are empty
+        };
+
+        if result.is_some() {
+            self.next_output_sample_pos += 1;
+        }
+
+        if self.next_output_sample_pos == self.target.get() {
+            self.next_output_sample_pos = 0;
+
+            if self.input.channels() > self.target {
+                for _ in self.target.get()..self.input.channels().get() {
+                    self.input.next(); // discarding extra input
+                }
+            }
+        }
+        result
+    }
+}

--- a/src/fixed_source/conversions/sample_rate.rs
+++ b/src/fixed_source/conversions/sample_rate.rs
@@ -1,0 +1,204 @@
+use crate::conversions::sample_rate::rubato::{ResampleInner, RubatoAsyncResample};
+use crate::conversions::Interpolation;
+use crate::math::gcd;
+use crate::source::ResampleConfig;
+use crate::{FixedSource, Sample, SampleRate, Source};
+
+use crate::conversions::sample_rate::{InSamples, OutSamples};
+use crate::fixed_source::IntoDynamicSource;
+
+/// Resamples an audio source to a target sample rate using Rubato.
+pub struct SampleRateConvertor<S: FixedSource> {
+    // Option so we can take out the source and rebuild the resampler without unsafe
+    inner: Option<ResampleInner<IntoDynamicSource<S>>>,
+    target_rate: SampleRate,
+}
+
+#[derive(thiserror::Error)]
+#[error("The resampler was already running")]
+pub struct ResamplerRunning<S: FixedSource>(SampleRateConvertor<S>);
+
+impl<S: FixedSource> SampleRateConvertor<S> {
+    pub(crate) fn new(source: S, target_rate: SampleRate) -> Self {
+        Self {
+            inner: Some(Self::create_resampler(
+                source.into_dynamic_source(),
+                target_rate,
+                ResampleConfig::default(),
+            )),
+            target_rate,
+        }
+    }
+
+    /// Further configure the resampler created with [`with_sample_rate`](FixedSource::with_sample_rate).
+    /// You usually do not need to do this unless you have a specific use-case that requires very
+    /// fast or extremely high quality resampling. The [`ResampleConfig`] has a number of factories
+    /// with good defaults for such use-cases.
+    ///
+    /// # Errors
+    /// If the resampler can no longer be reconfigured, usually after yielding
+    /// the first sample.
+    ///
+    /// # Example
+    /// ```
+    /// # use rodio::generators::fixed_source::Silence;
+    /// # use rodio::SampleRate;
+    /// # fn hi() -> Option<()> { // to enable ? in the example
+    /// use rodio::FixedSource;
+    /// use rodio::conversions::ResampleConfig;
+    /// 
+    /// let source = Silence::new(SampleRate::new(44_100)?);
+    /// let resampled = source
+    ///     .with_sample_rate(SampleRate::new(48_000)?)
+    ///     .with_config(ResampleConfig::fast());
+    /// # Some(())
+    /// # }
+    /// # hi().unwrap();
+    /// ```
+    #[allow(clippy::result_large_err, reason = "the Ok variant is the same size")]
+    pub fn with_config(mut self, config: ResampleConfig) -> Result<Self, ResamplerRunning<S>> {
+        if !self.resampler().can_reconfigure() {
+            return Err(ResamplerRunning(self));
+        }
+
+        let source = self
+            .inner
+            .take()
+            .expect(
+                "we are the only ones who set this to none and we set it to \
+            some at the end of this fn",
+            )
+            .into_inner();
+
+        Ok(Self {
+            inner: Some(Self::create_resampler(source, self.target_rate, config)),
+            target_rate: self.target_rate,
+        })
+    }
+
+    fn resampler(&self) -> &ResampleInner<IntoDynamicSource<S>> {
+        self.inner
+            .as_ref()
+            .expect("never none outside `with_config`")
+    }
+
+    fn resampler_mut(&mut self) -> &mut ResampleInner<IntoDynamicSource<S>> {
+        self.inner
+            .as_mut()
+            .expect("never none outside `with_config`")
+    }
+
+    fn create_resampler(
+        source: IntoDynamicSource<S>,
+        target_rate: SampleRate,
+        config: ResampleConfig,
+    ) -> ResampleInner<IntoDynamicSource<S>> {
+        if source.sample_rate() == target_rate {
+            let channels = source.channels();
+            ResampleInner::Passthrough {
+                source_rate: source.sample_rate(),
+                source,
+                input_span_pos: InSamples::ZERO,
+                channels,
+            }
+        } else {
+            match config {
+                ResampleConfig::Poly { degree, chunk_size } => {
+                    let resampler =
+                        RubatoAsyncResample::new_poly(source, target_rate, chunk_size, degree)
+                            .expect("Failed to create polynomial resampler");
+                    ResampleInner::Poly(resampler)
+                }
+                ResampleConfig::Sinc(mut sinc) => {
+                    #[cfg(feature = "rubato-fft")]
+                    if sinc.is_supported_fixed_ratio(target_rate, source_rate) {
+                        let resampler = RubatoFftResample::new(
+                            source,
+                            target_rate,
+                            sinc.chunk_size,
+                            sinc.sub_chunks,
+                        )
+                        .expect("Failed to create FFT resampler");
+                        return ResampleInner::Fft(resampler);
+                    }
+
+                    if sinc.is_supported_fixed_ratio(target_rate, source.sample_rate()) {
+                        sinc.interpolation = Interpolation::Nearest;
+                        let g = gcd(target_rate.get(), source.sample_rate().get());
+                        let numer = target_rate.get() / g;
+                        let denom = source.sample_rate().get() / g;
+                        let ratio = numer.max(denom) as usize;
+                        sinc.oversampling_factor = ratio;
+                    }
+                    ResampleInner::Sinc(sinc.build(source, target_rate))
+                }
+            }
+        }
+    }
+}
+
+impl<S: FixedSource> FixedSource for SampleRateConvertor<S> {
+    fn channels(&self) -> crate::ChannelCount {
+        self.resampler().inner().channels()
+    }
+
+    fn sample_rate(&self) -> SampleRate {
+        self.target_rate
+    }
+
+    fn total_duration(&self) -> Option<std::time::Duration> {
+        self.resampler().inner().total_duration()
+    }
+}
+
+impl<S> Iterator for SampleRateConvertor<S>
+where
+    S: FixedSource,
+{
+    type Item = Sample;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.resampler_mut() {
+            ResampleInner::Passthrough { source, .. } => source.next(),
+            ResampleInner::Poly(resampler) => resampler.next_sample(),
+            ResampleInner::Sinc(resampler) => resampler.next_sample(),
+            #[cfg(feature = "rubato-fft")]
+            ResampleInner::Fft(resampler) => resampler.next_sample(),
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self.resampler() {
+            ResampleInner::Passthrough { source, .. } => source.size_hint(),
+            ResampleInner::Poly(resampler) | ResampleInner::Sinc(resampler) => {
+                let adjusted_for_resampling = |samples| {
+                    InSamples(samples).resampled_by(resampler.resample_ratio)
+                        + resampler.output.len()
+                        + resampler
+                            .frames_being_resampled
+                            .samples(resampler.output.channels)
+                };
+                let (lower, upper) = resampler.input.size_hint();
+                let lower = adjusted_for_resampling(lower);
+                let upper = upper.map(adjusted_for_resampling);
+                (lower.raw(), upper.as_ref().map(OutSamples::raw))
+            }
+            #[cfg(feature = "rubato-fft")]
+            ResampleInner::Fft(resampler) => {
+                let adjusted_for_resampling = |samples| {
+                    InSamples(samples).resampled_by(resampler.resample_ratio)
+                        + resampler.output.len()
+                        + resampler
+                            .frames_being_resampled
+                            .samples(resampler.output.channels)
+                };
+                let (lower, upper) = resampler.input.size_hint();
+                let lower = adjusted_for_resampling(lower);
+                let upper = upper.map(adjusted_for_resampling);
+                (lower.raw(), upper.as_ref().map(OutSamples::raw))
+            }
+        }
+    }
+}

--- a/src/generators.rs
+++ b/src/generators.rs
@@ -1,0 +1,10 @@
+//! Sources that produce sound without consuming anything
+
+// Note we make everything be it effects or generators available under <source_type>/<thing>
+
+mod silence;
+
+/// Generators with both the sample rate and channel count known at compile time.
+pub mod const_source {
+    pub use super::silence::const_source::Silence;
+}

--- a/src/generators.rs
+++ b/src/generators.rs
@@ -8,3 +8,8 @@ mod silence;
 pub mod const_source {
     pub use super::silence::const_source::Silence;
 }
+
+/// Generators where the sample rate and channel may be passed in at runtime
+pub mod fixed_source {
+    pub use super::silence::fixed_source::Silence;
+}

--- a/src/generators/silence.rs
+++ b/src/generators/silence.rs
@@ -1,0 +1,54 @@
+pub mod const_source {
+    use crate::ConstSource;
+
+    /// A source producing an infinite amount of Silence. Like all generators you
+    /// probably want to limit the duration of this source.
+    ///
+    /// # Example
+    /// Padding a [`TakeDuration`](crate::effects::const_source::TakeDuration) to
+    /// guarantee an exact playtime:
+    ///
+    /// ```rust,no_run
+    /// # use std::time::Duration;
+    /// # use rodio::nz;
+    /// # use rodio::generators::const_source::Silence;
+    /// # use rodio::ConstSource;
+    /// # let unknown_length = Silence::new();
+    /// let silence: Silence<44100> = Silence::new();
+    /// let two_seconds = unknown_length
+    ///     .chain_source(silence)
+    ///     .take_duration(Duration::from_secs(2));
+    /// ```
+    pub struct Silence<const SR: u32>;
+
+    impl<const SR: u32> Silence<SR> {
+        /// Create an infinite silence
+        pub fn new() -> Self {
+            Self
+        }
+    }
+    
+    impl<const SR: u32> Default for Silence<SR> {
+        fn default() -> Self {
+            Self
+        }
+    }
+
+    impl<const SR: u32> ConstSource<SR, 1> for Silence<SR> {
+        fn total_duration(&self) -> Option<std::time::Duration> {
+            None
+        }
+    }
+
+    impl<const SR: u32> Iterator for Silence<SR> {
+        type Item = crate::Sample;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            Some(0.0)
+        }
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            (usize::MAX, None)
+        }
+    }
+}

--- a/src/generators/silence.rs
+++ b/src/generators/silence.rs
@@ -1,3 +1,66 @@
+pub mod fixed_source {
+    use crate::{ChannelCount, SampleRate};
+    use crate::{FixedSource, nz};
+
+    /// A source producing an infinite amount of Silence. Like all generators you
+    /// probably want to limit the duration of this source.
+    ///
+    /// # Example
+    /// Padding a [`TakeDuration`](crate::fixed_source::Placeholder) to
+    /// guarantee an exact playtime:
+    ///
+    /// ```rust,no_run
+    /// # use std::time::Duration;
+    /// # use rodio::nz;
+    /// # use rodio::generators::fixed_source::Silence;
+    /// # use rodio::{ConstSource, FixedSource};
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let unknown_length = Silence::new(nz!(44100));
+    /// let silence = Silence::new(nz!(44100));
+    /// let two_seconds = unknown_length
+    ///     .try_chain_source(silence)?
+    ///     .take_duration(Duration::from_secs(2));
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub struct Silence {
+        sample_rate: SampleRate,
+    }
+
+    impl Silence {
+        /// Create an infinite silence
+        pub fn new(sample_rate: SampleRate) -> Self {
+            Self { sample_rate }
+        }
+    }
+
+    impl FixedSource for Silence {
+        fn channels(&self) -> ChannelCount {
+            nz!(1)
+        }
+
+        fn sample_rate(&self) -> SampleRate {
+            self.sample_rate
+        }
+
+        fn total_duration(&self) -> Option<std::time::Duration> {
+            None
+        }
+    }
+
+    impl Iterator for Silence {
+        type Item = crate::Sample;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            Some(0.0)
+        }
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            (usize::MAX, None)
+        }
+    }
+}
+
 pub mod const_source {
     use std::time::Duration;
 
@@ -17,6 +80,7 @@ pub mod const_source {
     /// # use rodio::generators::const_source::Silence;
     /// # use rodio::ConstSource;
     /// # let unknown_length = Silence::new();
+    ///
     /// let silence: Silence<44100> = Silence::new();
     /// let two_seconds = unknown_length
     ///     .chain_source(silence)

--- a/src/generators/silence.rs
+++ b/src/generators/silence.rs
@@ -1,11 +1,14 @@
 pub mod const_source {
+    use std::time::Duration;
+
+    use crate::source::SeekError;
     use crate::ConstSource;
 
     /// A source producing an infinite amount of Silence. Like all generators you
     /// probably want to limit the duration of this source.
     ///
     /// # Example
-    /// Padding a [`TakeDuration`](crate::effects::const_source::TakeDuration) to
+    /// Padding a [`TakeDuration`](crate::const_source::Placeholder) to
     /// guarantee an exact playtime:
     ///
     /// ```rust,no_run
@@ -27,7 +30,7 @@ pub mod const_source {
             Self
         }
     }
-    
+
     impl<const SR: u32> Default for Silence<SR> {
         fn default() -> Self {
             Self
@@ -37,6 +40,11 @@ pub mod const_source {
     impl<const SR: u32> ConstSource<SR, 1> for Silence<SR> {
         fn total_duration(&self) -> Option<std::time::Duration> {
             None
+        }
+
+        /// This does nothing since all silence is equal :3
+        fn try_seek(&mut self, _: Duration) -> Result<(), SeekError> {
+            Ok(())
         }
     }
 

--- a/src/generators/silence.rs
+++ b/src/generators/silence.rs
@@ -1,6 +1,9 @@
 pub mod fixed_source {
+    use std::time::Duration;
+
+    use crate::source::SeekError;
+    use crate::{nz, FixedSource};
     use crate::{ChannelCount, SampleRate};
-    use crate::{FixedSource, nz};
 
     /// A source producing an infinite amount of Silence. Like all generators you
     /// probably want to limit the duration of this source.
@@ -45,6 +48,11 @@ pub mod fixed_source {
 
         fn total_duration(&self) -> Option<std::time::Duration> {
             None
+        }
+
+        /// This does nothing since all silence is equal :3
+        fn try_seek(&mut self, _: Duration) -> Result<(), SeekError> {
+            Ok(())
         }
     }
 
@@ -102,7 +110,7 @@ pub mod const_source {
     }
 
     impl<const SR: u32> ConstSource<SR, 1> for Silence<SR> {
-        fn total_duration(&self) -> Option<std::time::Duration> {
+        fn total_duration(&self) -> Option<Duration> {
             None
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,6 +228,8 @@ pub mod conversions;
 pub mod decoder;
 #[cfg(feature = "experimental")]
 pub mod fixed_source;
+pub mod const_source;
+
 pub mod math;
 #[cfg(feature = "recording")]
 /// Microphone input support for audio recording.
@@ -241,6 +243,7 @@ pub use crate::common::{BitDepth, ChannelCount, Float, Sample, SampleRate, DEFAU
 pub use crate::decoder::Decoder;
 #[cfg(feature = "experimental")]
 pub use crate::fixed_source::FixedSource;
+pub use crate::const_source::ConstSource;
 pub use crate::player::Player;
 pub use crate::source::Source;
 pub use crate::spatial_player::SpatialPlayer;
@@ -250,3 +253,5 @@ pub use crate::stream::{play, DeviceSinkBuilder, DeviceSinkError, MixerDeviceSin
 pub use crate::wav_output::wav_to_file;
 #[cfg(feature = "wav_output")]
 pub use crate::wav_output::wav_to_writer;
+
+pub use Source as DynamicSource;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,10 +224,10 @@ pub mod stream;
 mod wav_output;
 
 pub mod buffer;
-pub mod const_source;
 pub mod conversions;
 pub mod decoder;
 
+pub mod const_source;
 pub mod fixed_source;
 
 pub mod generators;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,6 +230,7 @@ pub mod decoder;
 pub mod fixed_source;
 pub mod const_source;
 
+pub mod generators;
 pub mod math;
 #[cfg(feature = "recording")]
 /// Microphone input support for audio recording.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,11 +224,11 @@ pub mod stream;
 mod wav_output;
 
 pub mod buffer;
+pub mod const_source;
 pub mod conversions;
 pub mod decoder;
 #[cfg(feature = "experimental")]
 pub mod fixed_source;
-pub mod const_source;
 
 pub mod generators;
 pub mod math;
@@ -241,10 +241,10 @@ pub mod source;
 pub mod static_buffer;
 
 pub use crate::common::{BitDepth, ChannelCount, Float, Sample, SampleRate, DEFAULT_SAMPLE_RATE};
+pub use crate::const_source::ConstSource;
 pub use crate::decoder::Decoder;
 #[cfg(feature = "experimental")]
 pub use crate::fixed_source::FixedSource;
-pub use crate::const_source::ConstSource;
 pub use crate::player::Player;
 pub use crate::source::Source;
 pub use crate::spatial_player::SpatialPlayer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,10 +227,11 @@ pub mod buffer;
 pub mod const_source;
 pub mod conversions;
 pub mod decoder;
-#[cfg(feature = "experimental")]
+
 pub mod fixed_source;
 
 pub mod generators;
+
 pub mod math;
 #[cfg(feature = "recording")]
 /// Microphone input support for audio recording.
@@ -243,7 +244,6 @@ pub mod static_buffer;
 pub use crate::common::{BitDepth, ChannelCount, Float, Sample, SampleRate, DEFAULT_SAMPLE_RATE};
 pub use crate::const_source::ConstSource;
 pub use crate::decoder::Decoder;
-#[cfg(feature = "experimental")]
 pub use crate::fixed_source::FixedSource;
 pub use crate::player::Player;
 pub use crate::source::Source;

--- a/src/microphone.rs
+++ b/src/microphone.rs
@@ -4,7 +4,7 @@
 //!
 //! ```no_run
 //! use rodio::microphone::MicrophoneBuilder;
-//! use rodio::Source;
+//! use rodio::FixedSource;
 //! use std::time::Duration;
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -106,7 +106,7 @@ use std::time::Duration;
 
 use crate::common::assert_error_traits;
 use crate::conversions::SampleTypeConverter;
-use crate::{Sample, Source};
+use crate::Sample;
 
 mod builder;
 mod config;
@@ -188,25 +188,6 @@ pub struct Microphone {
     config: InputConfig,
 }
 
-impl Source for Microphone {
-    fn current_span_len(&self) -> Option<usize> {
-        None
-    }
-
-    fn channels(&self) -> crate::ChannelCount {
-        self.config.channel_count
-    }
-
-    fn sample_rate(&self) -> crate::SampleRate {
-        self.config.sample_rate
-    }
-
-    fn total_duration(&self) -> Option<std::time::Duration> {
-        None
-    }
-}
-
-#[cfg(feature = "experimental")]
 impl crate::FixedSource for Microphone {
     fn channels(&self) -> crate::ChannelCount {
         self.config.channel_count

--- a/src/microphone/builder.rs
+++ b/src/microphone/builder.rs
@@ -538,7 +538,7 @@ where
     /// # Example
     /// ```no_run
     /// # use rodio::microphone::MicrophoneBuilder;
-    /// # use rodio::Source;
+    /// # use rodio::FixedSource;
     /// # use std::time::Duration;
     /// let mic = MicrophoneBuilder::new()
     ///     .default_device()?

--- a/src/source/amplify.rs
+++ b/src/source/amplify.rs
@@ -21,7 +21,7 @@ pub struct Amplify<I> {
     factor: Float,
 }
 
-impl<I> Amplify<I> {
+impl<S> Amplify<S> {
     /// Modifies the amplification factor.
     #[inline]
     pub fn set_factor(&mut self, factor: Float) {
@@ -34,23 +34,7 @@ impl<I> Amplify<I> {
         self.factor = math::db_to_linear(factor);
     }
 
-    /// Returns a reference to the inner source.
-    #[inline]
-    pub fn inner(&self) -> &I {
-        &self.input
-    }
-
-    /// Returns a mutable reference to the inner source.
-    #[inline]
-    pub fn inner_mut(&mut self) -> &mut I {
-        &mut self.input
-    }
-
-    /// Returns the inner source.
-    #[inline]
-    pub fn into_inner(self) -> I {
-        self.input
-    }
+    crate::common::source::add_inner_accessors! {input}
 }
 
 impl<I> Iterator for Amplify<I>

--- a/src/source/automatic_gain_control/agc.rs
+++ b/src/source/automatic_gain_control/agc.rs
@@ -112,9 +112,9 @@ pub struct AutomaticGainControl<I> {
     slow_down_state: SlowDownState,
 }
 
-impl<I> AutomaticGainControl<I>
+impl<S> AutomaticGainControl<S>
 where
-    I: Source,
+    S: Source,
 {
     /// Constructs an `AutomaticGainControl` object with specified parameters.
     ///
@@ -129,16 +129,16 @@ where
     /// `floor` - The minimum output level (gain floor) that the AGC will not go below
     #[inline]
     pub(crate) fn new(
-        input: I,
+        input: S,
         target_level: Float,
         attack_time: Duration,
         release_time: Duration,
         absolute_max_gain: Float,
         peak_tracking_window: Duration,
         floor: Float,
-    ) -> AutomaticGainControl<I>
+    ) -> AutomaticGainControl<S>
     where
-        I: Source,
+        S: Source,
     {
         let sample_rate = input.sample_rate();
         let attack_duration = duration_to_float(attack_time);
@@ -377,7 +377,7 @@ where
     }
 
     #[inline]
-    fn process_sample(&mut self, sample: I::Item) -> I::Item {
+    fn process_sample(&mut self, sample: S::Item) -> S::Item {
         // Cache atomic loads at the start - avoids repeated atomic operations
         let target_level = self.target_level();
         let absolute_max_gain = self.absolute_max_gain();
@@ -468,15 +468,7 @@ where
         sample * self.current_gain
     }
 
-    /// Returns an immutable reference to the inner source.
-    pub fn inner(&self) -> &I {
-        &self.input
-    }
-
-    /// Returns a mutable reference to the inner source.
-    pub fn inner_mut(&mut self) -> &mut I {
-        &mut self.input
-    }
+    crate::common::source::add_inner_accessors! {input}
 }
 
 impl<I> Iterator for AutomaticGainControl<I>

--- a/src/source/channel_volume.rs
+++ b/src/source/channel_volume.rs
@@ -19,14 +19,14 @@ where
     current_sample: Option<Sample>,
 }
 
-impl<I> ChannelVolume<I>
+impl<S> ChannelVolume<S>
 where
-    I: Source,
+    S: Source,
 {
     /// Wrap the input source and make it mono. Play that mono sound to each
     /// channel at the volume set by the user. The volume can be changed using
     /// [`ChannelVolume::set_volume`].
-    pub fn new(input: I, channel_volumes: Vec<Float>) -> ChannelVolume<I> {
+    pub fn new(input: S, channel_volumes: Vec<Float>) -> ChannelVolume<S> {
         let channel_count = channel_volumes.len(); // See next() implementation.
         ChannelVolume {
             input,
@@ -42,28 +42,12 @@ where
         self.channel_volumes[channel] = volume;
     }
 
-    /// Returns a reference to the inner source.
-    #[inline]
-    pub fn inner(&self) -> &I {
-        &self.input
-    }
-
-    /// Returns a mutable reference to the inner source.
-    #[inline]
-    pub fn inner_mut(&mut self) -> &mut I {
-        &mut self.input
-    }
-
-    /// Returns the inner source.
-    #[inline]
-    pub fn into_inner(self) -> I {
-        self.input
-    }
-
     /// Gets the volume for a given channel number. Returns `None` if channel number is invalid.
     pub fn volume(&self, channel: usize) -> Option<Float> {
         self.channel_volumes.get(channel).copied()
     }
+
+    crate::common::source::add_inner_accessors! {input}
 }
 
 impl<I> Iterator for ChannelVolume<I>

--- a/src/source/delay.rs
+++ b/src/source/delay.rs
@@ -35,27 +35,11 @@ pub struct Delay<I> {
     requested_duration: Duration,
 }
 
-impl<I> Delay<I>
+impl<S> Delay<S>
 where
-    I: Source,
+    S: Source,
 {
-    /// Returns a reference to the inner source.
-    #[inline]
-    pub fn inner(&self) -> &I {
-        &self.input
-    }
-
-    /// Returns a mutable reference to the inner source.
-    #[inline]
-    pub fn inner_mut(&mut self) -> &mut I {
-        &mut self.input
-    }
-
-    /// Returns the inner source.
-    #[inline]
-    pub fn into_inner(self) -> I {
-        self.input
-    }
+    crate::common::source::add_inner_accessors! {input}
 }
 
 impl<I> Iterator for Delay<I>

--- a/src/source/distortion.rs
+++ b/src/source/distortion.rs
@@ -24,7 +24,7 @@ pub struct Distortion<I> {
     threshold: Float,
 }
 
-impl<I> Distortion<I> {
+impl<S> Distortion<S> {
     /// Modifies the distortion gain.
     #[inline]
     pub fn set_gain(&mut self, gain: Float) {
@@ -37,23 +37,7 @@ impl<I> Distortion<I> {
         self.threshold = threshold;
     }
 
-    /// Returns a reference to the inner source.
-    #[inline]
-    pub fn inner(&self) -> &I {
-        &self.input
-    }
-
-    /// Returns a mutable reference to the inner source.
-    #[inline]
-    pub fn inner_mut(&mut self) -> &mut I {
-        &mut self.input
-    }
-
-    /// Returns the inner source.
-    #[inline]
-    pub fn into_inner(self) -> I {
-        self.input
-    }
+    crate::common::source::add_inner_accessors! {input}
 }
 
 impl<I> Iterator for Distortion<I>

--- a/src/source/done.rs
+++ b/src/source/done.rs
@@ -30,24 +30,10 @@ where
             signal_sent: false,
         }
     }
+}
 
-    /// Returns a reference to the inner source.
-    #[inline]
-    pub fn inner(&self) -> &I {
-        &self.input
-    }
-
-    /// Returns a mutable reference to the inner source.
-    #[inline]
-    pub fn inner_mut(&mut self) -> &mut I {
-        &mut self.input
-    }
-
-    /// Returns the inner source.
-    #[inline]
-    pub fn into_inner(self) -> I {
-        self.input
-    }
+impl<S: Source, F: FnMut(&mut S)> Done<S, F> {
+    crate::common::source::add_inner_accessors! {input}
 }
 
 impl<I, F> Iterator for Done<I, F>

--- a/src/source/from_iter.rs
+++ b/src/source/from_iter.rs
@@ -40,10 +40,10 @@ pub struct FromIter<I> {
     sample_rate: SampleRate,
 }
 
-impl<I> FromIter<I> {
+impl<S> FromIter<S> {
     /// Creates a new `FromIter` from an iterator and audio parameters.
     #[inline]
-    pub fn new(iter: I, channels: ChannelCount, sample_rate: SampleRate) -> Self {
+    pub fn new(iter: S, channels: ChannelCount, sample_rate: SampleRate) -> Self {
         Self {
             iter,
             channels,
@@ -51,23 +51,7 @@ impl<I> FromIter<I> {
         }
     }
 
-    /// Destroys this source and returns the underlying iterator.
-    #[inline]
-    pub fn into_inner(self) -> I {
-        self.iter
-    }
-
-    /// Get immutable access to the underlying iterator.
-    #[inline]
-    pub fn inner(&self) -> &I {
-        &self.iter
-    }
-
-    /// Get mutable access to the underlying iterator.
-    #[inline]
-    pub fn inner_mut(&mut self) -> &mut I {
-        &mut self.iter
-    }
+    crate::common::source::add_inner_accessors! {iter}
 }
 
 impl<I> Iterator for FromIter<I>

--- a/src/source/linear_ramp.rs
+++ b/src/source/linear_ramp.rs
@@ -46,27 +46,11 @@ pub struct LinearGainRamp<I> {
     span: SpanTracker,
 }
 
-impl<I> LinearGainRamp<I>
+impl<S> LinearGainRamp<S>
 where
-    I: Source,
+    S: Source,
 {
-    /// Returns a reference to the inner source.
-    #[inline]
-    pub fn inner(&self) -> &I {
-        &self.input
-    }
-
-    /// Returns a mutable reference to the inner source.
-    #[inline]
-    pub fn inner_mut(&mut self) -> &mut I {
-        &mut self.input
-    }
-
-    /// Returns the inner source.
-    #[inline]
-    pub fn into_inner(self) -> I {
-        self.input
-    }
+    crate::common::source::add_inner_accessors! {input}
 }
 
 impl<I> Iterator for LinearGainRamp<I>

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -217,9 +217,7 @@ pub trait Source: Iterator<Item = Sample> {
     /// Returns the rate at which the source should be played. In number of samples per second.
     fn sample_rate(&self) -> SampleRate;
 
-    /// Returns the total duration of this source, if known.
-    ///
-    /// `None` indicates at the same time "infinite" or "unknown".
+    #[doc = include_str!("../docs/total_duration.md")]
     fn total_duration(&self) -> Option<Duration>;
 
     /// Stores the source in a buffer in addition to returning it. This iterator can be cloned.

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -695,23 +695,8 @@ pub trait Source: Iterator<Item = Sample> {
         SampleRateConverter::new(self, target_rate, config)
     }
 
-    /// Attempts to seek to a given position in the current source.
-    ///
-    /// As long as the duration of the source is known, seek is guaranteed to saturate
-    /// at the end of the source. For example given a source that reports a total duration
-    /// of 42 seconds calling `try_seek()` with 60 seconds as argument will seek to
-    /// 42 seconds.
-    ///
-    /// # Errors
-    /// This function will return [`SeekError::NotSupported`] if one of the underlying
-    /// sources does not support seeking.
-    ///
-    /// It will return an error if an implementation ran
-    /// into one during the seek.
-    ///
-    /// Seeking beyond the end of a source might return an error if the total duration of
-    /// the source is not known.
     #[allow(unused_variables)]
+    #[doc = include_str!("../docs/try_seek.md")]
     fn try_seek(&mut self, pos: Duration) -> Result<(), SeekError> {
         Err(SeekError::NotSupported {
             underlying_source: std::any::type_name::<Self>(),

--- a/src/source/pausable.rs
+++ b/src/source/pausable.rs
@@ -34,9 +34,9 @@ pub struct Pausable<I> {
     remaining_paused_samples: u16,
 }
 
-impl<I> Pausable<I>
+impl<S> Pausable<S>
 where
-    I: Source,
+    S: Source,
 {
     /// Sets whether the filter applies.
     ///
@@ -56,23 +56,7 @@ where
         self.paused_channels.is_some()
     }
 
-    /// Returns a reference to the inner source.
-    #[inline]
-    pub fn inner(&self) -> &I {
-        &self.input
-    }
-
-    /// Returns a mutable reference to the inner source.
-    #[inline]
-    pub fn inner_mut(&mut self) -> &mut I {
-        &mut self.input
-    }
-
-    /// Returns the inner source.
-    #[inline]
-    pub fn into_inner(self) -> I {
-        self.input
-    }
+    crate::common::source::add_inner_accessors! {input}
 }
 
 impl<I> Iterator for Pausable<I>

--- a/src/source/periodic.rs
+++ b/src/source/periodic.rs
@@ -41,29 +41,13 @@ pub struct PeriodicAccess<I, F> {
     samples_until_update: usize,
 }
 
-impl<I, F> PeriodicAccess<I, F>
+impl<S, F> PeriodicAccess<S, F>
 where
-    I: Source,
+    S: Source,
 
-    F: FnMut(&mut I),
+    F: FnMut(&mut S),
 {
-    /// Returns a reference to the inner source.
-    #[inline]
-    pub fn inner(&self) -> &I {
-        &self.input
-    }
-
-    /// Returns a mutable reference to the inner source.
-    #[inline]
-    pub fn inner_mut(&mut self) -> &mut I {
-        &mut self.input
-    }
-
-    /// Returns the inner source.
-    #[inline]
-    pub fn into_inner(self) -> I {
-        self.input
-    }
+    crate::common::source::add_inner_accessors! {input}
 }
 
 impl<I, F> Iterator for PeriodicAccess<I, F>

--- a/src/source/position.rs
+++ b/src/source/position.rs
@@ -28,24 +28,8 @@ pub struct TrackPosition<I> {
     span: SpanTracker,
 }
 
-impl<I> TrackPosition<I> {
-    /// Returns a reference to the inner source.
-    #[inline]
-    pub fn inner(&self) -> &I {
-        &self.input
-    }
-
-    /// Returns a mutable reference to the inner source.
-    #[inline]
-    pub fn inner_mut(&mut self) -> &mut I {
-        &mut self.input
-    }
-
-    /// Returns the inner source.
-    #[inline]
-    pub fn into_inner(self) -> I {
-        self.input
-    }
+impl<S> TrackPosition<S> {
+    crate::common::source::add_inner_accessors! {input}
 }
 
 impl<I> TrackPosition<I>

--- a/src/source/skip.rs
+++ b/src/source/skip.rs
@@ -89,27 +89,11 @@ pub struct SkipDuration<I> {
     skipped_duration: Duration,
 }
 
-impl<I> SkipDuration<I>
+impl<S> SkipDuration<S>
 where
-    I: Source,
+    S: Source,
 {
-    /// Returns a reference to the inner source.
-    #[inline]
-    pub fn inner(&self) -> &I {
-        &self.input
-    }
-
-    /// Returns a mutable reference to the inner source.
-    #[inline]
-    pub fn inner_mut(&mut self) -> &mut I {
-        &mut self.input
-    }
-
-    /// Returns the inner source.
-    #[inline]
-    pub fn into_inner(self) -> I {
-        self.input
-    }
+    crate::common::source::add_inner_accessors! {input}
 }
 
 impl<I> Iterator for SkipDuration<I>

--- a/src/source/skippable.rs
+++ b/src/source/skippable.rs
@@ -23,7 +23,7 @@ pub struct Skippable<I> {
     do_skip: bool,
 }
 
-impl<I> Skippable<I> {
+impl<S> Skippable<S> {
     /// Skips the current source
     #[inline]
     pub fn skip(&mut self) {
@@ -36,23 +36,7 @@ impl<I> Skippable<I> {
         self.do_skip
     }
 
-    /// Returns a reference to the inner source.
-    #[inline]
-    pub fn inner(&self) -> &I {
-        &self.input
-    }
-
-    /// Returns a mutable reference to the inner source.
-    #[inline]
-    pub fn inner_mut(&mut self) -> &mut I {
-        &mut self.input
-    }
-
-    /// Returns the inner source.
-    #[inline]
-    pub fn into_inner(self) -> I {
-        self.input
-    }
+    crate::common::source::add_inner_accessors! {input}
 }
 
 impl<I> Iterator for Skippable<I>

--- a/src/source/speed.rs
+++ b/src/source/speed.rs
@@ -64,9 +64,9 @@ pub struct Speed<I> {
     factor: f32,
 }
 
-impl<I> Speed<I>
+impl<S> Speed<S>
 where
-    I: Source,
+    S: Source,
 {
     /// Modifies the speed factor.
     #[inline]
@@ -74,23 +74,7 @@ where
         self.factor = factor;
     }
 
-    /// Returns a reference to the inner source.
-    #[inline]
-    pub fn inner(&self) -> &I {
-        &self.input
-    }
-
-    /// Returns a mutable reference to the inner source.
-    #[inline]
-    pub fn inner_mut(&mut self) -> &mut I {
-        &mut self.input
-    }
-
-    /// Returns the inner source.
-    #[inline]
-    pub fn into_inner(self) -> I {
-        self.input
-    }
+    crate::common::source::add_inner_accessors! {input}
 }
 
 impl<I> Iterator for Speed<I>

--- a/src/source/stoppable.rs
+++ b/src/source/stoppable.rs
@@ -19,30 +19,14 @@ pub struct Stoppable<I> {
     stopped: bool,
 }
 
-impl<I> Stoppable<I> {
+impl<S> Stoppable<S> {
     /// Stops the sound.
     #[inline]
     pub fn stop(&mut self) {
         self.stopped = true;
     }
 
-    /// Returns a reference to the inner source.
-    #[inline]
-    pub fn inner(&self) -> &I {
-        &self.input
-    }
-
-    /// Returns a mutable reference to the inner source.
-    #[inline]
-    pub fn inner_mut(&mut self) -> &mut I {
-        &mut self.input
-    }
-
-    /// Returns the inner source.
-    #[inline]
-    pub fn into_inner(self) -> I {
-        self.input
-    }
+    crate::common::source::add_inner_accessors! {input}
 }
 
 impl<I> Iterator for Stoppable<I>

--- a/src/source/take.rs
+++ b/src/source/take.rs
@@ -56,35 +56,19 @@ pub struct TakeDuration<I> {
     silence_samples_remaining: usize,
 }
 
-impl<I> TakeDuration<I>
+impl<S> TakeDuration<S>
 where
-    I: Source,
+    S: Source,
 {
     /// Returns the duration elapsed for each sample extracted.
     #[inline]
-    fn get_duration_per_sample(input: &I) -> Duration {
+    fn get_duration_per_sample(input: &S) -> Duration {
         let ns = NANOS_PER_SEC / (input.sample_rate().get() as u64 * input.channels().get() as u64);
         // \|/ the maximum value of `ns` is one billion, so this can't fail
         Duration::new(0, ns as u32)
     }
 
-    /// Returns a reference to the inner source.
-    #[inline]
-    pub fn inner(&self) -> &I {
-        &self.input
-    }
-
-    /// Returns a mutable reference to the inner source.
-    #[inline]
-    pub fn inner_mut(&mut self) -> &mut I {
-        &mut self.input
-    }
-
-    /// Returns the inner source.
-    #[inline]
-    pub fn into_inner(self) -> I {
-        self.input
-    }
+    crate::common::source::add_inner_accessors! {input}
 
     /// Make the truncated source end with a FadeOut. The fadeout covers the
     /// entire length of the take source.


### PR DESCRIPTION
review **after** #905 (this includes it's changes)

Tracking issue: https://github.com/RustAudio/rodio/issues/901
 
- Adds sample rate conversion to both FixedSource and ConstSource

This uses the rubato resampler. It builds around InnerResampler. This might not be as optimal as it could be, especially in the ConstSource case but it seems like a good start for now.