### PR TITLE
The ability to fetch the current length of a SourcesQueueInput instance.

### DIFF
--- a/src/queue.rs
+++ b/src/queue.rs
@@ -100,6 +100,11 @@ impl SourcesQueueInput {
         self.keep_alive_if_empty.load(Ordering::Acquire)
     }
 
+    /// Returns the additional length of the queue.
+    pub fn queue_len(&self) -> usize {
+        self.next_sounds.lock().unwrap().len()
+    }
+
     /// Removes all the sounds from the queue. Returns the number of sounds cleared.
     pub fn clear(&self) -> usize {
         let mut sounds = self.next_sounds.lock().unwrap();


### PR DESCRIPTION
I wanted to know the length of a queue and I could not find a built-in function to do so. I thought this might be helpful to implement so that with this function we can expose the length of the queue. 