### PR TITLE
refactor: Update symphonia from `0.5.5` to `0.6.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,12 +109,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
 name = "asio-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,15 +599,6 @@ name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "enum-primitive-derive"
@@ -2015,9 +2000,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "symphonia"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
+checksum = "a7edef6a96b696d4e0cab5ee9ebb7ca155ed95f30a6b45bbb8b97d2727f02424"
 dependencies = [
  "lazy_static",
  "symphonia-bundle-flac",
@@ -2038,9 +2023,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-adapter-fdk-aac"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82194865c2b438a75a2b40a12495d5d1a6c3cb2bb36671f9921ab44756ee77d2"
+checksum = "b9cc5d16c27e9cd23e028655c3740ec78e31eb6cb513f1837d36afed82b2dd44"
 dependencies = [
  "fdk-aac",
  "log",
@@ -2049,9 +2034,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-adapter-libopus"
-version = "0.2.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bfc8e95f95c23ed1b5328eb66920ad28d9968c797f9c7aa755d4b45a5f47a41"
+checksum = "c6febe6f88f9a9483db7e5b72a2dad916d8f8eb588d18905a39c861319fc7fa1"
 dependencies = [
  "log",
  "opusic-sys",
@@ -2060,44 +2045,44 @@ dependencies = [
 
 [[package]]
 name = "symphonia-bundle-flac"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91565e180aea25d9b80a910c546802526ffd0072d0b8974e3ebe59b686c9976"
+checksum = "6405d5c34ff6f8f7ca08a4101efe66d21e180f7322ef9359900a0e55698a7892"
 dependencies = [
  "log",
+ "symphonia-common",
  "symphonia-core",
  "symphonia-metadata",
- "symphonia-utils-xiph",
 ]
 
 [[package]]
 name = "symphonia-bundle-mp3"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4872dd6bb56bf5eac799e3e957aa1981086c3e613b27e0ac23b176054f7c57ed"
+checksum = "98ea5ffc8716bff677dfb3b01b420c7b758de901a72b8c330bf2040ab74b4add"
 dependencies = [
  "lazy_static",
  "log",
  "symphonia-core",
- "symphonia-metadata",
 ]
 
 [[package]]
 name = "symphonia-codec-aac"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c263845aa86881416849c1729a54c7f55164f8b96111dba59de46849e73a790"
+checksum = "f5bf8e39552d34a3c4c98333370e62f48c92456d2e814f273b5c3ad7c4a5f45c"
 dependencies = [
  "lazy_static",
  "log",
+ "symphonia-common",
  "symphonia-core",
 ]
 
 [[package]]
 name = "symphonia-codec-adpcm"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dddc50e2bbea4cfe027441eece77c46b9f319748605ab8f3443350129ddd07f"
+checksum = "445932ecb0c59362fde9c082dd63a75380650c5077fdb8b80b8cac850442a74c"
 dependencies = [
  "log",
  "symphonia-core",
@@ -2105,19 +2090,20 @@ dependencies = [
 
 [[package]]
 name = "symphonia-codec-alac"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8413fa754942ac16a73634c9dfd1500ed5c61430956b33728567f667fdd393ab"
+checksum = "920a78f96f3cf62932d0c497959c0cc2100ef36b03c7ca1417b260f432a482d8"
 dependencies = [
  "log",
+ "symphonia-common",
  "symphonia-core",
 ]
 
 [[package]]
 name = "symphonia-codec-pcm"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e89d716c01541ad3ebe7c91ce4c8d38a7cf266a3f7b2f090b108fb0cb031d95"
+checksum = "e04ba75686acbe43542fdd374571195f0530c0b7785ca25cc6840e9c6c4b6eea"
 dependencies = [
  "log",
  "symphonia-core",
@@ -2125,83 +2111,93 @@ dependencies = [
 
 [[package]]
 name = "symphonia-codec-vorbis"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f025837c309cd69ffef572750b4a2257b59552c5399a5e49707cc5b1b85d1c73"
+checksum = "73d90b4fcf796137cc683c538282804ff9629f8ad9dbfd881fcbba331ac4e986"
+dependencies = [
+ "log",
+ "symphonia-common",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-common"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acc3fcc18ec9b8cdd48614e259c4cf0d27b71d41e5d9b120b42c5adab12d7c4"
 dependencies = [
  "log",
  "symphonia-core",
- "symphonia-utils-xiph",
+ "symphonia-metadata",
 ]
 
 [[package]]
 name = "symphonia-core"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea00cc4f79b7f6bb7ff87eddc065a1066f3a43fe1875979056672c9ef948c2af"
+checksum = "01c412864d599d4750d0c3d684d7e093ec05e5309681ef5252cc1096a437f6e0"
 dependencies = [
- "arrayvec",
- "bitflags 1.3.2",
+ "bitflags 2.13.0",
  "bytemuck",
  "lazy_static",
  "log",
+ "num-complex",
  "rustfft",
+ "smallvec",
 ]
 
 [[package]]
 name = "symphonia-format-caf"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8faf379316b6b6e6bbc274d00e7a592e0d63ff1a7e182ce8ba25e24edd3d096"
+checksum = "ab64327ee1920531c5bf86cf7e9cd1a599d57013ddc30691da62683cefc65191"
 dependencies = [
  "log",
+ "symphonia-common",
  "symphonia-core",
- "symphonia-metadata",
 ]
 
 [[package]]
 name = "symphonia-format-isomp4"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243739585d11f81daf8dac8d9f3d18cc7898f6c09a259675fc364b382c30e0a5"
+checksum = "0e681a70e1870d34e02abf1dbc51e4267c3f1827801474e8870be8c689fc4dc3"
 dependencies = [
- "encoding_rs",
  "log",
+ "symphonia-common",
  "symphonia-core",
  "symphonia-metadata",
- "symphonia-utils-xiph",
 ]
 
 [[package]]
 name = "symphonia-format-mkv"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122d786d2c43a49beb6f397551b4a050d8229eaa54c7ddf9ee4b98899b8742d0"
+checksum = "d015c5c0558864665894b3f4cbd95e10abb01b9c868e751c72670f326a56360e"
 dependencies = [
  "lazy_static",
  "log",
+ "symphonia-common",
  "symphonia-core",
- "symphonia-metadata",
- "symphonia-utils-xiph",
 ]
 
 [[package]]
 name = "symphonia-format-ogg"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b4955c67c1ed3aa8ae8428d04ca8397fbef6a19b2b051e73b5da8b1435639cb"
+checksum = "0b5495e7f7e3c7035328d82b6d6e377eef289bb0c4105bdeb557fc93a833f994"
 dependencies = [
  "log",
+ "symphonia-common",
  "symphonia-core",
  "symphonia-metadata",
- "symphonia-utils-xiph",
 ]
 
 [[package]]
 name = "symphonia-format-riff"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d7c3df0e7d94efb68401d81906eae73c02b40d5ec1a141962c592d0f11a96f"
+checksum = "1ff70929083a8c1a5f6cd7c904b6071c7914ad04739b510c2f7239dfc9b7dabe"
 dependencies = [
  "extended",
  "log",
@@ -2211,24 +2207,15 @@ dependencies = [
 
 [[package]]
 name = "symphonia-metadata"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36306ff42b9ffe6e5afc99d49e121e0bd62fe79b9db7b9681d48e29fa19e6b16"
+checksum = "83713a97705d77bdef7cdbc0768fd6e5a54e4cd7e48d60a806ae85639e2c87c6"
 dependencies = [
- "encoding_rs",
  "lazy_static",
  "log",
+ "regex-lite",
+ "smallvec",
  "symphonia-core",
-]
-
-[[package]]
-name = "symphonia-utils-xiph"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27c85ab799a338446b68eec77abf42e1a6f1bb490656e121c6e27bfbab9f16"
-dependencies = [
- "symphonia-core",
- "symphonia-metadata",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,7 +154,7 @@ claxon = { version = "0.4", optional = true }
 hound = { version = "3.5", optional = true }
 lewton = { version = "0.10", optional = true }
 minimp3_fixed = { version = "0.5.4", optional = true }
-symphonia = { version = "0.5.5", optional = true, default-features = false }
+symphonia = { version = "0.6.1", optional = true, default-features = false }
 crossbeam-channel = { version = "0.5.15", optional = true }
 thiserror = "2"
 
@@ -168,7 +168,7 @@ rtrb = { version = "0.3.2", optional = true }
 # Rubato resampling
 rubato = { version = "3.0", default-features = false }
 
-symphonia-adapter-libopus = { version = "0.2", optional = true }
+symphonia-adapter-libopus = { version = "0.3", optional = true }
 
 [dev-dependencies]
 quickcheck = "1"
@@ -177,7 +177,7 @@ rstest_reuse = "0.7"
 approx = "0.5.1"
 divan = "0.1.14"
 inquire = "0.9.3"
-symphonia-adapter-fdk-aac = "0.1"
+symphonia-adapter-fdk-aac = "0.2"
 clap = { version = "4", features = ["derive"] }
 
 [[bench]]

--- a/src/decoder/builder.rs
+++ b/src/decoder/builder.rs
@@ -46,7 +46,7 @@ use crate::decoder::symphonia::Registry;
 use self::read_seek_source::ReadSeekSource;
 #[cfg(feature = "symphonia")]
 use ::symphonia::core::{
-    codecs::CodecRegistry,
+    codecs::registry::{CodecRegistry, RegisterableAudioDecoder},
     io::{MediaSource, MediaSourceStream},
 };
 #[cfg(feature = "symphonia")]
@@ -104,7 +104,7 @@ impl Default for Settings {
                 let mut codec_registry = CodecRegistry::new();
                 register_enabled_codecs(&mut codec_registry);
                 #[cfg(feature = "symphonia-libopus")]
-                codec_registry.register_all::<symphonia_adapter_libopus::OpusDecoder>();
+                codec_registry.register_audio_decoder::<symphonia_adapter_libopus::OpusDecoder>();
                 Registry::new(codec_registry)
             },
         }
@@ -257,9 +257,12 @@ impl<R: Read + Seek + Send + Sync + 'static> DecoderBuilder<R> {
     #[cfg(feature = "symphonia")]
     pub fn with_symphonia_decoder<D>(self) -> Self
     where
-        D: ::symphonia::core::codecs::Decoder,
+        D: RegisterableAudioDecoder,
     {
-        self.settings.codec_registry.write().register_all::<D>();
+        self.settings
+            .codec_registry
+            .write()
+            .register_audio_decoder::<D>();
         self
     }
 
@@ -296,7 +299,7 @@ impl<R: Read + Seek + Send + Sync + 'static> DecoderBuilder<R> {
     }
 
     /// Creates the decoder implementation with configured settings.
-    fn build_impl(self) -> Result<(DecoderImpl<R>, Settings), DecoderError> {
+    fn build_impl(self) -> Result<(DecoderImpl<'static, R>, Settings), DecoderError> {
         let data = self.data.ok_or(DecoderError::UnrecognizedFormat)?;
 
         #[cfg(all(feature = "hound", not(feature = "symphonia-wav")))]
@@ -346,7 +349,7 @@ impl<R: Read + Seek + Send + Sync + 'static> DecoderBuilder<R> {
     ///
     /// Returns `DecoderError::UnrecognizedFormat` if the audio format could not be determined
     /// or is not supported.
-    pub fn build(self) -> Result<Decoder<R>, DecoderError> {
+    pub fn build(self) -> Result<Decoder<'static, R>, DecoderError> {
         let (decoder, _) = self.build_impl()?;
         Ok(Decoder(decoder))
     }
@@ -357,7 +360,7 @@ impl<R: Read + Seek + Send + Sync + 'static> DecoderBuilder<R> {
     ///
     /// Returns `DecoderError::UnrecognizedFormat` if the audio format could not be determined
     /// or is not supported.
-    pub fn build_looped(self) -> Result<LoopedDecoder<R>, DecoderError> {
+    pub fn build_looped(self) -> Result<LoopedDecoder<'static, R>, DecoderError> {
         let (decoder, settings) = self.build_impl()?;
         Ok(LoopedDecoder {
             inner: Some(decoder),

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -81,7 +81,7 @@ mod wav;
 
 /// Source of audio samples decoded from an input stream.
 /// See the [module-level documentation](self) for examples and usage.
-pub struct Decoder<R: Read + Seek>(DecoderImpl<R>);
+pub struct Decoder<'a, R: Read + Seek>(DecoderImpl<'a, R>);
 
 /// Source of audio samples from decoding a file that never ends.
 /// When the end of the file is reached, the decoder starts again from the beginning.
@@ -98,9 +98,9 @@ pub struct Decoder<R: Read + Seek>(DecoderImpl<R>);
 /// let file = File::open("audio.mp3").unwrap();
 /// let looped_decoder = Decoder::new_looped(file).unwrap();
 /// ```
-pub struct LoopedDecoder<R: Read + Seek> {
+pub struct LoopedDecoder<'a, R: Read + Seek> {
     /// The underlying decoder implementation.
-    inner: Option<DecoderImpl<R>>,
+    inner: Option<DecoderImpl<'a, R>>,
 
     /// Configuration settings for the decoder.
     settings: Settings,
@@ -109,7 +109,7 @@ pub struct LoopedDecoder<R: Read + Seek> {
 // Cannot really reduce the size of the VorbisDecoder. There are not any
 // arrays just a lot of struct fields.
 #[allow(clippy::large_enum_variant)]
-enum DecoderImpl<R: Read + Seek> {
+enum DecoderImpl<'a, R: Read + Seek> {
     #[cfg(all(feature = "hound", not(feature = "symphonia-wav")))]
     Wav(wav::WavDecoder<R>),
     #[cfg(all(feature = "lewton", not(feature = "symphonia-vorbis")))]
@@ -119,7 +119,7 @@ enum DecoderImpl<R: Read + Seek> {
     #[cfg(all(feature = "minimp3", not(feature = "symphonia-mp3")))]
     Mp3(mp3::Mp3Decoder<R>),
     #[cfg(feature = "symphonia")]
-    Symphonia(symphonia::SymphoniaDecoder, PhantomData<R>),
+    Symphonia(symphonia::SymphoniaDecoder<'a>, PhantomData<R>),
     // This variant is here just to satisfy the compiler when there are no decoders enabled.
     // It is unreachable and should never be constructed.
     #[allow(dead_code)]
@@ -128,7 +128,7 @@ enum DecoderImpl<R: Read + Seek> {
 
 enum Unreachable {}
 
-impl<R: Read + Seek> DecoderImpl<R> {
+impl<'a, R: Read + Seek> DecoderImpl<'a, R> {
     #[inline]
     fn next(&mut self) -> Option<Sample> {
         match self {
@@ -281,7 +281,7 @@ impl<R: Read + Seek> DecoderImpl<R> {
 /// let file = File::open("audio.mp3").unwrap();
 /// let decoder = Decoder::try_from(file).unwrap();
 /// ```
-impl TryFrom<std::fs::File> for Decoder<BufReader<std::fs::File>> {
+impl TryFrom<std::fs::File> for Decoder<'_, BufReader<std::fs::File>> {
     type Error = DecoderError;
 
     fn try_from(file: std::fs::File) -> Result<Self, Self::Error> {
@@ -317,7 +317,7 @@ impl TryFrom<std::fs::File> for Decoder<BufReader<std::fs::File>> {
 /// let reader = BufReader::new(file);
 /// let decoder = Decoder::try_from(reader).unwrap();
 /// ```
-impl<R> TryFrom<BufReader<R>> for Decoder<BufReader<R>>
+impl<'a, R> TryFrom<BufReader<R>> for Decoder<'a, BufReader<R>>
 where
     R: Read + Seek + Send + Sync + 'static,
 {
@@ -348,7 +348,7 @@ where
 /// let cursor = Cursor::new(data);
 /// let decoder = Decoder::try_from(cursor).unwrap();
 /// ```
-impl<T> TryFrom<std::io::Cursor<T>> for Decoder<std::io::Cursor<T>>
+impl<T> TryFrom<std::io::Cursor<T>> for Decoder<'_, std::io::Cursor<T>>
 where
     T: AsRef<[u8]> + Send + Sync + 'static,
 {
@@ -359,7 +359,7 @@ where
     }
 }
 
-impl<R: Read + Seek + Send + Sync + 'static> Decoder<R> {
+impl<'a, R: Read + Seek + Send + Sync + 'static> Decoder<'a, R> {
     /// Returns a builder for creating a new decoder with customizable settings.
     ///
     /// # Examples
@@ -400,7 +400,7 @@ impl<R: Read + Seek + Send + Sync + 'static> Decoder<R> {
     ///
     /// Returns `DecoderError::UnrecognizedFormat` if the audio format could not be determined
     /// or is not supported.
-    pub fn new_looped(data: R) -> Result<LoopedDecoder<R>, DecoderError> {
+    pub fn new_looped(data: R) -> Result<LoopedDecoder<'a, R>, DecoderError> {
         DecoderBuilder::new().with_data(data).build_looped()
     }
 
@@ -561,7 +561,7 @@ impl<R: Read + Seek + Send + Sync + 'static> Decoder<R> {
     }
 }
 
-impl<R> Iterator for Decoder<R>
+impl<'a, R> Iterator for Decoder<'a, R>
 where
     R: Read + Seek,
 {
@@ -578,7 +578,7 @@ where
     }
 }
 
-impl<R> Source for Decoder<R>
+impl<'a, R> Source for Decoder<'a, R>
 where
     R: Read + Seek,
 {
@@ -607,7 +607,7 @@ where
     }
 }
 
-impl<R> Iterator for LoopedDecoder<R>
+impl<'a, R> Iterator for LoopedDecoder<'a, R>
 where
     R: Read + Seek,
 {
@@ -707,7 +707,7 @@ where
     }
 }
 
-impl<R> Source for LoopedDecoder<R>
+impl<'a, R> Source for LoopedDecoder<'a, R>
 where
     R: Read + Seek,
 {

--- a/src/decoder/symphonia.rs
+++ b/src/decoder/symphonia.rs
@@ -5,14 +5,16 @@ use std::{
 };
 use symphonia::{
     core::{
-        audio::{AudioBufferRef, SampleBuffer, SignalSpec},
-        codecs::{CodecRegistry, Decoder, DecoderOptions, CODEC_TYPE_NULL},
+        audio::{AudioSpec, GenericAudioBufferRef},
+        codecs::{
+            audio::{AudioCodecParameters, AudioDecoder, AudioDecoderOptions},
+            registry::CodecRegistry,
+            CodecParameters,
+        },
         errors::Error,
-        formats::{FormatOptions, FormatReader, SeekMode, SeekTo, SeekedTo},
+        formats::{probe::Hint, FormatOptions, FormatReader, SeekMode, SeekTo, SeekedTo},
         io::MediaSourceStream,
         meta::MetadataOptions,
-        probe::Hint,
-        units,
     },
     default::get_probe,
 };
@@ -48,21 +50,37 @@ impl Registry {
     }
 }
 
-pub(crate) struct SymphoniaDecoder {
-    decoder: Box<dyn Decoder>,
+fn samples_from_time_f64(
+    t: symphonia::core::units::Time,
+    sample_rate: u32,
+    channels: u32,
+) -> usize {
+    let (secs_i64, nanos_u32) = t.parts();
+    if secs_i64 < 0 {
+        return 0;
+    }
+    let secs = secs_i64 as f64 + (nanos_u32 as f64) / 1e9_f64;
+    (secs * sample_rate as f64 * channels as f64).ceil() as usize
+}
+
+pub(crate) struct SymphoniaDecoder<'a> {
+    decoder: Box<dyn AudioDecoder>,
     current_span_offset: usize,
-    format: Box<dyn FormatReader>,
+    format: Box<dyn FormatReader + 'a>,
     total_duration: Option<Duration>,
-    buffer: SampleBuffer<Sample>,
-    spec: SignalSpec,
+    buffer: Vec<Sample>,
+    spec: AudioSpec,
     seek_mode: SeekMode,
     selected_track_id: u32,
     samples_in_current_frame: usize,
     silence_samples_remaining: usize,
 }
 
-impl SymphoniaDecoder {
-    pub(crate) fn new(mss: MediaSourceStream, settings: &Settings) -> Result<Self, DecoderError> {
+impl<'a> SymphoniaDecoder<'a> {
+    pub(crate) fn new(
+        mss: MediaSourceStream<'a>,
+        settings: &Settings,
+    ) -> Result<Self, DecoderError> {
         match SymphoniaDecoder::init(mss, settings) {
             Err(e) => match e {
                 Error::IoError(e) => Err(DecoderError::IoError(e.to_string())),
@@ -73,6 +91,8 @@ impl SymphoniaDecoder {
                 Error::Unsupported(_) => Err(DecoderError::UnrecognizedFormat),
                 Error::LimitError(e) => Err(DecoderError::LimitError(e)),
                 Error::ResetRequired => Err(DecoderError::ResetRequired),
+                // Catch-all for future/other Error variants (required because Error is non-exhaustive)
+                _ => Err(DecoderError::IoError(format!("probe error: {:?}", e))),
             },
             Ok(Some(decoder)) => Ok(decoder),
             Ok(None) => Err(DecoderError::NoStreams),
@@ -80,14 +100,14 @@ impl SymphoniaDecoder {
     }
 
     #[inline]
-    pub(crate) fn into_inner(self) -> MediaSourceStream {
+    pub(crate) fn into_inner(self) -> MediaSourceStream<'a> {
         self.format.into_inner()
     }
 
     fn init(
-        mss: MediaSourceStream,
+        mss: MediaSourceStream<'a>,
         settings: &Settings,
-    ) -> symphonia::core::errors::Result<Option<SymphoniaDecoder>> {
+    ) -> symphonia::core::errors::Result<Option<SymphoniaDecoder<'a>>> {
         let mut hint = Hint::new();
         if let Some(ext) = settings.hint.as_ref() {
             hint.with_extension(ext);
@@ -95,55 +115,70 @@ impl SymphoniaDecoder {
         if let Some(typ) = settings.mime_type.as_ref() {
             hint.mime_type(typ);
         }
-        let format_opts: FormatOptions = FormatOptions {
-            enable_gapless: settings.gapless,
-            ..Default::default()
-        };
+
+        let format_opts: FormatOptions = Default::default();
+
         let metadata_opts: MetadataOptions = Default::default();
         let seek_mode = if settings.coarse_seek {
             SeekMode::Coarse
         } else {
             SeekMode::Accurate
         };
-        let mut probed = get_probe().format(&hint, mss, &format_opts, &metadata_opts)?;
 
-        let stream = match probed.format.default_track() {
-            Some(stream) => stream,
-            None => return Ok(None),
-        };
+        // Probe the input and get the FormatReader directly.
+        let mut format = get_probe().probe(&hint, mss, format_opts, metadata_opts)?;
 
-        // Select the first supported track
-        let track = probed
-            .format
+        // Find the first track that contains audio codec parameters
+        let track = format
             .tracks()
             .iter()
-            .find(|t| t.codec_params.codec != CODEC_TYPE_NULL)
+            .find(|t| matches!(t.codec_params.as_ref(), Some(CodecParameters::Audio(_))))
             .ok_or(symphonia::core::errors::Error::Unsupported(
-                "No track with supported codec",
+                "No track with audio codec parameters",
             ))?;
         let track_id = track.id;
+
+        let audio_params: &AudioCodecParameters = match &track.codec_params {
+            Some(CodecParameters::Audio(a)) => a,
+            _ => {
+                return Err(symphonia::core::errors::Error::Unsupported(
+                    "Track does not contain audio codec parameters",
+                ))
+            }
+        };
+
+        let mut decoder_opts = AudioDecoderOptions::default();
+        decoder_opts.gapless = settings.gapless;
 
         let mut decoder = settings
             .codec_registry
             .read()
-            .make(&track.codec_params, &DecoderOptions::default())?;
+            .make_audio_decoder(audio_params, &decoder_opts)?;
 
         let total_duration = track
-            .codec_params
             .time_base
-            .zip(stream.codec_params.n_frames)
-            .map(|(base, spans)| base.calc_time(spans).into())
-            .filter(|d: &Duration| !d.is_zero());
+            .zip(track.duration)
+            .and_then(|(tb, dur)| tb.calc_duration(dur))
+            .and_then(|t| {
+                let (secs, nanos) = t.parts();
+                if secs < 0 {
+                    None // std::time::Duration can't represent negative times
+                } else {
+                    Some(Duration::new(secs as u64, nanos))
+                }
+            })
+            .filter(|d| !d.is_zero());
 
         let decoded = loop {
-            let current_span = match probed.format.next_packet() {
-                Ok(packet) => packet,
+            let current_span = match format.next_packet() {
+                Ok(Some(packet)) => packet,
+                Ok(None) => break decoder.last_decoded(), // EOF
                 Err(Error::IoError(_)) => break decoder.last_decoded(),
                 Err(e) => return Err(e),
             };
 
             // If the packet does not belong to the selected track, skip over it
-            if current_span.track_id() != track_id {
+            if current_span.track_id != track_id {
                 continue;
             }
 
@@ -162,11 +197,11 @@ impl SymphoniaDecoder {
             }
         };
         let spec = decoded.spec().to_owned();
-        let buffer = SymphoniaDecoder::get_buffer(decoded, &spec);
+        let buffer = SymphoniaDecoder::get_buffer(decoded);
         Ok(Some(SymphoniaDecoder {
             decoder,
             current_span_offset: 0,
-            format: probed.format,
+            format,
             total_duration,
             buffer,
             spec,
@@ -178,15 +213,14 @@ impl SymphoniaDecoder {
     }
 
     #[inline]
-    fn get_buffer(decoded: AudioBufferRef, spec: &SignalSpec) -> SampleBuffer<Sample> {
-        let duration = units::Duration::from(decoded.capacity() as u64);
-        let mut buffer = SampleBuffer::<Sample>::new(duration, *spec);
-        buffer.copy_interleaved_ref(decoded);
-        buffer
+    fn get_buffer(decoded: GenericAudioBufferRef) -> Vec<Sample> {
+        let mut out = Vec::new();
+        decoded.copy_to_vec_interleaved(&mut out);
+        out
     }
 }
 
-impl Source for SymphoniaDecoder {
+impl<'a> Source for SymphoniaDecoder<'a> {
     #[inline]
     fn current_span_len(&self) -> Option<usize> {
         Some(self.buffer.len())
@@ -196,7 +230,7 @@ impl Source for SymphoniaDecoder {
     fn channels(&self) -> ChannelCount {
         ChannelCount::new(
             self.spec
-                .channels
+                .channels()
                 .count()
                 .try_into()
                 .expect("rodio only support up to u16::MAX channels (65_535)"),
@@ -206,7 +240,7 @@ impl Source for SymphoniaDecoder {
 
     #[inline]
     fn sample_rate(&self) -> SampleRate {
-        SampleRate::new(self.spec.rate).expect("audio should always have a non zero SampleRate")
+        SampleRate::new(self.spec.rate()).expect("audio should always have a non zero SampleRate")
     }
 
     #[inline]
@@ -215,9 +249,20 @@ impl Source for SymphoniaDecoder {
     }
 
     fn try_seek(&mut self, pos: Duration) -> Result<(), source::SeekError> {
-        if matches!(self.seek_mode, SeekMode::Accurate)
-            && self.decoder.codec_params().time_base.is_none()
-        {
+        // Find track by selected_track_id
+        let track = self
+            .format
+            .tracks()
+            .iter()
+            .find(|t| t.id == self.selected_track_id)
+            .ok_or_else(|| {
+                source::SeekError::SymphoniaDecoder(SeekError::Demuxer(Arc::new(
+                    symphonia::core::errors::Error::Unsupported("Selected track not found"),
+                )))
+            })?;
+
+        // Refuse accurate seek if time base is missing.
+        if matches!(self.seek_mode, SeekMode::Accurate) && track.time_base.is_none() {
             return Err(source::SeekError::SymphoniaDecoder(
                 SeekError::AccurateSeekNotSupported,
             ));
@@ -232,13 +277,41 @@ impl Source for SymphoniaDecoder {
             }
         }
 
-        // Remember the current channel, so we can restore it after seeking.
-        let active_channel = self.current_span_offset % self.channels().get() as usize;
+        let tb = track.time_base.expect("time base checked above");
 
+        let num = tb.numer.get() as u64;
+        let den = tb.denom.get() as u64;
+
+        let secs = target.as_secs();
+        let nanos = target.subsec_nanos() as u64;
+
+        // Compute integer ticks (truncated).
+        let ticks_secs = secs.saturating_mul(den) / num;
+        let ticks_nanos = (nanos.saturating_mul(den)) / (num * 1_000_000_000u64);
+        let mut ticks = ticks_secs.saturating_add(ticks_nanos);
+
+        // Defensive clamp: ensure ticks does not exceed the track's last valid tick (if available)
+        if let Some(max_ticks_dur) = track.duration {
+            let mut max_ticks: u64 = max_ticks_dur.get();
+            // Make sure we use the last valid tick (avoid handing the demuxer a tick equal to duration)
+            if max_ticks > 0 {
+                max_ticks = max_ticks.saturating_sub(1);
+            }
+            if ticks > max_ticks {
+                ticks = max_ticks;
+            }
+        }
+
+        let units_dur = symphonia::core::units::Duration::from(ticks);
+        let units_time = tb.calc_duration(units_dur).ok_or_else(|| {
+            source::SeekError::SymphoniaDecoder(SeekError::AccurateSeekNotSupported)
+        })?;
+
+        // Perform seek on the format reader
         let seek_res = match self.format.seek(
             self.seek_mode,
             SeekTo::Time {
-                time: target.into(),
+                time: units_time,
                 track_id: None,
             },
         ) {
@@ -250,22 +323,18 @@ impl Source for SymphoniaDecoder {
             other => other.map_err(Arc::new).map_err(SeekError::Demuxer),
         }?;
 
-        // Seeking is a demuxer operation without the decoder knowing about it,
-        // so we need to reset the decoder to make sure it's in sync and prevent
-        // audio glitches.
+        // Reset decoder state and mark buffer offset invalid
         self.decoder.reset();
-
-        // Force the iterator to decode the next packet.
         self.current_span_offset = usize::MAX;
 
-        // Symphonia does not seek to the exact position, it seeks to the closest keyframe.
-        // If accurate seeking is required, fast-forward to the exact position.
+        // Refine position when accurate seek requested
         if matches!(self.seek_mode, SeekMode::Accurate) {
             self.refine_position(seek_res)?;
         }
 
         // After seeking, we are at the beginning of an inter-sample frame, i.e. the first
         // channel. We need to advance the iterator to the right channel.
+        let active_channel = self.current_span_offset % self.channels().get() as usize;
         for _ in 0..active_channel {
             self.next();
         }
@@ -294,26 +363,40 @@ pub enum SeekError {
 }
 assert_error_traits!(SeekError);
 
-impl SymphoniaDecoder {
+impl<'a> SymphoniaDecoder<'a> {
     /// Note span offset must be set after
     fn refine_position(&mut self, seek_res: SeekedTo) -> Result<(), source::SeekError> {
-        // Calculate the number of samples to skip.
-        let mut samples_to_skip = (Duration::from(
-            self.decoder
-                .codec_params()
-                .time_base
-                .expect("time base availability guaranteed by caller")
-                .calc_time(seek_res.required_ts.saturating_sub(seek_res.actual_ts)),
-        )
-        .as_secs_f32()
-            * self.sample_rate().get() as f32
-            * self.channels().get() as f32)
-            .ceil() as usize;
+        // Get track and time base for timestamp conversion
+        let track = self
+            .format
+            .tracks()
+            .iter()
+            .find(|t| t.id == self.selected_track_id)
+            .expect("selected track must exist");
+        let tb = track
+            .time_base
+            .expect("time base availability guaranteed by caller");
 
-        // Re-align the seek position to the first channel.
-        samples_to_skip -= samples_to_skip % self.channels().get() as usize;
+        // Convert required and actual seek timestamps to `Time`
+        let req_time_opt = tb.calc_time(seek_res.required_ts);
+        let act_time_opt = tb.calc_time(seek_res.actual_ts);
 
-        // Skip ahead to the precise position.
+        let sr = self.sample_rate().get();
+        let ch = self.channels().get();
+
+        // Convert times to sample counts
+        let req_samples = req_time_opt
+            .map(|t| samples_from_time_f64(t, sr, ch.into()))
+            .unwrap_or(0);
+        let act_samples = act_time_opt
+            .map(|t| samples_from_time_f64(t, sr, ch.into()))
+            .unwrap_or(0);
+
+        // Compute whole-frame samples to skip
+        let mut samples_to_skip = req_samples.saturating_sub(act_samples);
+        samples_to_skip -= samples_to_skip % ch as usize;
+
+        // Skip the computed number of samples via `next()`
         for _ in 0..samples_to_skip {
             self.next();
         }
@@ -322,7 +405,7 @@ impl SymphoniaDecoder {
     }
 }
 
-impl Iterator for SymphoniaDecoder {
+impl<'a> Iterator for SymphoniaDecoder<'a> {
     type Item = Sample;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -334,17 +417,24 @@ impl Iterator for SymphoniaDecoder {
             }
 
             if self.current_span_offset >= self.buffer.len() {
+                // Decode next packet(s) into buffer.
                 let decoded = loop {
                     let packet = match self.format.next_packet() {
-                        Ok(packet) => {
-                            if packet.track_id() == self.selected_track_id {
-                                packet
-                            } else {
-                                continue;
+                        Ok(Some(p)) if p.track_id == self.selected_track_id => p,
+                        Ok(Some(_)) => continue, // packet for another track, skip
+                        Ok(None) => {
+                            // Input exhausted - check if mid-frame
+                            let channels = self.channels();
+                            self.silence_samples_remaining =
+                                padding_samples_needed(self.samples_in_current_frame, channels);
+                            if self.silence_samples_remaining > 0 {
+                                self.samples_in_current_frame = 0;
+                                break None;
                             }
+                            return None;
                         }
                         Err(_) => {
-                            // Input exhausted - check if mid-frame
+                            // Error from demuxer - treat like exhaustion for padding
                             let channels = self.channels();
                             self.silence_samples_remaining =
                                 padding_samples_needed(self.samples_in_current_frame, channels);
@@ -389,7 +479,7 @@ impl Iterator for SymphoniaDecoder {
                 match decoded {
                     Some(decoded) => {
                         decoded.spec().clone_into(&mut self.spec);
-                        self.buffer = SymphoniaDecoder::get_buffer(decoded, &self.spec);
+                        self.buffer = SymphoniaDecoder::get_buffer(decoded);
                         self.current_span_offset = 0;
                     }
                     None => {
@@ -399,7 +489,7 @@ impl Iterator for SymphoniaDecoder {
                 }
             }
 
-            let sample = *self.buffer.samples().get(self.current_span_offset)?;
+            let sample = *self.buffer.get(self.current_span_offset)?;
             self.current_span_offset += 1;
 
             let channels = self.channels();

--- a/tests/channel_volume.rs
+++ b/tests/channel_volume.rs
@@ -6,7 +6,7 @@ use std::io::BufReader;
 use rodio::source::ChannelVolume;
 use rodio::{queue, Decoder, Sample, Source};
 
-fn create_6_channel_source() -> ChannelVolume<Decoder<BufReader<fs::File>>> {
+fn create_6_channel_source() -> ChannelVolume<Decoder<'static, BufReader<fs::File>>> {
     let file = fs::File::open("assets/music.mp3").unwrap();
     let decoder = Decoder::try_from(file).unwrap();
     assert_eq!(decoder.channels().get(), 2);


### PR DESCRIPTION
This is a very rough draft (basically got it compiling and it works in the libopus example): @yara-blue 

Seeking is especially rough. I would like some input on the best way to handle that.

Closes #919

Here are test results as of 47e574bfe00284be39f855eb7c437993f578ef8f:

```Bash
running 26 tests
test seek_does_not_break_channel_order::case_3 ... ok
test seek_beyond_end_saturates::case_4 ... ok
test seek_beyond_end_saturates::case_3 ... ok
test seek_beyond_end_saturates::case_5 ... ok
test seek_beyond_end_saturates::case_2 ... ok
test random_access_seeks ... ok
test seek_beyond_end_saturates::case_1 ... FAILED
test seek_returns_err_if_unsupported::case_2 ... ok
test seek_returns_err_if_unsupported::case_3 ... ok
test seek_returns_err_if_unsupported::case_4 ... ok
test seek_returns_err_if_unsupported::case_5 ... ok
test seek_returns_err_if_unsupported::case_1 ... ok
test seek_possible_after_exausting_source::case_4 ... ok
test seek_possible_after_exausting_source::case_3 ... FAILED
test seek_results_in_correct_remaining_playtime::case_4 ... ok
test seek_possible_after_exausting_source::case_5 ... ok
test seek_results_in_correct_remaining_playtime::case_3 ... ok
test seek_does_not_break_channel_order::case_4 ... FAILED
test seek_possible_after_exausting_source::case_2 ... ok
test seek_results_in_correct_remaining_playtime::case_5 ... ok
test seek_results_in_correct_remaining_playtime::case_2 ... ok
test seek_does_not_break_channel_order::case_1 ... FAILED
test seek_does_not_break_channel_order::case_2 ... FAILED
test seek_does_not_break_channel_order::case_5 ... FAILED
test seek_possible_after_exausting_source::case_1 ... ok
test seek_results_in_correct_remaining_playtime::case_1 ... ok

failures:

---- seek_beyond_end_saturates::case_1 stdout ----
------------ TEST ARGUMENTS ------------
format = "ogg"
decoder_name = "symphonia"
-------------- TEST START --------------
seeking beyond end for: ogg	 decoded by: symphonia

thread 'seek_beyond_end_saturates::case_1' (3520265) panicked at tests/seek.rs:124:5:
err: Err(SymphoniaDecoder(Demuxer(SeekError(OutOfRange))))
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- seek_possible_after_exausting_source::case_3 stdout ----
------------ TEST ARGUMENTS ------------
format = "m4a"
_decoder_name = "symphonia"
-------------- TEST START --------------

thread 'seek_possible_after_exausting_source::case_3' (3520277) panicked at tests/seek.rs:182:5:
assertion failed: source.next().is_some()

---- seek_does_not_break_channel_order::case_4 stdout ----
------------ TEST ARGUMENTS ------------
format = "wav"
_decoder_name = "symphonia"
-------------- TEST START --------------

thread 'seek_does_not_break_channel_order::case_4' (3520273) panicked at tests/seek.rs:231:9:
channel0 should be silent,
    channel0 starts at idx: 1
    seek: 1.357709765s + 22.676µs
    samples: [3.0517578e-5, -0.0016174316, 0.0, -0.0026550293, 0.0, -0.0037231445, 0.0, -0.0048217773, 0.0, -0.00592041, 0.0, -0.0068359375, 0.0, -0.0076293945, 0.0, -0.008087158, 3.0517578e-5, -0.0082092285, -3.0517578e-5, -0.008117676, 0.0, -0.007537842, 0.0, -0.0066223145, 0.0, -0.005432129, 0.0, -0.0037841797, 0.0, -0.0018920898, 0.0, 0.0002746582, 0.0, 0.0025939941, -3.0517578e-5, 0.004852295, 0.0, 0.007171631, 3.0517578e-5, 0.009277344, 0.0, 0.011199951, -3.0517578e-5, 0.013580322, -3.0517578e-5, 0.01675415, 3.0517578e-5, 0.020812988, 3.0517578e-5, 0.025543213, -3.0517578e-5, 0.030456543, 0.0, 0.035614014, 3.0517578e-5, 0.040496826, -3.0517578e-5, 0.044647217, 3.0517578e-5, 0.048095703, 0.0, 0.0501709, -3.0517578e-5, 0.05078125, 6.1035156e-5, 0.049987793, 0.0, 0.047210693, -3.0517578e-5, 0.04272461, 3.0517578e-5, 0.036712646, -3.0517578e-5, 0.028808594, -3.0517578e-5, 0.019805908, 6.1035156e-5, 0.009796143, -3.0517578e-5, -0.0012512207, 0.0, -0.012481689, 3.0517578e-5, -0.023742676, -3.0517578e-5, -0.03475952, 0.0, -0.044799805, 3.0517578e-5, -0.053771973, -3.0517578e-5, -0.061309814, 0.0, -0.066986084, 0.0, -0.07080078, 0.0, -0.0725708, 0.0, -0.07223511]

---- seek_does_not_break_channel_order::case_1 stdout ----
------------ TEST ARGUMENTS ------------
format = "ogg"
_decoder_name = "symphonia"
-------------- TEST START --------------

thread 'seek_does_not_break_channel_order::case_1' (3520270) panicked at tests/seek.rs:231:9:
channel0 should be silent,
    channel0 starts at idx: 1
    seek: 1.357709765s + 22.676µs
    samples: [4.9912433e-8, 0.4392503, 5.834984e-7, 0.32712096, 8.8944273e-7, 0.2075035, 6.7825005e-7, 0.08379031, -3.972579e-8, -0.04053174, -9.2329697e-7, -0.16199267, -1.4915049e-6, -0.2772506, -1.4203649e-6, -0.3831966, -7.509369e-7, -0.47705132, 1.3289568e-7, -0.5564503, 7.475783e-7, -0.6195134, 8.160449e-7, -0.6648979, 4.3407422e-7, -0.69183284, -1.4623488e-8, -0.7001327, -1.3781239e-7, -0.6901939, 1.8062504e-7, -0.6629672, 6.8655174e-7, -0.6199163, 9.2156205e-7, -0.5629564, 5.4289205e-7, -0.49437943, -4.1678263e-7, -0.41676825, -1.529566e-6, -0.33290076, -2.2166344e-6, -0.24565068, -2.1050532e-6, -0.15788575, -1.2669452e-6, -0.07236801, -1.8295327e-7, 0.008339234, 5.5088833e-7, 0.081956394, 5.87114e-7, 0.14656077, 2.938458e-8, 0.20064433, -6.5391947e-7, 0.24315663, -9.451089e-7, 0.27352905, -6.1408866e-7, 0.29168102, 1.4185548e-7, 0.2980082, 8.4221085e-7, 0.29335254, 1.0509118e-6, 0.27895617, 6.6801135e-7, 0.25640103, -7.347481e-9, 0.22753577, -4.814534e-7, 0.19439438, -3.98785e-7, 0.15910749, 2.2027808e-7, 0.12381243, 9.948559e-7, 0.09056284, 1.4398854e-6, 0.061243095, 1.2898488e-6, 0.037490606, 6.7175e-7, 0.020627499, 1.10041185e-8, 0.01160603, -2.6587333e-7, 0.010969676, -2.9875025e-8, 0.018829666, 4.5535037e-7, 0.034859806, 7.11217e-7, 0.058308855, 3.8001764e-7, 0.08803026, -5.060404e-7, 0.12252779]

---- seek_does_not_break_channel_order::case_2 stdout ----
------------ TEST ARGUMENTS ------------
format = "mp3"
_decoder_name = "symphonia"
-------------- TEST START --------------

thread 'seek_does_not_break_channel_order::case_2' (3520271) panicked at tests/seek.rs:231:9:
channel0 should be silent,
    channel0 starts at idx: 1
    seek: 1.357709765s + 22.676µs
    samples: [1.0423112e-5, -0.0016294387, -4.9453974e-6, -0.0026536994, 8.9397e-6, -0.0036932616, 4.3690736e-7, -0.004755194, -1.0356765e-5, -0.0057819746, 9.4480165e-6, -0.0066954927, -7.91055e-6, -0.007394767, 4.067429e-6, -0.007800345, 1.5708369e-5, -0.007936013, -2.1292157e-5, -0.0077399723, -9.301568e-7, -0.0072024595, 9.291465e-6, -0.0063259234, -1.1032974e-5, -0.005101697, 8.563777e-6, -0.0035740598, -1.16098505e-7, -0.001723657, 2.02343e-6, 0.00036147257, 3.3597164e-6, 0.002491219, -3.290601e-5, 0.0046943063, 9.994318e-6, 0.0068566864, 3.647355e-5, 0.008782985, -1.03526245e-5, 0.010650539, -1.8692994e-5, 0.012840481, -1.7845161e-5, 0.015836604, 2.2732072e-5, 0.019732144, 3.2617714e-5, 0.024096046, -4.0639923e-5, 0.02880069, 7.1341714e-7, 0.03368114, 2.7875561e-5, 0.03821358, -2.6742986e-5, 0.04221207, 2.3462013e-5, 0.045432296, 2.5439124e-6, 0.04739777, -3.5672205e-5, 0.04806757, 4.494227e-5, 0.04727385, -2.0444643e-6, 0.04470345, -2.609535e-5, 0.04052583, 3.9288254e-5, 0.034779817, -3.2762022e-5, 0.02740809, -1.5781987e-5, 0.018852957, 5.1654155e-5, 0.009361489, -2.3770068e-5, -0.00096200145, -5.7022e-6, -0.011666289, 2.086379e-5, -0.02231333, -3.438963e-5, -0.032679107, 9.52124e-6, -0.04228663, 1.8188473e-5, -0.05078717, -2.229829e-5, -0.05795565, 9.5245305e-6, -0.0634677, 6.8758595e-6, -0.06710686, -9.058814e-6, -0.06889602, 2.4789674e-6, -0.06872114]

---- seek_does_not_break_channel_order::case_5 stdout ----
------------ TEST ARGUMENTS ------------
format = "flac"
_decoder_name = "symphonia"
-------------- TEST START --------------

thread 'seek_does_not_break_channel_order::case_5' (3520274) panicked at tests/seek.rs:231:9:
channel0 should be silent,
    channel0 starts at idx: 1
    seek: 1.357709765s + 22.676µs
    samples: [1.5377998e-5, -0.0016144514, -4.4107437e-6, -0.0026631355, 3.8146973e-6, -0.0037113428, 6.0796738e-6, -0.004824519, -1.4781952e-5, -0.0059326887, 1.347065e-5, -0.0068320036, -7.6293945e-6, -0.00762856, 5.9604645e-7, -0.008083582, 2.1100044e-5, -0.008194566, -2.6106834e-5, -0.00810349, -9.536743e-7, -0.007529974, 1.1086464e-5, -0.006628394, -1.347065e-5, -0.0054428577, 1.13248825e-5, -0.0037925243, -1.4305115e-6, -0.0019015074, 1.66893e-6, 0.00026142597, 5.722046e-6, 0.002597928, -3.4928322e-5, 0.004859805, 9.298325e-6, 0.007163763, 3.8027763e-5, 0.00926578, -1.0609627e-5, 0.011194587, -1.8954277e-5, 0.013587832, -1.8715858e-5, 0.016742945, 2.4080276e-5, 0.020828009, 3.528595e-5, 0.025547028, -4.3034554e-5, 0.030449033, 2.026558e-6, 0.035618305, 2.9921532e-5, 0.040507913, -2.9087067e-5, 0.04465449, 2.5868416e-5, 0.04810202, 1.4305115e-6, 0.05018556, -3.8266182e-5, 0.050781846, 4.887581e-5, 0.049995065, -3.5762787e-6, 0.047219396, -2.7418137e-5, 0.042734742, 4.184246e-5, 0.036702514, -3.6478043e-5, 0.028821826, -1.5974045e-5, 0.019791603, 5.4597855e-5, 0.009784818, -2.5391579e-5, -0.0012466908, -5.2452087e-6, -0.012483478, 2.1576881e-5, -0.02373743, -3.540516e-5, -0.03475201, 9.894371e-6, -0.04479909, 1.7285347e-5, -0.05376935, -2.3126602e-5, -0.061309457, 9.775162e-6, -0.06697428, 7.6293945e-6, -0.07078862, -8.46386e-6, -0.07256484, 9.536743e-7, -0.07222581]


failures:
    seek_beyond_end_saturates::case_1
    seek_does_not_break_channel_order::case_1
    seek_does_not_break_channel_order::case_2
    seek_does_not_break_channel_order::case_4
    seek_does_not_break_channel_order::case_5
    seek_possible_after_exausting_source::case_3

test result: FAILED. 20 passed; 6 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.50s

error: test failed, to rerun pass `--test seek`
     Running tests/total_duration.rs (target/debug/build/rodio/6ad925b750fdf439/out/total_duration-6ad925b750fdf439)

running 5 tests
test decoder_returns_total_duration::case_4 ... ok
test decoder_returns_total_duration::case_5 ... ok
test decoder_returns_total_duration::case_2 ... FAILED
test decoder_returns_total_duration::case_3 ... ok
test decoder_returns_total_duration::case_1 ... ok

failures:

---- decoder_returns_total_duration::case_2 stdout ----
------------ TEST ARGUMENTS ------------
format = "mp3"
correct_duration = 10.187755102s
decoder_name = "symphonia mp3"
-------------- TEST START --------------
decoder: symphonia mp3

thread 'decoder_returns_total_duration::case_2' (3520392) panicked at tests/total_duration.rs:97:5:
decoder got 10.152380952, correct is: 10.187755102
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    decoder_returns_total_duration::case_2

test result: FAILED. 4 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
```